### PR TITLE
Update to progress tracking for loading a project

### DIFF
--- a/src/main/java/net/sf/mzmine/modules/projectmethods/projectload/MyZIS.java
+++ b/src/main/java/net/sf/mzmine/modules/projectmethods/projectload/MyZIS.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2006-2015 The MZmine 2 Development Team
+ *
+ * This file is part of MZmine 2.
+ *
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * MZmine 2; if not, write to the Free Software Foundation, Inc., 51 Franklin
+ * St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package net.sf.mzmine.modules.projectmethods.projectload;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.zip.ZipInputStream;
+
+public class MyZIS extends ZipInputStream {
+
+    public MyZIS(InputStream in) {
+        super(in);
+    }
+
+    @Override
+    public void close() throws IOException {
+    }
+
+    public void closeZIS() throws IOException {
+        super.close();
+    }
+
+}

--- a/src/main/java/net/sf/mzmine/modules/projectmethods/projectload/ProjectOpeningTask.java
+++ b/src/main/java/net/sf/mzmine/modules/projectmethods/projectload/ProjectOpeningTask.java
@@ -26,7 +26,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.util.Enumeration;
 import java.util.Hashtable;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
@@ -147,33 +146,33 @@ public class ProjectOpeningTask extends AbstractTask {
     	    // Get project ZIP stream
     	    FileInputStream fis = new FileInputStream(openFile);
     	    cis = new CountingInputStream(fis);
-    	    ZipInputStream zis = new ZipInputStream (cis);
+    	    MyZIS zis = new MyZIS(cis);
     	    ZipFile zipFile = new ZipFile(openFile);
 
             // Stage 1 - check version and load configuration
             loadVersion(zis);
             loadConfiguration(zis);
             if (isCanceled()) {
-                zis.close();
+                zis.closeZIS();
     	        return;
     	    }
 
             // Stage 2 - load raw data files and peak lists
            loadData(zis, zipFile);
             if (isCanceled()) {
-                zis.close();
+                zis.closeZIS();
     	        return;
     	    }
 
             // Stage 3 - load user parameters
             loadUserParameters(zis);
             if (isCanceled()) {
-                zis.close();
+                zis.closeZIS();
     	        return;
             }
 
             // Stage 4 - finish and close the project ZIP file
-            zis.close();
+            zis.closeZIS();
 
             // Final check for cancel
             if (isCanceled())

--- a/src/main/java/net/sf/mzmine/modules/projectmethods/projectload/ProjectOpeningTask.java
+++ b/src/main/java/net/sf/mzmine/modules/projectmethods/projectload/ProjectOpeningTask.java
@@ -74,13 +74,8 @@ public class ProjectOpeningTask extends AbstractTask {
     private PeakListOpenHandler peakListOpenHandler;
     private UserParameterOpenHandler userParameterOpenHandler;
 
-    private int currentStage;
     private CountingInputStream cis;
     private int totalBytes;
-    private double processedRawDataFiles = 0;
-    private double processedPeakDataFiles = 0;
-    private double rawdatafiles = 0;
-    private double peakdatafiles = 0;
     private String currentLoadedObjectName;
 
     // This hashtable maps stored IDs to raw data file objects
@@ -153,32 +148,7 @@ public class ProjectOpeningTask extends AbstractTask {
     	    ZipInputStream zis = new ZipInputStream (cis);
     	    ZipFile zipFile = new ZipFile(openFile);
 
-    	    // Find # raw data files and peak data files
-    	    Pattern rawFilePattern = Pattern
-    		    .compile("Raw data file #([\\d]+) (.*)\\.xml$");
-    	    Pattern peakFilePattern = Pattern
-    		    .compile("Peak list #([\\d]+) (.*)\\.xml$");
-
-    	    Enumeration<? extends ZipEntry> zipEntries = zipFile.entries();
-    	    while (zipEntries.hasMoreElements()) {
-    		ZipEntry entry = zipEntries.nextElement();
-    		String entryName = entry.getName();
-
-    		// Raw data files
-    		Matcher fileMatcher = rawFilePattern.matcher(entryName);
-    		if (fileMatcher.matches()) {
-    		    rawdatafiles++;
-    		}
-
-    		// Peak data files
-    		fileMatcher = peakFilePattern.matcher(entryName);
-    		if (fileMatcher.matches()) {
-    		    peakdatafiles++;
-    		}
-    	    }
-
             // Stage 1 - check version and load configuration
-            currentStage++;
             loadVersion(zipFile);
             loadConfiguration(zipFile);
             if (isCanceled()) {
@@ -187,7 +157,6 @@ public class ProjectOpeningTask extends AbstractTask {
     	    }
 
             // Stage 2 - load raw data files
-            currentStage++;
             loadRawDataFiles(zipFile);
             if (isCanceled()) {
     	        zipFile.close();
@@ -195,7 +164,6 @@ public class ProjectOpeningTask extends AbstractTask {
     	    }
 
             // Stage 3 - load peak lists
-            currentStage++;
             loadPeakLists(zipFile);
             if (isCanceled()) {
     	        zipFile.close();
@@ -203,7 +171,6 @@ public class ProjectOpeningTask extends AbstractTask {
     	    }
 
             // Stage 4 - load user parameters
-            currentStage++;
             loadUserParameters(zipFile);
             if (isCanceled()) {
     	        zipFile.close();
@@ -211,7 +178,6 @@ public class ProjectOpeningTask extends AbstractTask {
             }
 
             // Stage 5 - finish and close the project ZIP file
-            currentStage++;
             zipFile.close();
 
             // Final check for cancel
@@ -403,8 +369,6 @@ public class ProjectOpeningTask extends AbstractTask {
 			zipFile, scansEntry, entry);
 		newProject.addFile(newFile);
 		dataFilesIDMap.put(fileID, newFile);
-
-		processedRawDataFiles++;
 	    }
 
 	}
@@ -442,8 +406,6 @@ public class ProjectOpeningTask extends AbstractTask {
 			.readPeakList(peakListStream);
 
 		newProject.addPeakList(newPeakList);
-
-		processedPeakDataFiles++;
 	    }
 
 	}


### PR DESCRIPTION
When loading a project, is there a reason for why:
1. Raw data files and peak lists are not loaded into the lists as they are loaded from the zip file?
2. The progress tracker does not keep track of the entire project load?

I have made some changes to account for the above, please add your comments.

The issue is the same for saving a project where the total progress is not tracked. For me this is not very convenient.