### PR TITLE
Added Base Filtering Integer

### DIFF
--- a/src/main/java/net/sf/mzmine/parameters/parametertypes/selectors/ScanSelectionComponent.java
+++ b/src/main/java/net/sf/mzmine/parameters/parametertypes/selectors/ScanSelectionComponent.java
@@ -1,252 +1,245 @@
-/*
- * Copyright 2006-2015 The MZmine 2 Development Team
- * 
- * This file is part of MZmine 2.
- * 
- * MZmine 2 is free software; you can redistribute it and/or modify it under the
- * terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 2 of the License, or (at your option) any later
- * version.
- * 
- * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
- * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public License along with
- * MZmine 2; if not, write to the Free Software Foundation, Inc., 51 Franklin St,
- * Fifth Floor, Boston, MA 02110-1301 USA
- */
+    /*
+     * Copyright 2006-2015 The MZmine 2 Development Team
+     *
+     * This file is part of MZmine 2.
+     *
+     * MZmine 2 is free software; you can redistribute it and/or modify it under the
+     * terms of the GNU General Public License as published by the Free Software
+     * Foundation; either version 2 of the License, or (at your option) any later
+     * version.
+     *
+     * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY
+     * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+     * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+     *
+     * You should have received a copy of the GNU General Public License along with
+     * MZmine 2; if not, write to the Free Software Foundation, Inc., 51 Franklin St,
+     * Fifth Floor, Boston, MA 02110-1301 USA
+     */
 
-package net.sf.mzmine.parameters.parametertypes.selectors;
+    package net.sf.mzmine.parameters.parametertypes.selectors;
 
-import java.awt.Window;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.text.NumberFormat;
-import java.util.Arrays;
+    import java.awt.Window;
+    import java.awt.event.ActionEvent;
+    import java.awt.event.ActionListener;
+    import java.text.NumberFormat;
+    import java.util.Arrays;
 
-import javax.swing.BorderFactory;
-import javax.swing.Box;
-import javax.swing.BoxLayout;
-import javax.swing.JButton;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.SwingUtilities;
+    import javax.swing.BorderFactory;
+    import javax.swing.Box;
+    import javax.swing.BoxLayout;
+    import javax.swing.JButton;
+    import javax.swing.JLabel;
+    import javax.swing.JPanel;
+    import javax.swing.SwingUtilities;
 
-import com.google.common.base.Strings;
-import com.google.common.collect.Range;
+    import com.google.common.base.Strings;
+    import com.google.common.collect.Range;
 
-import net.sf.mzmine.datamodel.MassSpectrumType;
-import net.sf.mzmine.datamodel.PolarityType;
-import net.sf.mzmine.main.MZmineCore;
-import net.sf.mzmine.parameters.Parameter;
-import net.sf.mzmine.parameters.impl.SimpleParameterSet;
-import net.sf.mzmine.parameters.parametertypes.ComboParameter;
-import net.sf.mzmine.parameters.parametertypes.IntegerParameter;
-import net.sf.mzmine.parameters.parametertypes.StringParameter;
-import net.sf.mzmine.parameters.parametertypes.ranges.IntRangeParameter;
-import net.sf.mzmine.parameters.parametertypes.ranges.RTRangeParameter;
-import net.sf.mzmine.util.ExitCode;
-import net.sf.mzmine.util.GUIUtils;
+    import net.sf.mzmine.datamodel.MassSpectrumType;
+    import net.sf.mzmine.datamodel.PolarityType;
+    import net.sf.mzmine.main.MZmineCore;
+    import net.sf.mzmine.parameters.Parameter;
+    import net.sf.mzmine.parameters.impl.SimpleParameterSet;
+    import net.sf.mzmine.parameters.parametertypes.ComboParameter;
+    import net.sf.mzmine.parameters.parametertypes.IntegerParameter;
+    import net.sf.mzmine.parameters.parametertypes.StringParameter;
+    import net.sf.mzmine.parameters.parametertypes.ranges.IntRangeParameter;
+    import net.sf.mzmine.parameters.parametertypes.ranges.RTRangeParameter;
+    import net.sf.mzmine.util.ExitCode;
+    import net.sf.mzmine.util.GUIUtils;
 
-public class ScanSelectionComponent extends JPanel implements ActionListener {
+    public class ScanSelectionComponent extends JPanel implements ActionListener {
 
-    private static final long serialVersionUID = 1L;
+        private static final long serialVersionUID = 1L;
 
-    private final JButton setButton, clearButton;
+        private final JButton setButton, clearButton;
 
-    private final JLabel restrictionsList;
+        private final JLabel restrictionsList;
 
-    private Range<Integer> scanNumberRange;
-    private Range<Double> scanRTRange;
-    private Integer msLevel;
-    private PolarityType polarity;
-    private MassSpectrumType spectrumType;
-    private String scanDefinition;
+        private Range<Integer> scanNumberRange;
+        private Integer baseFilteringInteger;
+        private Range<Double> scanRTRange;
+        private Integer msLevel;
+        private PolarityType polarity;
+        private MassSpectrumType spectrumType;
+        private String scanDefinition;
 
-    public ScanSelectionComponent() {
+        public ScanSelectionComponent() {
 
-        BoxLayout layout = new BoxLayout(this, BoxLayout.X_AXIS);
-        setLayout(layout);
+            BoxLayout layout = new BoxLayout(this, BoxLayout.X_AXIS);
+            setLayout(layout);
 
-        setBorder(BorderFactory.createEmptyBorder(0, 8, 0, 0));
+            setBorder(BorderFactory.createEmptyBorder(0, 8, 0, 0));
 
-        restrictionsList = new JLabel();
-        add(restrictionsList);
-        updateRestrictionList();
+            restrictionsList = new JLabel();
+            add(restrictionsList);
+            updateRestrictionList();
 
-        add(Box.createHorizontalStrut(10));
+            add(Box.createHorizontalStrut(10));
 
-        setButton = GUIUtils.addButton(this, "Set filters", null, this);
-        clearButton = GUIUtils.addButton(this, "Clear filters", null, this);
+            setButton = GUIUtils.addButton(this, "Set filters", null, this);
+            clearButton = GUIUtils.addButton(this, "Clear filters", null, this);
 
-    }
+        }
 
-    void setValue(ScanSelection newValue) {
-        scanNumberRange = newValue.getScanNumberRange();
-        scanRTRange = newValue.getScanRTRange();
-        polarity = newValue.getPolarity();
-        spectrumType = newValue.getSpectrumType();
-        msLevel = newValue.getMsLevel();
-        scanDefinition = newValue.getScanDefinition();
+        void setValue(ScanSelection newValue) {
+            scanNumberRange = newValue.getScanNumberRange();
+            baseFilteringInteger = newValue.getBaseFilteringInteger();
+            scanRTRange = newValue.getScanRTRange();
+            polarity = newValue.getPolarity();
+            spectrumType = newValue.getSpectrumType();
+            msLevel = newValue.getMsLevel();
+            scanDefinition = newValue.getScanDefinition();
 
-        updateRestrictionList();
-    }
+            updateRestrictionList();
+        }
 
-    public ScanSelection getValue() {
-        return new ScanSelection(scanNumberRange, scanRTRange, polarity,
-                spectrumType, msLevel, scanDefinition);
-    }
+        public ScanSelection getValue() {
+            return new ScanSelection(scanNumberRange, baseFilteringInteger, scanRTRange, polarity, spectrumType, msLevel,
+                    scanDefinition);
+        }
 
-    public void actionPerformed(ActionEvent event) {
+        public void actionPerformed(ActionEvent event) {
 
-        Object src = event.getSource();
+            Object src = event.getSource();
 
-        if (src == setButton) {
+            if (src == setButton) {
 
-            SimpleParameterSet paramSet;
-            ExitCode exitCode;
-            Window parent = (Window) SwingUtilities
-                    .getAncestorOfClass(Window.class, this);
+                SimpleParameterSet paramSet;
+                ExitCode exitCode;
+                Window parent = (Window) SwingUtilities.getAncestorOfClass(Window.class, this);
 
-            final IntRangeParameter scanNumParameter = new IntRangeParameter(
-                    "Scan number", "Range of included scan numbers", false,
-                    scanNumberRange);
-            final RTRangeParameter rtParameter = new RTRangeParameter(false);
-            if (scanRTRange != null)
-                rtParameter.setValue(scanRTRange);
-            final IntegerParameter msLevelParameter = new IntegerParameter(
-                    "MS level", "MS level", msLevel, false);
-            final StringParameter scanDefinitionParameter = new StringParameter(
-                    "Scan definition",
-                    "Include only scans that match this scan definition. You can use wild cards, e.g. *FTMS*",
-                    scanDefinition, false);
-            final String polarityTypes[] = { "Any", "+", "-" };
-            final ComboParameter<String> polarityParameter = new ComboParameter<>(
-                    "Polarity", "Include only scans of this polarity",
-                    polarityTypes);
-            if ((polarity == PolarityType.POSITIVE)
-                    || (polarity == PolarityType.NEGATIVE))
-                polarityParameter.setValue(polarity.asSingleChar());
-            final String spectraTypes[] = { "Any", "Centroided", "Profile",
-                    "Thresholded" };
-            final ComboParameter<String> spectrumTypeParameter = new ComboParameter<>(
-                    "Spectrum type", "Include only spectra of this type",
-                    spectraTypes);
+                final IntRangeParameter scanNumParameter = new IntRangeParameter("Scan number",
+                        "Range of included scan numbers", false, scanNumberRange);
+                final IntegerParameter baseFilteringIntegerParameter = new IntegerParameter("Base Filtering Integer",
+                        "Enter an integer for which every multiple of that integer in the list will be filtered. (Every Nth element will be shown)", this.baseFilteringInteger, false);
+                final RTRangeParameter rtParameter = new RTRangeParameter(false);
+                if (scanRTRange != null)
+                    rtParameter.setValue(scanRTRange);
+                final IntegerParameter msLevelParameter = new IntegerParameter("MS level", "MS level", msLevel, false);
+                final StringParameter scanDefinitionParameter = new StringParameter("Scan definition",
+                        "Include only scans that match this scan definition. You can use wild cards, e.g. *FTMS*",
+                        scanDefinition, false);
+                final String polarityTypes[] = {"Any", "+", "-"};
+                final ComboParameter<String> polarityParameter = new ComboParameter<>("Polarity",
+                        "Include only scans of this polarity", polarityTypes);
+                if ((polarity == PolarityType.POSITIVE) || (polarity == PolarityType.NEGATIVE))
+                    polarityParameter.setValue(polarity.asSingleChar());
+                final String spectraTypes[] = {"Any", "Centroided", "Profile", "Thresholded"};
+                final ComboParameter<String> spectrumTypeParameter = new ComboParameter<>("Spectrum type",
+                        "Include only spectra of this type", spectraTypes);
+                if (spectrumType != null) {
+                    switch (spectrumType) {
+                        case CENTROIDED:
+                            spectrumTypeParameter.setValue(spectraTypes[1]);
+                            break;
+                        case PROFILE:
+                            spectrumTypeParameter.setValue(spectraTypes[2]);
+                            break;
+                        case THRESHOLDED:
+                            spectrumTypeParameter.setValue(spectraTypes[3]);
+                            break;
+                    }
+                }
+
+                paramSet = new SimpleParameterSet(new Parameter[]{scanNumParameter, baseFilteringIntegerParameter, rtParameter, msLevelParameter,
+                        scanDefinitionParameter, polarityParameter, spectrumTypeParameter});
+                exitCode = paramSet.showSetupDialog(parent, true);
+                if (exitCode == ExitCode.OK) {
+                    scanNumberRange = paramSet.getParameter(scanNumParameter).getValue();
+                    this.baseFilteringInteger = paramSet.getParameter(baseFilteringIntegerParameter).getValue();
+                    scanRTRange = paramSet.getParameter(rtParameter).getValue();
+                    msLevel = paramSet.getParameter(msLevelParameter).getValue();
+                    scanDefinition = paramSet.getParameter(scanDefinitionParameter).getValue();
+                    final int selectedPolarityIndex = Arrays.asList(polarityTypes)
+                            .indexOf(paramSet.getParameter(polarityParameter).getValue());
+                    switch (selectedPolarityIndex) {
+                        case 1:
+                            polarity = PolarityType.POSITIVE;
+                            break;
+                        case 2:
+                            polarity = PolarityType.NEGATIVE;
+                            break;
+                        default:
+                            polarity = null;
+                            break;
+                    }
+                    final int selectedSpectraTypeIndex = Arrays.asList(spectraTypes)
+                            .indexOf(paramSet.getParameter(spectrumTypeParameter).getValue());
+                    switch (selectedSpectraTypeIndex) {
+                        case 1:
+                            spectrumType = MassSpectrumType.CENTROIDED;
+                            break;
+                        case 2:
+                            spectrumType = MassSpectrumType.PROFILE;
+                            break;
+                        case 3:
+                            spectrumType = MassSpectrumType.THRESHOLDED;
+                            break;
+                        default:
+                            spectrumType = null;
+                            break;
+                    }
+
+                }
+            }
+
+            if (src == clearButton) {
+                scanNumberRange = null;
+                baseFilteringInteger = null;
+                scanRTRange = null;
+                polarity = null;
+                spectrumType = null;
+                msLevel = null;
+                scanDefinition = null;
+            }
+
+            updateRestrictionList();
+
+        }
+
+        @Override
+        public void setToolTipText(String toolTip) {
+            restrictionsList.setToolTipText(toolTip);
+        }
+
+        private void updateRestrictionList() {
+
+            if ((scanNumberRange == null) && (scanRTRange == null) && (polarity == null) && (spectrumType == null)
+                    && (msLevel == null) && Strings.isNullOrEmpty(scanDefinition) && (baseFilteringInteger == null)) {
+                restrictionsList.setText("All");
+                return;
+            }
+
+            StringBuilder newText = new StringBuilder("<html>");
+            if (scanNumberRange != null) {
+                int upperEndpoint = scanNumberRange.upperEndpoint();
+                String maxCountText = upperEndpoint == Integer.MAX_VALUE ? "Max" : Integer.toString(upperEndpoint);
+                newText.append("Scan number: " + scanNumberRange.lowerEndpoint() + " - " + maxCountText
+                        + "<br>");
+            }
+            if (baseFilteringInteger != null) {
+                newText.append("Base Filtering Integer: " + baseFilteringInteger + "<br>");
+            }
+            if (scanRTRange != null) {
+                NumberFormat rtFormat = MZmineCore.getConfiguration().getRTFormat();
+                newText.append("Retention time: " + rtFormat.format(scanRTRange.lowerEndpoint()) + " - "
+                        + rtFormat.format(scanRTRange.upperEndpoint()) + " min.<br>");
+            }
+            if (msLevel != null) {
+                newText.append("MS level: " + msLevel + "<br>");
+            }
+            if (!Strings.isNullOrEmpty(scanDefinition)) {
+                newText.append("Scan definition: " + scanDefinition + "<br>");
+            }
+            if (polarity != null) {
+                newText.append("Polarity: " + polarity.asSingleChar() + "<br>");
+            }
             if (spectrumType != null) {
-                switch (spectrumType) {
-                case CENTROIDED:
-                    spectrumTypeParameter.setValue(spectraTypes[1]);
-                    break;
-                case PROFILE:
-                    spectrumTypeParameter.setValue(spectraTypes[2]);
-                    break;
-                case THRESHOLDED:
-                    spectrumTypeParameter.setValue(spectraTypes[3]);
-                    break;
-                }
+                newText.append("Spectrum type: " + spectrumType.toString().toLowerCase());
             }
 
-            paramSet = new SimpleParameterSet(
-                    new Parameter[] { scanNumParameter, rtParameter,
-                            msLevelParameter, scanDefinitionParameter,
-                            polarityParameter, spectrumTypeParameter });
-            exitCode = paramSet.showSetupDialog(parent, true);
-            if (exitCode == ExitCode.OK) {
-                scanNumberRange = paramSet.getParameter(scanNumParameter)
-                        .getValue();
-                scanRTRange = paramSet.getParameter(rtParameter).getValue();
-                msLevel = paramSet.getParameter(msLevelParameter).getValue();
-                scanDefinition = paramSet.getParameter(scanDefinitionParameter)
-                        .getValue();
-                final int selectedPolarityIndex = Arrays.asList(polarityTypes)
-                        .indexOf(paramSet.getParameter(polarityParameter)
-                                .getValue());
-                switch (selectedPolarityIndex) {
-                case 1:
-                    polarity = PolarityType.POSITIVE;
-                    break;
-                case 2:
-                    polarity = PolarityType.NEGATIVE;
-                    break;
-                default:
-                    polarity = null;
-                    break;
-                }
-                final int selectedSpectraTypeIndex = Arrays.asList(spectraTypes)
-                        .indexOf(paramSet.getParameter(spectrumTypeParameter)
-                                .getValue());
-                switch (selectedSpectraTypeIndex) {
-                case 1:
-                    spectrumType = MassSpectrumType.CENTROIDED;
-                    break;
-                case 2:
-                    spectrumType = MassSpectrumType.PROFILE;
-                    break;
-                case 3:
-                    spectrumType = MassSpectrumType.THRESHOLDED;
-                    break;
-                default:
-                    spectrumType = null;
-                    break;
-                }
-
-            }
+            restrictionsList.setText(newText.toString());
         }
-
-        if (src == clearButton) {
-            scanNumberRange = null;
-            scanRTRange = null;
-            polarity = null;
-            spectrumType = null;
-            msLevel = null;
-            scanDefinition = null;
-        }
-
-        updateRestrictionList();
-
     }
-
-    @Override
-    public void setToolTipText(String toolTip) {
-        restrictionsList.setToolTipText(toolTip);
-    }
-
-    private void updateRestrictionList() {
-
-        if ((scanNumberRange == null) && (scanRTRange == null)
-                && (polarity == null) && (spectrumType == null)
-                && (msLevel == null) && Strings.isNullOrEmpty(scanDefinition)) {
-            restrictionsList.setText("All");
-            return;
-        }
-
-        StringBuilder newText = new StringBuilder("<html>");
-        if (scanNumberRange != null) {
-            newText.append("Scan number: " + scanNumberRange.lowerEndpoint()
-                    + " - " + scanNumberRange.upperEndpoint() + "<br>");
-        }
-        if (scanRTRange != null) {
-            NumberFormat rtFormat = MZmineCore.getConfiguration().getRTFormat();
-            newText.append("Retention time: "
-                    + rtFormat.format(scanRTRange.lowerEndpoint()) + " - "
-                    + rtFormat.format(scanRTRange.upperEndpoint())
-                    + " min.<br>");
-        }
-        if (msLevel != null) {
-            newText.append("MS level: " + msLevel + "<br>");
-        }
-        if (!Strings.isNullOrEmpty(scanDefinition)) {
-            newText.append("Scan definition: " + scanDefinition + "<br>");
-        }
-        if (polarity != null) {
-            newText.append("Polarity: " + polarity.asSingleChar() + "<br>");
-        }
-        if (spectrumType != null) {
-            newText.append(
-                    "Spectrum type: " + spectrumType.toString().toLowerCase());
-        }
-
-        restrictionsList.setText(newText.toString());
-    }
-}

--- a/src/main/java/net/sf/mzmine/parameters/parametertypes/selectors/ScanSelectionParameter.java
+++ b/src/main/java/net/sf/mzmine/parameters/parametertypes/selectors/ScanSelectionParameter.java
@@ -32,9 +32,7 @@ import net.sf.mzmine.datamodel.PolarityType;
 import net.sf.mzmine.parameters.UserParameter;
 import net.sf.mzmine.util.XMLUtils;
 
-public class ScanSelectionParameter
-        implements UserParameter<ScanSelection, ScanSelectionComponent> {
-
+public class ScanSelectionParameter implements UserParameter<ScanSelection, ScanSelectionComponent> {
     private final String name, description;
     private ScanSelection value;
 
@@ -46,8 +44,7 @@ public class ScanSelectionParameter
         this("Scans", "Select scans that should be included.", defaultValue);
     }
 
-    public ScanSelectionParameter(String name, String description,
-            ScanSelection defaultValue) {
+    public ScanSelectionParameter(String name, String description, ScanSelection defaultValue) {
         this.name = name;
         this.description = description;
         this.value = defaultValue;
@@ -65,8 +62,7 @@ public class ScanSelectionParameter
 
     @Override
     public ScanSelectionParameter cloneParameter() {
-        ScanSelectionParameter copy = new ScanSelectionParameter(name,
-                description, value);
+        ScanSelectionParameter copy = new ScanSelectionParameter(name, description, value);
         return copy;
     }
 
@@ -89,14 +85,14 @@ public class ScanSelectionParameter
     public void loadValueFromXML(Element xmlElement) {
 
         Range<Integer> scanNumberRange = null;
+        Integer baseFilteringInteger = null;
         Range<Double> scanRTRange = null;
         PolarityType polarity = null;
         MassSpectrumType spectrumType = null;
         Integer msLevel = null;
         String scanDefinition = null;
 
-        scanNumberRange = XMLUtils.parseIntegerRange(xmlElement,
-                "scan_numbers");
+        scanNumberRange = XMLUtils.parseIntegerRange(xmlElement, "scan_numbers");
         scanRTRange = XMLUtils.parseDoubleRange(xmlElement, "retention_time");
 
         NodeList items = xmlElement.getElementsByTagName("ms_level");
@@ -109,15 +105,13 @@ public class ScanSelectionParameter
             try {
                 polarity = PolarityType.valueOf(items.item(i).getTextContent());
             } catch (Exception e) {
-                polarity = PolarityType
-                        .fromSingleChar(items.item(i).getTextContent());
+                polarity = PolarityType.fromSingleChar(items.item(i).getTextContent());
             }
         }
 
         items = xmlElement.getElementsByTagName("spectrum_type");
         for (int i = 0; i < items.getLength(); i++) {
-            spectrumType = MassSpectrumType
-                    .valueOf(items.item(i).getTextContent());
+            spectrumType = MassSpectrumType.valueOf(items.item(i).getTextContent());
         }
 
         items = xmlElement.getElementsByTagName("scan_definition");
@@ -125,8 +119,8 @@ public class ScanSelectionParameter
             scanDefinition = items.item(i).getTextContent();
         }
 
-        this.value = new ScanSelection(scanNumberRange, scanRTRange, polarity,
-                spectrumType, msLevel, scanDefinition);
+        this.value = new ScanSelection(scanNumberRange, baseFilteringInteger, scanRTRange, polarity, spectrumType, msLevel,
+                scanDefinition);
     }
 
     @Override
@@ -137,15 +131,20 @@ public class ScanSelectionParameter
 
         final Range<Integer> scanNumberRange = value.getScanNumberRange();
         final Range<Double> scanRetentionTimeRange = value.getScanRTRange();
+        final Integer baseFilteringInteger = value.getBaseFilteringInteger();
         final PolarityType polarity = value.getPolarity();
         final MassSpectrumType spectrumType = value.getSpectrumType();
         final Integer msLevel = value.getMsLevel();
         final String scanDefinition = value.getScanDefinition();
 
         XMLUtils.appendRange(xmlElement, "scan_numbers", scanNumberRange);
-        XMLUtils.appendRange(xmlElement, "retention_time",
-                scanRetentionTimeRange);
+        XMLUtils.appendRange(xmlElement, "retention_time", scanRetentionTimeRange);
 
+        if (baseFilteringInteger != null) {
+            Element newElement = parentDocument.createElement("baseFilteringInteger");
+            newElement.setTextContent(baseFilteringInteger.toString());
+            xmlElement.appendChild(newElement);
+        }
         if (polarity != null) {
             Element newElement = parentDocument.createElement("polarity");
             newElement.setTextContent(polarity.toString());
@@ -165,8 +164,7 @@ public class ScanSelectionParameter
         }
 
         if (scanDefinition != null) {
-            Element newElement = parentDocument
-                    .createElement("scan_definition");
+            Element newElement = parentDocument.createElement("scan_definition");
             newElement.setTextContent(scanDefinition);
             xmlElement.appendChild(newElement);
         }
@@ -184,8 +182,7 @@ public class ScanSelectionParameter
     }
 
     @Override
-    public void setValueToComponent(ScanSelectionComponent component,
-            ScanSelection newValue) {
+    public void setValueToComponent(ScanSelectionComponent component, ScanSelection newValue) {
         component.setValue(newValue);
     }
 


### PR DESCRIPTION
I added the so called "Base Filtering Integer". I had troubles naming this variable, but it's possible to describe it in a longer manner (which is what I did in the tooltip).

The base filtering integer filters every Nth element of the current scan(s). It's best shown how it works by example.
If you input 3 as the base filtering integer it will filter this list in such a way:
[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
into
[1, 4, 7, 10]

As with the two previous pull requests, any ideas or changes are appreciated. A name change is very forseeable  It kind of bothers me and I can't think of anything more short and to the point.