### PR TITLE
Added option to export all identification results for a peak in the CSV export

### DIFF
--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/csvexport/CSVExportParameters.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/csvexport/CSVExportParameters.java
@@ -21,6 +21,7 @@ package net.sf.mzmine.modules.peaklistmethods.io.csvexport;
 
 import net.sf.mzmine.parameters.Parameter;
 import net.sf.mzmine.parameters.impl.SimpleParameterSet;
+import net.sf.mzmine.parameters.parametertypes.BooleanParameter;
 import net.sf.mzmine.parameters.parametertypes.MultiChoiceParameter;
 import net.sf.mzmine.parameters.parametertypes.StringParameter;
 import net.sf.mzmine.parameters.parametertypes.filenames.FileNameParameter;
@@ -51,9 +52,17 @@ public class CSVExportParameters extends SimpleParameterSet {
 	    "Selection of peak's elements to export",
 	    ExportRowDataFileElement.values());
 
+    public static final BooleanParameter exportAllIDs = new BooleanParameter(
+	     "Export all IDs for peak", "If checked, all identification results for a peak will be exported. ",
+	    false);
+
+    public static final StringParameter idSeparator = new StringParameter(
+	    "Identification separator",
+	    "Character(s) used to separate identification results in the exported file", ";");
+
     public CSVExportParameters() {
 	super(new Parameter[] { peakList, filename, fieldSeparator,
-		exportCommonItems, exportIdentityItems, exportDataFileItems });
+		exportCommonItems, exportIdentityItems, exportDataFileItems, exportAllIDs, idSeparator });
     }
 
 }

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/csvexport/CSVExportTask.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/csvexport/CSVExportTask.java
@@ -198,37 +198,39 @@ class CSVExportTask extends AbstractTask {
                 }
             }
 
-            // Identity elements
-            length = identityElements.length;
-            PeakIdentity peakIdentity = peakListRow.getPreferredPeakIdentity();
-            PeakIdentity[] peakIdentities = peakListRow.getPeakIdentities();
+	    // Identity elements
+	    length = identityElements.length;
+	    PeakIdentity peakIdentity = peakListRow.getPreferredPeakIdentity();
+	    PeakIdentity[] peakIdentities = peakListRow.getPeakIdentities();
 
-            if (exportAllIDs && peakIdentities.length > 1) {
-                // Export all identification results
-        	for (int i = 0; i < length; i++) {
-        	    String propertyValue = "";
-        	    for (int x = 0; x < peakIdentities.length; x++) {
-        		if (x == 0) {
-        		    propertyValue = escapeStringForCSV(peakIdentities[x].getPropertyValue(identityElements[i]));
-        		}
-        		else {
-        		    propertyValue = propertyValue + idSeparator + escapeStringForCSV(peakIdentities[x].getPropertyValue(identityElements[i]));
-        		}
-        	    }
-        	    line.append(propertyValue + fieldSeparator);
-        	}
-            }
-            else if (peakIdentity != null) {
-                for (int i = 0; i < length; i++) {
-                    String propertyValue = escapeStringForCSV(peakIdentity
-                            .getPropertyValue(identityElements[i]));
-                    line.append(propertyValue + fieldSeparator);
-                }
-            } else {
-                for (int i = 0; i < length; i++) {
-                    line.append(fieldSeparator);
-                }
-            }
+	    if (exportAllIDs && peakIdentities.length > 1) {
+		// Export all identification results
+		for (int i = 0; i < length; i++) {
+		    String propertyValue = "";
+		    for (int x = 0; x < peakIdentities.length; x++) {
+			if (x == 0) {
+			    propertyValue = escapeStringForCSV(peakIdentities[x]
+				    .getPropertyValue(identityElements[i]));
+			} else {
+			    propertyValue = propertyValue
+				    + idSeparator
+				    + escapeStringForCSV(peakIdentities[x]
+					    .getPropertyValue(identityElements[i]));
+			}
+		    }
+		    line.append(propertyValue + fieldSeparator);
+		}
+	    } else if (peakIdentity != null) {
+		for (int i = 0; i < length; i++) {
+		    String propertyValue = escapeStringForCSV(peakIdentity
+			    .getPropertyValue(identityElements[i]));
+		    line.append(propertyValue + fieldSeparator);
+		}
+	    } else {
+		for (int i = 0; i < length; i++) {
+		    line.append(fieldSeparator);
+		}
+	    }
 
             // Data file elements
             length = dataFileElements.length;

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/csvexport/CSVExportTask.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/csvexport/CSVExportTask.java
@@ -44,25 +44,27 @@ class CSVExportTask extends AbstractTask {
     private ExportRowCommonElement[] commonElements;
     private String[] identityElements;
     private ExportRowDataFileElement[] dataFileElements;
+    private Boolean exportAllIDs;
+    private String idSeparator;
 
     CSVExportTask(ParameterSet parameters) {
 
         this.peakList = parameters.getParameter(CSVExportParameters.peakList)
                 .getValue().getMatchingPeakLists()[0];
-
         fileName = parameters.getParameter(CSVExportParameters.filename)
                 .getValue();
         fieldSeparator = parameters.getParameter(
                 CSVExportParameters.fieldSeparator).getValue();
-
         commonElements = parameters.getParameter(
                 CSVExportParameters.exportCommonItems).getValue();
-
         identityElements = parameters.getParameter(
                 CSVExportParameters.exportIdentityItems).getValue();
         dataFileElements = parameters.getParameter(
                 CSVExportParameters.exportDataFileItems).getValue();
-
+        exportAllIDs = parameters.getParameter(
+                CSVExportParameters.exportAllIDs).getValue();
+        idSeparator = parameters.getParameter(
+                CSVExportParameters.idSeparator).getValue();
     }
 
     public double getFinishedPercentage() {
@@ -199,7 +201,24 @@ class CSVExportTask extends AbstractTask {
             // Identity elements
             length = identityElements.length;
             PeakIdentity peakIdentity = peakListRow.getPreferredPeakIdentity();
-            if (peakIdentity != null) {
+            PeakIdentity[] peakIdentities = peakListRow.getPeakIdentities();
+
+            if (exportAllIDs && peakIdentities.length > 1) {
+                // Export all identification results
+        	for (int i = 0; i < length; i++) {
+        	    String propertyValue = "";
+        	    for (int x = 0; x < peakIdentities.length; x++) {
+        		if (x == 0) {
+        		    propertyValue = escapeStringForCSV(peakIdentities[x].getPropertyValue(identityElements[i]));
+        		}
+        		else {
+        		    propertyValue = propertyValue + idSeparator + escapeStringForCSV(peakIdentities[x].getPropertyValue(identityElements[i]));
+        		}
+        	    }
+        	    line.append(propertyValue + fieldSeparator);
+        	}
+            }
+            else if (peakIdentity != null) {
                 for (int i = 0; i < length; i++) {
                     String propertyValue = escapeStringForCSV(peakIdentity
                             .getPropertyValue(identityElements[i]));

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/csvexport/help/help.html
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/csvexport/help/help.html
@@ -30,6 +30,12 @@ Missing values such as heights and areas of undetected peaks are exported as 0.
 <dt>Export elements</dt>
 <dd>Please select which columns from the peak list will be exported into the CSV file</dd>
 
+<dt>Export all IDs for peak</dt>
+<dd>If checked, all identification results for a peak will be exported</dd>
+
+<dt>Identification separator</dt>
+<dd>If multiple identification results are available for a peak, these will be separated by this character</dd>
+
 </dl>
 
 <p>


### PR DESCRIPTION
Modified the CSV export to accommodate feature request #56.