### PR TITLE
FileNameParameter: ignore case while appending extension

### DIFF
--- a/src/main/java/net/sf/mzmine/modules/visualization/infovisualizer/InfoVisualizerWindow.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/infovisualizer/InfoVisualizerWindow.java
@@ -113,8 +113,9 @@ class InfoVisualizerWindow extends JFrame {
 	GridBagConstraints c = new GridBagConstraints();
 
 	c.fill = GridBagConstraints.HORIZONTAL;
-	c.insets = new Insets(5, 5, 5, 5);
+	c.insets = new Insets(10, 10, 10, 10);
 	c.gridwidth = 1;
+	c.weightx = 1.0; // Use all horizontal space
 
 	c.gridx = 0;
 	c.gridy = 0;

--- a/src/main/java/net/sf/mzmine/parameters/parametertypes/WindowSettingsParameter.java
+++ b/src/main/java/net/sf/mzmine/parameters/parametertypes/WindowSettingsParameter.java
@@ -22,6 +22,8 @@ package net.sf.mzmine.parameters.parametertypes;
 import java.awt.Dimension;
 import java.awt.Frame;
 import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Toolkit;
 import java.awt.event.ComponentEvent;
 import java.awt.event.ComponentListener;
 import java.util.Collection;
@@ -35,155 +37,174 @@ import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
 public class WindowSettingsParameter implements Parameter<Object>,
-	ComponentListener {
+        ComponentListener {
 
     private static final String SIZE_ELEMENT = "size";
     private static final String POSITION_ELEMENT = "position";
     private static final String MAXIMIZED_ELEMENT = "maximized";
 
+    private static Point startPosition;
+
     private Point position;
     private Dimension dimension;
     private boolean isMaximized = false;
 
+    private Point offset = new Point(20, 20);
+
     @Override
     public String getName() {
-	return "Window state";
+        return "Window state";
     }
 
     @Override
     public WindowSettingsParameter cloneParameter() {
-	return this;
+        return this;
     }
 
     @Override
     public boolean checkValue(Collection<String> errorMessages) {
-	return true;
+        return true;
     }
 
     @Override
     public void loadValueFromXML(Element xmlElement) {
 
-	// Window position
-	NodeList posElement = xmlElement.getElementsByTagName(POSITION_ELEMENT);
-	if (posElement.getLength() == 1) {
-	    String posString = posElement.item(0).getTextContent();
-	    String posArray[] = posString.split(":");
-	    if (posArray.length == 2) {
-		int posX = Integer.valueOf(posArray[0]);
+        // Window position
+        NodeList posElement = xmlElement.getElementsByTagName(POSITION_ELEMENT);
+        if (posElement.getLength() == 1) {
+            String posString = posElement.item(0).getTextContent();
+            String posArray[] = posString.split(":");
+            if (posArray.length == 2) {
+                int posX = Integer.valueOf(posArray[0]);
 
-		int posY = Integer.valueOf(posArray[1]);
-		position = new Point(posX, posY);
-	    }
-	}
+                int posY = Integer.valueOf(posArray[1]);
+                position = new Point(posX, posY);
+            }
+        }
 
-	// Window size
-	NodeList sizeElement = xmlElement.getElementsByTagName(SIZE_ELEMENT);
-	if (sizeElement.getLength() == 1) {
-	    String sizeString = sizeElement.item(0).getTextContent();
-	    String sizeArray[] = sizeString.split(":");
-	    if (sizeArray.length == 2) {
-		int width = Integer.parseInt(sizeArray[0]);
-		int height = Integer.parseInt(sizeArray[1]);
-		dimension = new Dimension(width, height);
-	    }
-	}
+        // Window size
+        NodeList sizeElement = xmlElement.getElementsByTagName(SIZE_ELEMENT);
+        if (sizeElement.getLength() == 1) {
+            String sizeString = sizeElement.item(0).getTextContent();
+            String sizeArray[] = sizeString.split(":");
+            if (sizeArray.length == 2) {
+                int width = Integer.parseInt(sizeArray[0]);
+                int height = Integer.parseInt(sizeArray[1]);
+                dimension = new Dimension(width, height);
+            }
+        }
 
-	// Window maximized
-	NodeList maximizedElement = xmlElement
-		.getElementsByTagName(MAXIMIZED_ELEMENT);
-	if (maximizedElement.getLength() == 1) {
-	    String maximizedString = maximizedElement.item(0).getTextContent();
-	    isMaximized = Boolean.valueOf(maximizedString);
-	}
+        // Window maximized
+        NodeList maximizedElement = xmlElement
+                .getElementsByTagName(MAXIMIZED_ELEMENT);
+        if (maximizedElement.getLength() == 1) {
+            String maximizedString = maximizedElement.item(0).getTextContent();
+            isMaximized = Boolean.valueOf(maximizedString);
+        }
 
     }
 
     @Override
     public void saveValueToXML(Element xmlElement) {
 
-	// Add elements
-	Document doc = xmlElement.getOwnerDocument();
+        // Add elements
+        Document doc = xmlElement.getOwnerDocument();
 
-	if (position != null) {
-	    Element positionElement = doc.createElement(POSITION_ELEMENT);
-	    xmlElement.appendChild(positionElement);
-	    positionElement.setTextContent(position.x + ":" + position.y);
-	}
+        if (position != null) {
+            Element positionElement = doc.createElement(POSITION_ELEMENT);
+            xmlElement.appendChild(positionElement);
+            positionElement.setTextContent(position.x + ":" + position.y);
+        }
 
-	if (dimension != null) {
-	    Element sizeElement = doc.createElement(SIZE_ELEMENT);
-	    xmlElement.appendChild(sizeElement);
-	    sizeElement
-		    .setTextContent(dimension.width + ":" + dimension.height);
-	}
+        if (dimension != null) {
+            Element sizeElement = doc.createElement(SIZE_ELEMENT);
+            xmlElement.appendChild(sizeElement);
+            sizeElement
+                    .setTextContent(dimension.width + ":" + dimension.height);
+        }
 
-	Element maximizedElement = doc.createElement(MAXIMIZED_ELEMENT);
-	xmlElement.appendChild(maximizedElement);
-	maximizedElement.setTextContent(String.valueOf(isMaximized));
+        Element maximizedElement = doc.createElement(MAXIMIZED_ELEMENT);
+        xmlElement.appendChild(maximizedElement);
+        maximizedElement.setTextContent(String.valueOf(isMaximized));
 
     }
 
     @Override
     public Object getValue() {
-	return null;
+        return null;
     }
 
     @Override
     public void setValue(Object newValue) {
-	// ignore
+        // ignore
     }
 
     /**
      * Set window size and position according to the values in this instance
      */
     public void applySettingsToWindow(JFrame frame) {
-	if (position != null) {
-	    if (!isMaximized)
-		position.translate(20, 20);
-	    frame.setLocation(position);
-	}
-	if (dimension != null) {
-	    frame.setSize(dimension);
-	}
-	if (isMaximized) {
-	    frame.setExtendedState(Frame.MAXIMIZED_HORIZ | Frame.MAXIMIZED_VERT);
-	}
+        if (position != null) {
+            if (!isMaximized) {
+                // Reset to default, if we go outside screen limits
+                Dimension screenSize = Toolkit.getDefaultToolkit()
+                        .getScreenSize();
+                Point bottomRightPos = new Point(position.x + offset.x
+                        + frame.getWidth(), position.y + offset.y
+                        + frame.getHeight());
+                if (startPosition != null
+                        && !(new Rectangle(screenSize).contains(bottomRightPos))) {
+                    position = new Point(startPosition);
+                }
+                // Keep translating otherwise
+                position.translate(offset.x, offset.y);
+            }
+            frame.setLocation(position);
+
+            if (startPosition == null)
+                startPosition = new Point(position);
+        }
+        if (dimension != null) {
+            frame.setSize(dimension);
+        }
+        if (isMaximized) {
+            frame.setExtendedState(Frame.MAXIMIZED_HORIZ | Frame.MAXIMIZED_VERT);
+        }
     }
 
     @Override
     public void componentMoved(ComponentEvent e) {
-	if (!(e.getComponent() instanceof JFrame))
-	    return;
-	JFrame frame = (JFrame) e.getComponent();
-	int state = frame.getExtendedState();
-	isMaximized = ((state & Frame.MAXIMIZED_HORIZ) != 0)
-		&& ((state & Frame.MAXIMIZED_VERT) != 0);
-	if (!isMaximized) {
-	    position = frame.getLocation();
-	}
+        if (!(e.getComponent() instanceof JFrame))
+            return;
+        JFrame frame = (JFrame) e.getComponent();
+        int state = frame.getExtendedState();
+        isMaximized = ((state & Frame.MAXIMIZED_HORIZ) != 0)
+                && ((state & Frame.MAXIMIZED_VERT) != 0);
+        if (!isMaximized) {
+            position = frame.getLocation();
+        }
     }
 
     @Override
     public void componentResized(ComponentEvent e) {
-	if (!(e.getComponent() instanceof JFrame))
-	    return;
-	JFrame frame = (JFrame) e.getComponent();
-	int state = frame.getExtendedState();
-	isMaximized = ((state & Frame.MAXIMIZED_HORIZ) != 0)
-		&& ((state & Frame.MAXIMIZED_VERT) != 0);
-	if (!isMaximized) {
-	    dimension = frame.getSize();
-	}
+        if (!(e.getComponent() instanceof JFrame))
+            return;
+        JFrame frame = (JFrame) e.getComponent();
+        int state = frame.getExtendedState();
+        isMaximized = ((state & Frame.MAXIMIZED_HORIZ) != 0)
+                && ((state & Frame.MAXIMIZED_VERT) != 0);
+        if (!isMaximized) {
+            dimension = frame.getSize();
+        }
     }
 
     @Override
     public void componentHidden(ComponentEvent e) {
-	// ignore
+        // ignore
     }
 
     @Override
     public void componentShown(ComponentEvent e) {
-	// ignore
+        // ignore
     }
 
 }

--- a/src/main/java/net/sf/mzmine/parameters/parametertypes/filenames/FileNameParameter.java
+++ b/src/main/java/net/sf/mzmine/parameters/parametertypes/filenames/FileNameParameter.java
@@ -99,9 +99,8 @@ public class FileNameParameter
     public void setValueFromComponent(FileNameComponent component) {
         File compValue = component.getValue();
         if (extension != null) {
-            if (!(compValue.getName().toUpperCase()
-                    .endsWith(extension.toUpperCase()) || compValue.getName()
-                    .toLowerCase().endsWith(extension.toLowerCase())))
+            if (!compValue.getName()
+                    .toLowerCase().endsWith(extension.toLowerCase()))
                 compValue = new File(compValue.getPath() + "." + extension);
         }
         this.value = compValue;

--- a/src/main/java/net/sf/mzmine/parameters/parametertypes/filenames/FileNameParameter.java
+++ b/src/main/java/net/sf/mzmine/parameters/parametertypes/filenames/FileNameParameter.java
@@ -99,7 +99,9 @@ public class FileNameParameter
     public void setValueFromComponent(FileNameComponent component) {
         File compValue = component.getValue();
         if (extension != null) {
-            if (!compValue.getName().endsWith(extension))
+            if (!(compValue.getName().toUpperCase()
+                    .endsWith(extension.toUpperCase()) || compValue.getName()
+                    .toLowerCase().endsWith(extension.toLowerCase())))
                 compValue = new File(compValue.getPath() + "." + extension);
         }
         this.value = compValue;


### PR DESCRIPTION
Windows mostly users can have files with uppercase extension.
This fix avoids to get a file named `/dir/file.EXT` to get selected (and fail to be selected) as `/dir/file.EXT.ext` in case FileNameParameter is build with `'.ext'` as extension argument.