### PR TITLE
Removed the peaks selection from PCA parameters - do we need it?

### DIFF
--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/dataanalysis/clustering/ClusteringParameters.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/dataanalysis/clustering/ClusteringParameters.java
@@ -19,20 +19,39 @@
 
 package net.sf.mzmine.modules.peaklistmethods.dataanalysis.clustering;
 
+import java.util.Arrays;
+
 import net.sf.mzmine.modules.peaklistmethods.dataanalysis.clustering.em.EMClusterer;
 import net.sf.mzmine.modules.peaklistmethods.dataanalysis.clustering.farthestfirst.FarthestFirstClusterer;
 import net.sf.mzmine.modules.peaklistmethods.dataanalysis.clustering.hierarchical.HierarClusterer;
 import net.sf.mzmine.modules.peaklistmethods.dataanalysis.clustering.simplekmeans.SimpleKMeansClusterer;
-import net.sf.mzmine.modules.peaklistmethods.dataanalysis.projectionplots.ProjectionPlotParameters;
 import net.sf.mzmine.parameters.Parameter;
 import net.sf.mzmine.parameters.impl.SimpleParameterSet;
 import net.sf.mzmine.parameters.parametertypes.ComboParameter;
 import net.sf.mzmine.parameters.parametertypes.ModuleComboParameter;
 import net.sf.mzmine.parameters.parametertypes.selectors.PeakListsParameter;
+import net.sf.mzmine.parameters.parametertypes.selectors.PeakSelection;
+import net.sf.mzmine.parameters.parametertypes.selectors.PeakSelectionParameter;
+import net.sf.mzmine.parameters.parametertypes.selectors.RawDataFilesParameter;
+import net.sf.mzmine.parameters.parametertypes.selectors.RawDataFilesSelection;
+import net.sf.mzmine.parameters.parametertypes.selectors.RawDataFilesSelectionType;
+import net.sf.mzmine.util.PeakMeasurementType;
 
 public class ClusteringParameters extends SimpleParameterSet {
 
     public static final PeakListsParameter peakLists = new PeakListsParameter();
+
+    public static final ComboParameter<PeakMeasurementType> peakMeasurementType = new ComboParameter<PeakMeasurementType>(
+            "Peak measurement type", "Measure peaks using",
+            PeakMeasurementType.values());
+
+    public static final RawDataFilesParameter dataFiles = new RawDataFilesParameter(
+            new RawDataFilesSelection(RawDataFilesSelectionType.ALL_FILES));
+
+    public static final PeakSelectionParameter rows = new PeakSelectionParameter(
+            "Peak list rows", "Peak list rows to include in calculation",
+            Arrays.asList(new PeakSelection[] {
+                    new PeakSelection(null, null, null, null) }));
 
     private static ClusteringAlgorithm algorithms[] = new ClusteringAlgorithm[] {
             new EMClusterer(), new FarthestFirstClusterer(),
@@ -48,11 +67,8 @@ public class ClusteringParameters extends SimpleParameterSet {
             ClusteringDataType.values());
 
     public ClusteringParameters() {
-        super(new Parameter[] { peakLists,
-                ProjectionPlotParameters.peakMeasurementType,
-                ProjectionPlotParameters.dataFiles,
-                ProjectionPlotParameters.rows, clusteringAlgorithm,
-                typeOfData });
+        super(new Parameter[] { peakLists, peakMeasurementType, dataFiles, rows,
+                clusteringAlgorithm, typeOfData });
     }
 
 }

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/dataanalysis/clustering/ClusteringTask.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/dataanalysis/clustering/ClusteringTask.java
@@ -42,7 +42,6 @@ import net.sf.mzmine.main.MZmineCore;
 import net.sf.mzmine.modules.MZmineProcessingStep;
 import net.sf.mzmine.modules.peaklistmethods.dataanalysis.clustering.hierarchical.HierarClusterer;
 import net.sf.mzmine.modules.peaklistmethods.dataanalysis.projectionplots.ProjectionPlotDataset;
-import net.sf.mzmine.modules.peaklistmethods.dataanalysis.projectionplots.ProjectionPlotParameters;
 import net.sf.mzmine.modules.peaklistmethods.dataanalysis.projectionplots.ProjectionPlotWindow;
 import net.sf.mzmine.parameters.ParameterSet;
 import net.sf.mzmine.taskcontrol.TaskStatus;
@@ -88,10 +87,9 @@ public class ClusteringTask extends AbstractXYDataset
         this.peakList = parameters.getParameter(ClusteringParameters.peakLists)
                 .getValue().getMatchingPeakLists()[0];
         this.selectedRawDataFiles = parameters
-                .getParameter(ProjectionPlotParameters.dataFiles).getValue()
+                .getParameter(ClusteringParameters.dataFiles).getValue()
                 .getMatchingRawDataFiles();
-        this.selectedRows = parameters
-                .getParameter(ProjectionPlotParameters.rows)
+        this.selectedRows = parameters.getParameter(ClusteringParameters.rows)
                 .getMatchingRows(peakList);
         clusteringStep = parameters
                 .getParameter(ClusteringParameters.clusteringAlgorithm)
@@ -371,13 +369,11 @@ public class ClusteringTask extends AbstractXYDataset
     private double[][] createMatrix(boolean isForSamples) {
         // Generate matrix of raw data (input to CDA)
         boolean useArea = true;
-        if (parameters
-                .getParameter(ProjectionPlotParameters.peakMeasurementType)
+        if (parameters.getParameter(ClusteringParameters.peakMeasurementType)
                 .getValue() == PeakMeasurementType.AREA) {
             useArea = true;
         }
-        if (parameters
-                .getParameter(ProjectionPlotParameters.peakMeasurementType)
+        if (parameters.getParameter(ClusteringParameters.peakMeasurementType)
                 .getValue() == PeakMeasurementType.HEIGHT) {
             useArea = false;
         }

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/dataanalysis/projectionplots/CDADataset.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/dataanalysis/projectionplots/CDADataset.java
@@ -22,6 +22,8 @@ package net.sf.mzmine.modules.peaklistmethods.dataanalysis.projectionplots;
 import java.util.Vector;
 import java.util.logging.Logger;
 
+import org.jfree.data.xy.AbstractXYDataset;
+
 import jmprojection.CDA;
 import jmprojection.Preprocess;
 import jmprojection.ProjectionStatus;
@@ -34,8 +36,6 @@ import net.sf.mzmine.parameters.ParameterSet;
 import net.sf.mzmine.parameters.UserParameter;
 import net.sf.mzmine.taskcontrol.TaskStatus;
 import net.sf.mzmine.util.PeakMeasurementType;
-
-import org.jfree.data.xy.AbstractXYDataset;
 
 public class CDADataset extends AbstractXYDataset
         implements ProjectionPlotDataset {
@@ -87,8 +87,7 @@ public class CDADataset extends AbstractXYDataset
         selectedRawDataFiles = parameters
                 .getParameter(ProjectionPlotParameters.dataFiles).getValue()
                 .getMatchingRawDataFiles();
-        selectedRows = parameters.getParameter(ProjectionPlotParameters.rows)
-                .getMatchingRows(peakList);
+        selectedRows = peakList.getRows();
 
         datasetTitle = "Curvilinear distance analysis";
 

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/dataanalysis/projectionplots/PCADataset.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/dataanalysis/projectionplots/PCADataset.java
@@ -32,7 +32,6 @@ import net.sf.mzmine.datamodel.MZmineProject;
 import net.sf.mzmine.datamodel.PeakList;
 import net.sf.mzmine.datamodel.PeakListRow;
 import net.sf.mzmine.datamodel.RawDataFile;
-import net.sf.mzmine.main.MZmineCore;
 import net.sf.mzmine.parameters.ParameterSet;
 import net.sf.mzmine.parameters.UserParameter;
 import net.sf.mzmine.taskcontrol.TaskStatus;
@@ -89,8 +88,7 @@ public class PCADataset extends AbstractXYDataset
         selectedRawDataFiles = parameters
                 .getParameter(ProjectionPlotParameters.dataFiles).getValue()
                 .getMatchingRawDataFiles();
-        selectedRows = parameters.getParameter(ProjectionPlotParameters.rows)
-                .getMatchingRows(peakList);
+        selectedRows = peakList.getRows();
 
         datasetTitle = "Principal component analysis";
 

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/dataanalysis/projectionplots/ProjectionPlotParameters.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/dataanalysis/projectionplots/ProjectionPlotParameters.java
@@ -19,14 +19,10 @@
 
 package net.sf.mzmine.modules.peaklistmethods.dataanalysis.projectionplots;
 
-import java.util.Arrays;
-
 import net.sf.mzmine.parameters.Parameter;
 import net.sf.mzmine.parameters.impl.SimpleParameterSet;
 import net.sf.mzmine.parameters.parametertypes.ComboParameter;
 import net.sf.mzmine.parameters.parametertypes.selectors.PeakListsParameter;
-import net.sf.mzmine.parameters.parametertypes.selectors.PeakSelection;
-import net.sf.mzmine.parameters.parametertypes.selectors.PeakSelectionParameter;
 import net.sf.mzmine.parameters.parametertypes.selectors.RawDataFilesParameter;
 import net.sf.mzmine.parameters.parametertypes.selectors.RawDataFilesSelection;
 import net.sf.mzmine.parameters.parametertypes.selectors.RawDataFilesSelectionType;
@@ -55,13 +51,8 @@ public class ProjectionPlotParameters extends SimpleParameterSet {
             "Y-axis component", "Component on the Y-axis",
             componentPossibleValues, componentPossibleValues[1]);
 
-    public static final PeakSelectionParameter rows = new PeakSelectionParameter(
-            "Peak list rows", "Peak list rows to include in calculation",
-            Arrays.asList(new PeakSelection[] {
-                    new PeakSelection(null, null, null, null) }));
-
     public ProjectionPlotParameters() {
-        super(new Parameter[] { peakLists, dataFiles, rows, coloringType,
+        super(new Parameter[] { peakLists, dataFiles, coloringType,
                 peakMeasurementType, xAxisComponent, yAxisComponent });
     }
 

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/dataanalysis/projectionplots/SammonsDataset.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/dataanalysis/projectionplots/SammonsDataset.java
@@ -22,6 +22,8 @@ package net.sf.mzmine.modules.peaklistmethods.dataanalysis.projectionplots;
 import java.util.Vector;
 import java.util.logging.Logger;
 
+import org.jfree.data.xy.AbstractXYDataset;
+
 import jmprojection.Preprocess;
 import jmprojection.ProjectionStatus;
 import jmprojection.Sammons;
@@ -34,8 +36,6 @@ import net.sf.mzmine.parameters.ParameterSet;
 import net.sf.mzmine.parameters.UserParameter;
 import net.sf.mzmine.taskcontrol.TaskStatus;
 import net.sf.mzmine.util.PeakMeasurementType;
-
-import org.jfree.data.xy.AbstractXYDataset;
 
 public class SammonsDataset extends AbstractXYDataset
         implements ProjectionPlotDataset {
@@ -86,8 +86,7 @@ public class SammonsDataset extends AbstractXYDataset
         selectedRawDataFiles = parameters
                 .getParameter(ProjectionPlotParameters.dataFiles).getValue()
                 .getMatchingRawDataFiles();
-        selectedRows = parameters.getParameter(ProjectionPlotParameters.rows)
-                .getMatchingRows(peakList);
+        selectedRows = peakList.getRows();
 
         datasetTitle = "Sammon's projection";
 


### PR DESCRIPTION
Hi Thomas @dyrlund , Sandra @SandraCastilloPriego,
I have removed the peak selection from PCA plot parameters. I think it is a bit confusing and normally users will always want to do PCA on the whole dataset. Please let me know if you have a different opinion.