### PR TITLE
default rt range updated

### DIFF
--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/ResolvedPeak.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/ResolvedPeak.java
@@ -186,7 +186,7 @@ public class ResolvedPeak implements Feature {
         if (msmsRange == 0)
         	searchingRange = rawDataPointsMZRange;
         if (RTRangeMSMS == 0)
-        	searchingRangeRT = dataFile.getDataRTRange(1);
+        	searchingRangeRT =  rawDataPointsRTRange;
         
         fragmentScan = ScanUtils.findBestFragmentScan(dataFile,
         		searchingRangeRT, searchingRange);


### PR DESCRIPTION
Change the default Rt range when the Rt range for MS1/MS2 pairing at the deconvolution step is not provided by the user.