### PR TITLE
Added a reference to ADAP-GC 3.2 paper

### DIFF
--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/adap3decompositionV1_5/ADAP3DecompositionV1_5Parameters.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/adap3decompositionV1_5/ADAP3DecompositionV1_5Parameters.java
@@ -23,6 +23,7 @@ import java.awt.Window;
 import java.text.NumberFormat;
 
 import net.sf.mzmine.parameters.Parameter;
+import net.sf.mzmine.parameters.dialogs.ParameterSetupDialog;
 import net.sf.mzmine.parameters.impl.SimpleParameterSet;
 import net.sf.mzmine.parameters.parametertypes.BooleanParameter;
 import net.sf.mzmine.parameters.parametertypes.ComboParameter;
@@ -135,10 +136,17 @@ public class ADAP3DecompositionV1_5Parameters extends SimpleParameterSet {
     @Override
     public ExitCode showSetupDialog(Window parent, boolean valueCheckRequired)
     {
-        final ADAP3DecompositionV1_5SetupDialog dialog = 
-                new ADAP3DecompositionV1_5SetupDialog(
-                        parent, valueCheckRequired, this);
-        
+        String message = "<html>Module Disclaimer:" +
+                "<br> If you use this Spectral Deconvolution Module, please cite the " +
+                "<a href=\"https://bmcbioinformatics.biomedcentral.com/articles/10.1186/1471-2105-11-395\">MZmine2 paper</a> and the following article:" +
+                "<br><a href=\"http://pubs.acs.org/doi/10.1021/acs.jproteome.7b00633\"> Smirnov A, Jia W, Walker D, Jones D, Du X: ADAP-GC 3.2: Graphical Software Tool for " +
+                "<br>Efficient Spectral Deconvolution of Gas Cromatography&mdash;High-Resolution Mass Spectrometry " +
+                "<br>Metabolomics Data. J. Proteome Res 2017, DOI: 10.1021/acs.jproteome.7b00633</a>" +
+                "</html>";
+
+        final ADAP3DecompositionV1_5SetupDialog dialog = new ADAP3DecompositionV1_5SetupDialog(
+                parent, valueCheckRequired, this, message);
+
         dialog.setVisible(true);
         return dialog.getExitCode();
     }

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/adap3decompositionV1_5/ADAP3DecompositionV1_5Parameters.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/adap3decompositionV1_5/ADAP3DecompositionV1_5Parameters.java
@@ -23,7 +23,6 @@ import java.awt.Window;
 import java.text.NumberFormat;
 
 import net.sf.mzmine.parameters.Parameter;
-import net.sf.mzmine.parameters.dialogs.ParameterSetupDialog;
 import net.sf.mzmine.parameters.impl.SimpleParameterSet;
 import net.sf.mzmine.parameters.parametertypes.BooleanParameter;
 import net.sf.mzmine.parameters.parametertypes.ComboParameter;

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/adap3decompositionV1_5/ADAP3DecompositionV1_5SetupDialog.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/adap3decompositionV1_5/ADAP3DecompositionV1_5SetupDialog.java
@@ -107,9 +107,9 @@ public class ADAP3DecompositionV1_5SetupDialog extends ParameterSetupDialog
     public ADAP3DecompositionV1_5SetupDialog(
             Window parent,
             boolean valueCheckRequired,
-            final ParameterSet parameters)
+            final ParameterSet parameters, String message)
     {    
-        super(parent, valueCheckRequired, parameters);
+        super(parent, valueCheckRequired, parameters, message);
         
         Parameter[] params = parameters.getParameters();
         int size = params.length;


### PR DESCRIPTION
I've added a reference to our new paper. However, I noticed one strange behavior: a reference (footnote) looks fine in a window of the default size, but when the size changes a reference gets cropped. It happens with all references, not only with mine. I couldn't find the reason so far.

Some examples:

Wavelet (ADAP) chromatogram deconvolution
<img width="876" alt="wavelet adap chromatogram deconvolution default size" src="https://user-images.githubusercontent.com/13631120/32791695-9cc962aa-c92f-11e7-8f03-8fa87085eeb8.png">
<img width="624" alt="wavelet adap chromatogram deconvolution changed size" src="https://user-images.githubusercontent.com/13631120/32791705-a3a7bc3e-c92f-11e7-93e3-8a8a3251f908.png">

Spectral deconvolution. Hierarchical clustering.
<img width="933" alt="spectral deocnvolution default size" src="https://user-images.githubusercontent.com/13631120/32791771-c172b340-c92f-11e7-9fe8-6e6599877fa0.png">
<img width="1362" alt="spectral deconvolution changed size" src="https://user-images.githubusercontent.com/13631120/32791780-c566561e-c92f-11e7-9d46-eb6067510576.png">

