### PR TITLE
Added open ended ranges.

### DIFF
--- a/src/main/java/net/sf/mzmine/parameters/parametertypes/ranges/IntRangeComponent.java
+++ b/src/main/java/net/sf/mzmine/parameters/parametertypes/ranges/IntRangeComponent.java
@@ -30,7 +30,6 @@ import net.sf.mzmine.util.components.GridBagPanel;
 import com.google.common.collect.Range;
 
 public class IntRangeComponent extends GridBagPanel {
-
     private static final long serialVersionUID = 1L;
 
     private JTextField minTxtField, maxTxtField;
@@ -55,9 +54,15 @@ public class IntRangeComponent extends GridBagPanel {
         String maxString = maxTxtField.getText();
 
         try {
-            return Range.closed(Integer.parseInt(minString),
-                    Integer.parseInt(maxString));
-
+            if (!minString.isEmpty() && !maxString.isEmpty()) {
+                return Range.closed(Integer.parseInt(minString), Integer.parseInt(maxString));
+            } else if (!minString.isEmpty()) {
+                return Range.closed(Integer.parseInt(minString), Integer.MAX_VALUE);
+            } else if (!maxString.isEmpty()) {
+                return Range.closed(0, Integer.parseInt(maxString));
+            } else {
+                return null;
+            }
         } catch (Exception e) {
             return null;
         }


### PR DESCRIPTION
Integer Ranges can now be entered on one side, without the need to write anything in the other field:
Input of:
[15, BLANK] Will result in a range of:
[15, Integer.MAX_VALUE]

Input of:
[BLANK, 15] will result in a range of:
[0, 15]

Before these ranges would simply return null if one end was not entered in, a small quality of life fix. I thought of adding the maximum scan count to be the max range end instead of Integer.MAX_VALUE but I couldn't find where the currently selected scans are stored (Currently selected in my eyes is when a line is highlighted in blue) so that I left out. In another pull request I will make, where you can filter every Nth scans to be left, the other scans to be left out (Scan Filter buttton, ScanSelection in the project) I made it so instead of the 2 billion number it shows as soon as you click "OK" it will instead write "Max" for readability. As in my previous pull request and ideas how this code can be improved or changed will be appreciated.