### PR TITLE
docs: fix typos in three documentation files

### DIFF
--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/alignment/ransac/help/help.html
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/alignment/ransac/help/help.html
@@ -97,7 +97,7 @@
             The three first parameters (m/z tolerance, RT tolerance after the correction and RT tolerance)
             define 2 bi-dimensional windows with the same "altitude" (m/z tolerance) and different "longitude"
             (RT tolerances). The first window (m/z tolerance - RT tolerance after the correction) sets the
-            space where the matching peak should be present, and the second windows (m/z tolerance - RT tolerance)
+            space where the matching peak should be present, and the second window (m/z tolerance - RT tolerance)
             sets the total space where RANSAC algorithm will be applied. So, "RT tolerance" should be as big as
             the maximum deviation in the retention time along all the chromatogram, and "RT tolerance after the
             correction" can be more flexible and depends on the complexity of the data. If the data contains

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/centwave/help/help.html
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/centwave/help/help.html
@@ -21,7 +21,7 @@
     is convolved with the chromatogram. Local maxima in the convolution results determine the locations of possible
     peaks. When these candidate peak locations co-occur at multiple scales then the scale with the strongest response
     indicates peak width. Given the candidate peak locations and scales, peaks can then be reconstructed from the
-    original chromatogram. Full details of the algorithm are published in Tatenhahn et al. [<a href="#ref1">1</a>].
+    original chromatogram. Full details of the algorithm are published in Tautenhahn et al. [<a href="#ref1">1</a>].
 </p>
 
 <h4>Method parameters</h4>

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/smoothing/help/help.html
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/smoothing/help/help.html
@@ -7,7 +7,7 @@
     <title>Peak detection - Smoothing</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <link rel="stylesheet" type="text/css" href="/net/sf/mzmine/desktop/impl/helpsystem/HelpStyles.css">
- /head>
+ </head>
 
 <body>
 


### PR DESCRIPTION
I fixed two typos and one missing special character in the help files.