### PR TITLE
Row filter negation

### DIFF
--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/filtering/peakfilter/PeakFilterParameters.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/filtering/peakfilter/PeakFilterParameters.java
@@ -85,10 +85,6 @@ public class PeakFilterParameters extends SimpleParameterSet {
                     "Permissible range of the asymmetry factor for a peak",
                     MZmineCore.getConfiguration().getRTFormat(), Range.closed(
                             0.5, 2.0)));
-    
-    public static final BooleanParameter LOGICAL_NOT = new BooleanParameter(
-            "Exclude rows based instead of keeping",
-            "If checked, the peaklist will remove rows that match the critera");
 
     public static final BooleanParameter AUTO_REMOVE = new BooleanParameter(
             "Remove source peak list after filtering",
@@ -97,7 +93,7 @@ public class PeakFilterParameters extends SimpleParameterSet {
     public PeakFilterParameters() {
         super(new Parameter[] { PEAK_LISTS, SUFFIX, PEAK_DURATION, PEAK_AREA,
                 PEAK_HEIGHT, PEAK_DATAPOINTS, PEAK_FWHM, PEAK_TAILINGFACTOR,
-                PEAK_ASYMMETRYFACTOR, LOGICAL_NOT, AUTO_REMOVE });
+                PEAK_ASYMMETRYFACTOR, AUTO_REMOVE });
     }
 
     @Override

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/filtering/peakfilter/PeakFilterParameters.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/filtering/peakfilter/PeakFilterParameters.java
@@ -85,6 +85,10 @@ public class PeakFilterParameters extends SimpleParameterSet {
                     "Permissible range of the asymmetry factor for a peak",
                     MZmineCore.getConfiguration().getRTFormat(), Range.closed(
                             0.5, 2.0)));
+    
+    public static final BooleanParameter LOGICAL_NOT = new BooleanParameter(
+            "Exclude rows based instead of keeping",
+            "If checked, the peaklist will remove rows that match the critera");
 
     public static final BooleanParameter AUTO_REMOVE = new BooleanParameter(
             "Remove source peak list after filtering",
@@ -93,7 +97,7 @@ public class PeakFilterParameters extends SimpleParameterSet {
     public PeakFilterParameters() {
         super(new Parameter[] { PEAK_LISTS, SUFFIX, PEAK_DURATION, PEAK_AREA,
                 PEAK_HEIGHT, PEAK_DATAPOINTS, PEAK_FWHM, PEAK_TAILINGFACTOR,
-                PEAK_ASYMMETRYFACTOR, AUTO_REMOVE });
+                PEAK_ASYMMETRYFACTOR, LOGICAL_NOT, AUTO_REMOVE });
     }
 
     @Override

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/filtering/rowsfilter/RowsFilterParameters.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/filtering/rowsfilter/RowsFilterParameters.java
@@ -83,9 +83,9 @@ public class RowsFilterParameters extends SimpleParameterSet {
             new StringParameter("Text in comment",
                     "Only rows that contain this text in their comment field will be retained."));
     
-    public static final BooleanParameter REMOVE_ROW = new BooleanParameter(
-            "Remove rows instead of keeping?",
-            "If checked, rows will be removed based on criteria instead of kept");
+    public static final ComboParameter<Object> REMOVE_ROW = new ComboParameter<Object>(
+            "Keep or remove rows",
+            "If selected, rows will be removed based on criteria instead of kept",new Object[0]);
 
     public static final BooleanParameter AUTO_REMOVE = new BooleanParameter(
             "Remove source peak list after filtering",
@@ -116,6 +116,9 @@ public class RowsFilterParameters extends SimpleParameterSet {
             }
         }
 
+        String[] removeRowChoices = {"Keep rows that match all criteria","Remove rows that match all criteria"};
+        getParameter(RowsFilterParameters.REMOVE_ROW).setChoices(removeRowChoices);
+        
         getParameter(RowsFilterParameters.GROUPSPARAMETER).setChoices(choices);
         ParameterSetupDialog dialog = new ParameterSetupDialog(parent,
                 valueCheckRequired, this);

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/filtering/rowsfilter/RowsFilterParameters.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/filtering/rowsfilter/RowsFilterParameters.java
@@ -82,6 +82,10 @@ public class RowsFilterParameters extends SimpleParameterSet {
     public static final OptionalParameter<StringParameter> COMMENT_TEXT = new OptionalParameter<>(
             new StringParameter("Text in comment",
                     "Only rows that contain this text in their comment field will be retained."));
+    
+    public static final BooleanParameter REMOVE_ROW = new BooleanParameter(
+            "Remove rows instead of keeping?",
+            "If checked, rows will be removed based on criteria instead of kept");
 
     public static final BooleanParameter AUTO_REMOVE = new BooleanParameter(
             "Remove source peak list after filtering",
@@ -91,7 +95,7 @@ public class RowsFilterParameters extends SimpleParameterSet {
         super(new Parameter[] { PEAK_LISTS, SUFFIX, MIN_PEAK_COUNT,
                 MIN_ISOTOPE_PATTERN_COUNT, MZ_RANGE, RT_RANGE, PEAK_DURATION,
                 GROUPSPARAMETER, HAS_IDENTITIES, IDENTITY_TEXT,
-                COMMENT_TEXT, AUTO_REMOVE });
+                COMMENT_TEXT, REMOVE_ROW,AUTO_REMOVE });
     }
 
     @Override

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/filtering/rowsfilter/RowsFilterTask.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/filtering/rowsfilter/RowsFilterTask.java
@@ -176,8 +176,14 @@ public class RowsFilterTask extends AbstractTask {
                 RowsFilterParameters.RT_RANGE).getValue();
         final boolean filterByDuration = parameters.getParameter(
                 RowsFilterParameters.PEAK_DURATION).getValue();
-        final boolean removeRow = parameters.getParameter(
+        final String removeRowString = (String) parameters.getParameter(
                 RowsFilterParameters.REMOVE_ROW).getValue();
+        
+        boolean removeRow = false;
+        if ( removeRowString.equalsIgnoreCase("Keep rows that match all criteria") )
+            removeRow = false;
+        if ( removeRowString.equalsIgnoreCase("Remove rows that match all criteria") )
+            removeRow = true;
         
         boolean filterRowCriteriaFailed = false; //Keep rows that don't match any criteria.  Keep by default.  
         //Remove by default w/ remove_row == true
@@ -186,6 +192,8 @@ public class RowsFilterTask extends AbstractTask {
         final PeakListRow[] rows = peakList.getRows();
         totalRows = rows.length;
         for (processedRows = 0; !isCanceled() && processedRows < totalRows; processedRows++) {
+            
+            filterRowCriteriaFailed = false;
 
 
             final PeakListRow row = rows[processedRows];
@@ -215,7 +223,6 @@ public class RowsFilterTask extends AbstractTask {
                 final Range<Double> mzRange = parameters
                         .getParameter(RowsFilterParameters.MZ_RANGE)
                         .getEmbeddedParameter().getValue();
-                System.out.println("entering function");
                 if (!mzRange.contains(row.getAverageMZ()))
                     filterRowCriteriaFailed = true;
 
@@ -255,7 +262,7 @@ public class RowsFilterTask extends AbstractTask {
             if (filterByCommentText) {
 
                 if (row.getComment() == null && !removeRow)
-                    continue;
+                    filterRowCriteriaFailed = true;
                 if (row.getComment() != null && removeRow)
                 {
                 final String searchText = parameters
@@ -314,8 +321,8 @@ public class RowsFilterTask extends AbstractTask {
             if (!filterRowCriteriaFailed && !removeRow)
                 //Only add the row if none of the criteria have failed.
                 newPeakList.addRow(copyPeakRow(row));
-            if (filterRowCriteriaFailed && removeRow) //NOT FULLY IMPLEMENTED
-                //Only add the rows that don't meet any of the criteria.
+            if (filterRowCriteriaFailed && removeRow)
+                //Only remove rows that match *all* of the criteria, so add rows that fail any of the criteria.
                 newPeakList.addRow(copyPeakRow(row));
             
 

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/filtering/rowsfilter/RowsFilterTask.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/filtering/rowsfilter/RowsFilterTask.java
@@ -186,7 +186,6 @@ public class RowsFilterTask extends AbstractTask {
             removeRow = true;
         
         boolean filterRowCriteriaFailed = false; //Keep rows that don't match any criteria.  Keep by default.  
-        //Remove by default w/ remove_row == true
         
         // Filter rows.
         final PeakListRow[] rows = peakList.getRows();
@@ -235,7 +234,7 @@ public class RowsFilterTask extends AbstractTask {
                         .getParameter(RowsFilterParameters.RT_RANGE)
                         .getEmbeddedParameter().getValue();
 
-                if (!rtRange.contains(row.getAverageRT()) && !removeRow)
+                if (!rtRange.contains(row.getAverageRT()))
                     filterRowCriteriaFailed = true;
 
             }
@@ -261,9 +260,9 @@ public class RowsFilterTask extends AbstractTask {
             // Search peak comment text.
             if (filterByCommentText) {
 
-                if (row.getComment() == null && !removeRow)
+                if (row.getComment() == null)
                     filterRowCriteriaFailed = true;
-                if (row.getComment() != null && removeRow)
+                if (row.getComment() != null)
                 {
                 final String searchText = parameters
                         .getParameter(RowsFilterParameters.COMMENT_TEXT)


### PR DESCRIPTION
Added the ability to remove peaklist rows that match all the conditions in the peaklist row filter (instead of keeping the rows based on the conditions).  Did do some tests to verify, but it is possible that I missed some edge cases with nulls etc.