### PR TITLE
Export merged MSMS and export single features

### DIFF
--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/siriusexport/SiriusExportModule.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/siriusexport/SiriusExportModule.java
@@ -12,14 +12,18 @@
 
 package net.sf.mzmine.modules.peaklistmethods.io.siriusexport;
 
-import java.util.Collection;
-import javax.annotation.Nonnull;
 import net.sf.mzmine.datamodel.MZmineProject;
+import net.sf.mzmine.datamodel.PeakListRow;
+import net.sf.mzmine.main.MZmineCore;
 import net.sf.mzmine.modules.MZmineModuleCategory;
 import net.sf.mzmine.modules.MZmineProcessingModule;
 import net.sf.mzmine.parameters.ParameterSet;
 import net.sf.mzmine.taskcontrol.Task;
+import net.sf.mzmine.util.ExceptionUtils;
 import net.sf.mzmine.util.ExitCode;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
 
 public class SiriusExportModule implements MZmineProcessingModule {
     private static final String MODULE_NAME = "Export for SIRIUS";
@@ -42,6 +46,30 @@ public class SiriusExportModule implements MZmineProcessingModule {
 	SiriusExportTask task = new SiriusExportTask(parameters);
 	tasks.add(task);
 	return ExitCode.OK;
+
+    }
+
+
+    public static void exportSinglePeakList(PeakListRow row) {
+
+        try {
+            ParameterSet parameters = MZmineCore.getConfiguration()
+                    .getModuleParameters(SiriusExportModule.class);
+
+            ExitCode exitCode = parameters.showSetupDialog(MZmineCore.getDesktop()
+                    .getMainWindow(), true);
+            if (exitCode != ExitCode.OK)
+                return;
+            // Open file
+            final SiriusExportTask task = new SiriusExportTask(parameters);
+            task.runSingleRow(row);
+        } catch (Exception e) {
+            e.printStackTrace();
+            MZmineCore.getDesktop().displayErrorMessage(
+                    MZmineCore.getDesktop().getMainWindow(),
+                    "Error while exporting feature to SIRIUS: "
+                            + ExceptionUtils.exceptionToString(e));
+        }
 
     }
 

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/siriusexport/SiriusExportParameters.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/siriusexport/SiriusExportParameters.java
@@ -15,7 +15,7 @@ package net.sf.mzmine.modules.peaklistmethods.io.siriusexport;
 import net.sf.mzmine.parameters.Parameter;
 import net.sf.mzmine.parameters.dialogs.ParameterSetupDialog;
 import net.sf.mzmine.parameters.impl.SimpleParameterSet;
-import net.sf.mzmine.parameters.parametertypes.BooleanParameter;
+import net.sf.mzmine.parameters.parametertypes.ComboParameter;
 import net.sf.mzmine.parameters.parametertypes.MassListParameter;
 import net.sf.mzmine.parameters.parametertypes.filenames.FileNameParameter;
 import net.sf.mzmine.parameters.parametertypes.selectors.PeakListsParameter;
@@ -26,6 +26,15 @@ import java.awt.*;
 
 public class SiriusExportParameters extends SimpleParameterSet
 {
+
+    public static final ComboParameter<MERGE_MODE> MERGE = new ComboParameter<MERGE_MODE>(
+            "Merge mode", "How to merge MS/MS spectra", MERGE_MODE.values(), MERGE_MODE.MERGE_CONSECUTIVE_SCANS);
+
+    public SiriusExportParameters() {
+        super(new Parameter[]{PEAK_LISTS, FILENAME, MERGE, MASS_LIST});
+    }
+
+
     public static final PeakListsParameter PEAK_LISTS = new PeakListsParameter();
 
     public static final FileNameParameter FILENAME = new FileNameParameter(
@@ -40,17 +49,30 @@ public class SiriusExportParameters extends SimpleParameterSet
 //            "Fractional m/z values", "If checked, write fractional m/z values",
 //            true);
 
-
+/*
     public static final BooleanParameter INCLUDE_MSSCAN = new BooleanParameter(
             "include MS1",
             "For each MS/MS scan include also the corresponding MS scan (additionally to possibly detected isotope patterns). MS1 scans might contain valuable informations that can be processed by SIRIUS. But they increase file size significantly",
             true
     );
+*/
 
     public static final MassListParameter MASS_LIST = new MassListParameter();
 
-    public SiriusExportParameters() {
-        super(new Parameter[]{PEAK_LISTS, FILENAME, INCLUDE_MSSCAN, MASS_LIST});
+    public static enum MERGE_MODE {
+        NO_MERGE("Do not merge"),
+        MERGE_CONSECUTIVE_SCANS("Merge consecutive scans"),
+        MERGE_OVER_SAMPLES("Merge all MS/MS belonging to the same feature");
+        private final String name;
+
+        private MERGE_MODE(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String toString() {
+            return name;
+        }
     }
 
     public ExitCode showSetupDialog(Window parent, boolean valueCheckRequired) {

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/siriusexport/SiriusExportTask.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/siriusexport/SiriusExportTask.java
@@ -13,27 +13,46 @@
 package net.sf.mzmine.modules.peaklistmethods.io.siriusexport;
 
 import net.sf.mzmine.datamodel.*;
+import net.sf.mzmine.datamodel.impl.SimpleDataPoint;
 import net.sf.mzmine.parameters.ParameterSet;
 import net.sf.mzmine.taskcontrol.AbstractTask;
 import net.sf.mzmine.taskcontrol.TaskStatus;
+import net.sf.mzmine.util.DataPointSorter;
+import net.sf.mzmine.util.SortingDirection;
+import net.sf.mzmine.util.SortingProperty;
+import org.apache.commons.math3.special.Erf;
 
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.HashMap;
+import java.util.*;
 import java.util.regex.Pattern;
 
 public class SiriusExportTask extends AbstractTask {
 
     private final static String plNamePattern = "{}";
-    protected final boolean includeMs1;
+    protected static final Comparator<DataPoint> CompareDataPointsByMz = new Comparator<DataPoint>() {
+        @Override
+        public int compare(DataPoint o1, DataPoint o2) {
+            return Double.compare(o1.getMZ(), o2.getMZ());
+        }
+    };
     private final PeakList[] peakLists;
 	private final File fileName;
 	// private final boolean fractionalMZ;
 	private final String massListName;
     protected double progress, totalProgress;
+    protected final SiriusExportParameters.MERGE_MODE mergeMsMs;
+
+
+    public double getFinishedPercentage() {
+        return (totalProgress == 0 ? 0 : progress / totalProgress);
+    }
+
+    public String getTaskDescription() {
+        return "Exporting peak list(s) " + Arrays.toString(peakLists) + " to MGF file(s)";
+    }
 
 	SiriusExportTask(ParameterSet parameters) {
 		this.peakLists = parameters.getParameter(SiriusExportParameters.PEAK_LISTS).getValue().getMatchingPeakLists();
@@ -45,16 +64,8 @@ public class SiriusExportTask extends AbstractTask {
 		// .getValue();
 
 		this.massListName = parameters.getParameter(SiriusExportParameters.MASS_LIST).getValue();
-        this.includeMs1 = parameters.getParameter(SiriusExportParameters.INCLUDE_MSSCAN).getValue();
+        this.mergeMsMs = parameters.getParameter(SiriusExportParameters.MERGE).getValue();
     }
-
-	public double getFinishedPercentage() {
-        return (totalProgress == 0 ? 0 : progress / totalProgress);
-    }
-
-	public String getTaskDescription() {
-		return "Exporting peak list(s) " + Arrays.toString(peakLists) + " to MGF file(s)";
-	}
 
 	public void run() {
         this.progress = 0d;
@@ -99,10 +110,136 @@ public class SiriusExportTask extends AbstractTask {
 			setStatus(TaskStatus.FINISHED);
 	}
 
+    private static DataPoint[] merge(double parentPeak, List<DataPoint[]> scans) {
+        final DataPointSorter sorter = new DataPointSorter(SortingProperty.Intensity, SortingDirection.Descending);
+        double maxTIC = 0d;
+        int best = 0;
+        for (int i = 0; i < scans.size(); ++i) {
+            final DataPoint[] scan = scans.get(i);
+            Arrays.sort(scan, sorter);
+            double tic = 0d;
+            for (int j = 0; j < Math.min(40, scan.length); ++j) {
+                tic += scan[j].getIntensity();
+            }
+            if (tic > maxTIC) {
+                maxTIC = tic;
+                best = i;
+            }
+            DataPoint[] m = scans.get(0);
+            scans.set(0, scans.get(best));
+            scans.set(best, m);
+        }
+        final DataPoint[] mergedSpectrum = scans.get(0).clone();
+        Arrays.sort(mergedSpectrum, CompareDataPointsByMz);
+        for (int i = 1; i < scans.size(); ++i) {
+            merge(mergedSpectrum, scans.get(i));
+        }
+        // remove noise
+        if (mergedSpectrum.length > 60) {
+            double lowestIntensity = Double.POSITIVE_INFINITY, secondLowestIntensity = Double.POSITIVE_INFINITY;
+            for (int i = 0; i < mergedSpectrum.length; ++i) {
+                final double z = mergedSpectrum[i].getIntensity();
+                if (z < secondLowestIntensity) {
+                    if (z < lowestIntensity) {
+                        secondLowestIntensity = lowestIntensity;
+                        lowestIntensity = z;
+                    } else secondLowestIntensity = z;
+                }
+            }
+            double baseline = lowestIntensity + secondLowestIntensity;
+            int behindParent = Arrays.binarySearch(mergedSpectrum, new SimpleDataPoint(parentPeak + 5, 0d), CompareDataPointsByMz);
+            if (behindParent < 0) {
+                behindParent = -(behindParent + 1);
+            }
+            final int noisePeaksBehindParentPeak = mergedSpectrum.length - behindParent;
+            if (noisePeaksBehindParentPeak >= 10) {
+                final DataPoint[] subspec = new DataPoint[noisePeaksBehindParentPeak];
+                System.arraycopy(mergedSpectrum, noisePeaksBehindParentPeak, subspec, 0, subspec.length);
+                Arrays.sort(subspec, sorter);
+                int q75 = (int) (subspec.length * 0.75);
+                baseline = Math.max(subspec[q75].getIntensity(), baseline);
+            }
+            final List<DataPoint> keep = new ArrayList<>();
+            for (int i = 0; i < mergedSpectrum.length; ++i) {
+                if (mergedSpectrum[i].getIntensity() > baseline) keep.add(mergedSpectrum[i]);
+            }
+            return keep.toArray(new DataPoint[keep.size()]);
+        }
+        return mergedSpectrum;
+    }
+
+    private static void merge(DataPoint[] orderedByMz, DataPoint[] orderedByInt) {
+        // we assume a rather large deviation as signal peaks should be contained in more than one
+        // measurement
+        final List<DataPoint> append = new ArrayList<>();
+        final double absoluteDeviation = 0.005;
+        for (int k = 0; k < orderedByInt.length; ++k) {
+            final DataPoint peak = orderedByInt[k];
+            final double dev = Math.max(absoluteDeviation, peak.getMZ() * 10e-6);
+            final double lb = peak.getMZ() - dev, ub = peak.getMZ() + dev;
+            int mz1 = Arrays.binarySearch(orderedByMz, peak, CompareDataPointsByMz);
+            if (mz1 < 0) {
+                mz1 = -(mz1 + 1);
+            }
+            int mz0 = mz1 - 1;
+            while (mz1 < orderedByMz.length && orderedByMz[mz1].getMZ() <= ub) ++mz1;
+            --mz1;
+            while (mz0 >= 0 && orderedByMz[mz0].getMZ() >= lb) --mz0;
+            ++mz0;
+            if (mz0 <= mz1) {
+                // merge!
+                int mostIntensive = mz0;
+                double bestScore = Double.NEGATIVE_INFINITY;
+                for (int i = mz0; i <= mz1; ++i) {
+                    final double massDiff = orderedByMz[i].getMZ() - peak.getMZ();
+                    final double score = Erf.erfc(3 * massDiff) / (dev * Math.sqrt(2)) * orderedByMz[i].getIntensity();
+                    if (score > bestScore) {
+                        bestScore = score;
+                        mostIntensive = i;
+                    }
+                }
+                final double mzValue = peak.getIntensity() > orderedByMz[mostIntensive].getIntensity() ? peak.getMZ() : orderedByMz[mostIntensive].getMZ();
+                orderedByMz[mostIntensive] = new SimpleDataPoint(mzValue, peak.getIntensity() + orderedByMz[mostIntensive].getIntensity());
+            } else {
+                // append
+                append.add(peak);
+            }
+        }
+        if (append.size() > 0) {
+            int offset = orderedByMz.length;
+            orderedByMz = Arrays.copyOf(orderedByMz, orderedByMz.length + append.size());
+            for (DataPoint p : append) {
+                orderedByMz[offset++] = p;
+            }
+            Arrays.sort(orderedByMz, CompareDataPointsByMz);
+        }
+    }
+
+    public void runSingleRow(PeakListRow row) {
+        this.progress = 0d;
+        setStatus(TaskStatus.PROCESSING);
+        try (final BufferedWriter bw = new BufferedWriter(new FileWriter(fileName, true))) {
+            exportPeakListRow(row, bw, getFragmentScans(row.getRawDataFiles()));
+        } catch (IOException e) {
+            setStatus(TaskStatus.ERROR);
+            setErrorMessage("Could not open file " + fileName + " for writing.");
+        }
+        if (getStatus() == TaskStatus.PROCESSING)
+            setStatus(TaskStatus.FINISHED);
+    }
+
     private void exportPeakList(PeakList peakList, BufferedWriter writer) throws IOException {
 
+        final HashMap<String, int[]> fragmentScans = getFragmentScans(peakList.getRawDataFiles());
+
+        for (PeakListRow row : peakList.getRows()) {
+            exportPeakListRow(row, writer, fragmentScans);
+        }
+    }
+
+    private HashMap<String, int[]> getFragmentScans(RawDataFile[] rawDataFiles) {
         final HashMap<String, int[]> fragmentScans = new HashMap<>();
-        for (RawDataFile r : peakList.getRawDataFiles()) {
+        for (RawDataFile r : rawDataFiles) {
             int[] scans = new int[0];
             for (int msLevel : r.getMSLevels()) {
                 if (msLevel > 1) {
@@ -115,37 +252,46 @@ public class SiriusExportTask extends AbstractTask {
             Arrays.sort(scans);
             fragmentScans.put(r.getName(), scans);
         }
+        return fragmentScans;
+    }
 
-		for (PeakListRow row : peakList.getRows()) {
-            if (isSkipRow(row))
-                continue;
-            // get row charge and polarity
-            char polarity = 0;
-            for (Feature f : row.getPeaks()) {
-                char pol = f.getDataFile().getScan(f.getRepresentativeScanNumber()).getPolarity().asSingleChar().charAt(0);
-                if (pol != polarity && polarity != 0) {
-                    setErrorMessage("Joined features have different polarity. This is most likely a bug. If not, please separate them as individual features and/or write a feature request on github.");
-                    setStatus(TaskStatus.ERROR);
-                    return;
-                } else {
-                    polarity = pol;
-                }
+    private void exportPeakListRow(PeakListRow row, BufferedWriter writer, final HashMap<String, int[]> fragmentScans) throws IOException {
+        if (isSkipRow(row))
+            return;
+        // get row charge and polarity
+        char polarity = 0;
+        for (Feature f : row.getPeaks()) {
+            char pol = f.getDataFile().getScan(f.getRepresentativeScanNumber()).getPolarity().asSingleChar().charAt(0);
+            if (pol != polarity && polarity != 0) {
+                setErrorMessage("Joined features have different polarity. This is most likely a bug. If not, please separate them as individual features and/or write a feature request on github.");
+                setStatus(TaskStatus.ERROR);
+                return;
+            } else {
+                polarity = pol;
             }
-            // write correlation spectrum
-            writeHeader(writer, row, row.getBestPeak().getDataFile(), polarity, MsType.CORRELATED, -1);
-            writeCorrelationSpectrum(writer, row.getBestPeak());
-            // for each MS/MS write corresponding MS1 and MSMS spectrum
-            for (Feature f : row.getPeaks()) {
-                if (f.getFeatureStatus() == Feature.FeatureStatus.DETECTED && f.getMostIntenseFragmentScanNumber() >= 0) {
-                    final int[] scanNumbers = f.getScanNumbers().clone();
-                    Arrays.sort(scanNumbers);
-                    int[] fs = fragmentScans.get(f.getDataFile().getName());
-                    int startWith = scanNumbers[0];
-                    int j = Arrays.binarySearch(fs, startWith);
-                    if (j < 0) j = (-j - 1);
-                    for (int k = j; k < fs.length; ++k) {
-                        final Scan scan = f.getDataFile().getScan(fs[k]);
-                        if (scan.getMSLevel() > 1 && Math.abs(scan.getPrecursorMZ() - f.getMZ()) < 0.1) {
+        }
+        // write correlation spectrum
+        writeHeader(writer, row, row.getBestPeak().getDataFile(), polarity, MsType.CORRELATED, -1);
+        writeCorrelationSpectrum(writer, row.getBestPeak());
+
+        List<DataPoint[]> toMerge = new ArrayList<>();
+        List<String> sources = new ArrayList<>();
+
+        // for each MS/MS write corresponding MS1 and MSMS spectrum
+        for (Feature f : row.getPeaks()) {
+            if (mergeMsMs == SiriusExportParameters.MERGE_MODE.MERGE_CONSECUTIVE_SCANS)
+                toMerge.clear();
+            if (f.getFeatureStatus() == Feature.FeatureStatus.DETECTED && f.getMostIntenseFragmentScanNumber() >= 0) {
+                final int[] scanNumbers = f.getScanNumbers().clone();
+                Arrays.sort(scanNumbers);
+                int[] fs = fragmentScans.get(f.getDataFile().getName());
+                int startWith = scanNumbers[0];
+                int j = Arrays.binarySearch(fs, startWith);
+                if (j < 0) j = (-j - 1);
+                for (int k = j; k < fs.length; ++k) {
+                    final Scan scan = f.getDataFile().getScan(fs[k]);
+                    if (scan.getMSLevel() > 1 && Math.abs(scan.getPrecursorMZ() - f.getMZ()) < 0.1) {
+                            /*
                             if (includeMs1) {
                                 // find precursor scan
                                 int prec = Arrays.binarySearch(scanNumbers, fs[k]);
@@ -159,13 +305,27 @@ public class SiriusExportTask extends AbstractTask {
                                     }
                                 }
                             }
+                            */ // Do not include MS1 scans (except for isotope pattern)
+                        if (mergeMsMs == SiriusExportParameters.MERGE_MODE.NO_MERGE) {
                             writeHeader(writer, row, f.getDataFile(), polarity, MsType.MSMS, scan.getScanNumber());
                             writeSpectrum(writer, massListName != null ? scan.getMassList(massListName).getDataPoints() : scan.getDataPoints());
+                        } else {
+                            if (mergeMsMs == SiriusExportParameters.MERGE_MODE.MERGE_OVER_SAMPLES)
+                                sources.add(f.getDataFile().getName());
+                            toMerge.add(massListName != null ? scan.getMassList(massListName).getDataPoints() : scan.getDataPoints());
                         }
                     }
                 }
-                ++progress;
+                if (mergeMsMs == SiriusExportParameters.MERGE_MODE.MERGE_CONSECUTIVE_SCANS && toMerge.size() > 0) {
+                    writeHeader(writer, row, f.getDataFile(), polarity, MsType.MSMS, null);
+                    writeSpectrum(writer, merge(f.getMZ(), toMerge));
+                }
             }
+            ++progress;
+        }
+        if (mergeMsMs == SiriusExportParameters.MERGE_MODE.MERGE_OVER_SAMPLES && toMerge.size() > 0) {
+            writeHeader(writer, row, row.getBestPeak().getDataFile(), polarity, MsType.MSMS, null, sources);
+            writeSpectrum(writer, merge(row.getAverageMZ(), toMerge));
         }
     }
 
@@ -180,9 +340,11 @@ public class SiriusExportTask extends AbstractTask {
         return true;
     }
 
-    ;
+    private void writeHeader(BufferedWriter writer, PeakListRow row, RawDataFile raw, char polarity, MsType msType, Integer scanNumber) throws IOException {
+        writeHeader(writer, row, raw, polarity, msType, scanNumber, null);
+    }
 
-    private void writeHeader(BufferedWriter writer, PeakListRow row, RawDataFile raw, char polarity, MsType msType, int scanNumber) throws IOException {
+    private void writeHeader(BufferedWriter writer, PeakListRow row, RawDataFile raw, char polarity, MsType msType, Integer scanNumber, List<String> sources) throws IOException {
         final Feature feature = row.getPeak(raw);
         writer.write("BEGIN IONS");
         writer.newLine();
@@ -212,7 +374,14 @@ public class SiriusExportTask extends AbstractTask {
                 writer.newLine();
         }
         writer.write("FILENAME=");
-        if (msType == MsType.CORRELATED) {
+        if (sources != null) {
+            writer.write(escape(sources.get(0), ";"));
+            for (int i = 1; i < sources.size(); ++i) {
+                writer.write(";");
+                writer.write(escape(sources.get(i), ";"));
+            }
+            writer.newLine();
+        } else if (msType == MsType.CORRELATED) {
             RawDataFile[] raws = row.getRawDataFiles();
             writer.write(escape(raws[0].getName(), ";"));
             for (int i = 1; i < raws.length; ++i) {
@@ -224,7 +393,7 @@ public class SiriusExportTask extends AbstractTask {
             writer.write(feature.getDataFile().getName());
             writer.newLine();
         }
-        if (scanNumber >= 0) {
+        if (scanNumber != null) {
             writer.write("SCANS=");
             writer.write(String.valueOf(scanNumber));
             writer.newLine();

--- a/src/main/java/net/sf/mzmine/modules/visualization/peaklisttable/PeakListTablePopupMenu.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/peaklisttable/PeakListTablePopupMenu.java
@@ -19,33 +19,14 @@
 
 package net.sf.mzmine.modules.visualization.peaklisttable;
 
-import java.awt.Component;
-import java.awt.Point;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import javax.swing.JMenu;
-import javax.swing.JMenuItem;
-import javax.swing.JPopupMenu;
-import javax.swing.ListSelectionModel;
-import javax.swing.SwingUtilities;
-import javax.swing.table.AbstractTableModel;
-
-import net.sf.mzmine.datamodel.Feature;
-import net.sf.mzmine.datamodel.PeakIdentity;
-import net.sf.mzmine.datamodel.PeakList;
-import net.sf.mzmine.datamodel.PeakListRow;
-import net.sf.mzmine.datamodel.RawDataFile;
+import com.google.common.collect.Range;
+import net.sf.mzmine.datamodel.*;
 import net.sf.mzmine.datamodel.impl.SimplePeakListRow;
 import net.sf.mzmine.main.MZmineCore;
 import net.sf.mzmine.modules.peaklistmethods.identification.formulaprediction.FormulaPredictionModule;
 import net.sf.mzmine.modules.peaklistmethods.identification.nist.NistMsSearchModule;
 import net.sf.mzmine.modules.peaklistmethods.identification.onlinedbsearch.OnlineDBSearchModule;
+import net.sf.mzmine.modules.peaklistmethods.io.siriusexport.SiriusExportModule;
 import net.sf.mzmine.modules.rawdatamethods.peakpicking.manual.ManualPeakPickerModule;
 import net.sf.mzmine.modules.visualization.intensityplot.IntensityPlotModule;
 import net.sf.mzmine.modules.visualization.peaklisttable.export.IsotopePatternExportModule;
@@ -63,7 +44,13 @@ import net.sf.mzmine.modules.visualization.twod.TwoDVisualizerModule;
 import net.sf.mzmine.parameters.parametertypes.selectors.ScanSelection;
 import net.sf.mzmine.util.GUIUtils;
 
-import com.google.common.collect.Range;
+import javax.swing.*;
+import javax.swing.table.AbstractTableModel;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.*;
+import java.util.List;
 
 /**
  * Peak-list table pop-up menu.
@@ -93,6 +80,10 @@ public class PeakListTablePopupMenu extends JPopupMenu implements
     private final JMenuItem show3DItem;
     private final JMenuItem exportIsotopesItem;
     private final JMenuItem exportMSMSItem;
+
+    ///// kaidu edit
+    private final JMenuItem exportToSirius;
+    ////
     private final JMenuItem manuallyDefineItem;
     private final JMenuItem showPeakRowSummaryItem;
     private final JMenuItem clearIdsItem;
@@ -154,6 +145,9 @@ public class PeakListTablePopupMenu extends JPopupMenu implements
         add(exportMenu);
         exportIsotopesItem = GUIUtils.addMenuItem(exportMenu,
                 "Isotope pattern", this);
+        // kaidu edit
+        exportToSirius = GUIUtils.addMenuItem(exportMenu, "Export to SIRIUS", this);
+        //
         exportMSMSItem = GUIUtils
                 .addMenuItem(exportMenu, "MS/MS pattern", this);
 
@@ -205,6 +199,7 @@ public class PeakListTablePopupMenu extends JPopupMenu implements
         showMenu.setEnabled(rowsSelected);
         idsMenu.setEnabled(rowsSelected);
         exportIsotopesItem.setEnabled(rowsSelected);
+        exportToSirius.setEnabled(rowsSelected);
         exportMenu.setEnabled(rowsSelected);
 
         final boolean oneRowSelected = selectedRows.length == 1;
@@ -562,6 +557,9 @@ public class PeakListTablePopupMenu extends JPopupMenu implements
 
         if (exportIsotopesItem.equals(src)) {
             IsotopePatternExportModule.exportIsotopePattern(clickedPeakListRow);
+        }
+        if (exportToSirius.equals(src)) {
+            SiriusExportModule.exportSinglePeakList(clickedPeakListRow);
         }
 
         if (exportMSMSItem.equals(src)) {


### PR DESCRIPTION
- SiriusExportTask now provides three merging options:
 - no merge
 - merge only scans from the same sample
 - merge over all scans from all samples (all aligned columns within a feature row)
- merging is done by keeping the m/z of the most intensive peak but sum up intensities. Very close peaks from multiple spectra are merged together within 10 ppm

- add export function for single features. However, I have to check again what this strange fragment scan hashmap is doing I create at the beginning. Sounds not very efficiently if I do this for every single feature again.