### PR TITLE
'Fixed chromatogram deconvolution fails with recent version of xcms #298

### DIFF
--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/centwave/CentWaveDetector.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/centwave/CentWaveDetector.java
@@ -222,7 +222,7 @@ public class CentWaveDetector implements PeakResolver {
         rSession.eval("xRaw <- new(\"xcmsRaw\")");
         rSession.eval("xRaw@tic <- intensity");
         rSession.eval("xRaw@scantime <- scantime * " + SECONDS_PER_MINUTE);
-        rSession.eval("xRaw@scanindex <- 1:numPoints");
+        rSession.eval("xRaw@scanindex <- 0:(numPoints-1)");
         rSession.eval("xRaw@env$mz <- rep(mz, numPoints)");
         rSession.eval("xRaw@env$intensity <- intensity");
 


### PR DESCRIPTION
Fix should be compatible with older R releases since I think this was caused by an additional check in R 3.4.X.

Please tell me if this work as expected with this fix in _centWave_ R code.