### PR TITLE
Streams/parallel streams for PeakListRows

### DIFF
--- a/src/main/java/net/sf/mzmine/datamodel/PeakList.java
+++ b/src/main/java/net/sf/mzmine/datamodel/PeakList.java
@@ -3,25 +3,23 @@
  * 
  * This file is part of MZmine 2.
  * 
- * MZmine 2 is free software; you can redistribute it and/or modify it under the
- * terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 2 of the License, or (at your option) any later
- * version.
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
  * 
- * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the im plied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
- * details.
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the im plied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
  * 
- * You should have received a copy of the GNU General Public License along with
- * MZmine 2; if not, write to the Free Software Foundation, Inc., 51 Franklin St,
- * Fifth Floor, Boston, MA 02110-1301 USA
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
  */
 
 package net.sf.mzmine.datamodel;
 
+import java.util.stream.Stream;
 import javax.annotation.Nonnull;
-
 import com.google.common.collect.Range;
 
 /**
@@ -29,202 +27,193 @@ import com.google.common.collect.Range;
  */
 public interface PeakList {
 
-    public interface PeakListAppliedMethod {
+  public interface PeakListAppliedMethod {
 
-	@Nonnull
-	public String getDescription();
+    @Nonnull
+    public String getDescription();
 
-	@Nonnull
-	public String getParameters();
+    @Nonnull
+    public String getParameters();
 
-    }
+  }
 
-    /**
-     * @return Short descriptive name for the peak list
-     */
-    public String getName();
+  /**
+   * @return Short descriptive name for the peak list
+   */
+  public String getName();
 
-    /**
-     * Change the name of this peak list
-     */
-    public void setName(String name);
+  /**
+   * Change the name of this peak list
+   */
+  public void setName(String name);
 
-    /**
-     * Returns number of raw data files participating in the peak list
-     */
-    public int getNumberOfRawDataFiles();
+  /**
+   * Returns number of raw data files participating in the peak list
+   */
+  public int getNumberOfRawDataFiles();
 
-    /**
-     * Returns all raw data files participating in the peak list
-     */
-    public RawDataFile[] getRawDataFiles();
+  /**
+   * Returns all raw data files participating in the peak list
+   */
+  public RawDataFile[] getRawDataFiles();
 
-    /**
-     * Returns true if this peak list contains given file
-     */
-    public boolean hasRawDataFile(RawDataFile file);
+  /**
+   * Returns true if this peak list contains given file
+   */
+  public boolean hasRawDataFile(RawDataFile file);
 
-    /**
-     * Returns a raw data file
-     * 
-     * @param position
-     *            Position of the raw data file in the matrix (running numbering
-     *            from left 0,1,2,...)
-     */
-    public RawDataFile getRawDataFile(int position);
+  /**
+   * Returns a raw data file
+   * 
+   * @param position Position of the raw data file in the matrix (running numbering from left
+   *        0,1,2,...)
+   */
+  public RawDataFile getRawDataFile(int position);
 
-    /**
-     * Returns number of rows in the alignment result
-     */
-    public int getNumberOfRows();
+  /**
+   * Returns number of rows in the alignment result
+   */
+  public int getNumberOfRows();
 
-    /**
-     * Returns the peak of a given raw data file on a give row of the peak list
-     * 
-     * @param row
-     *            Row of the peak list
-     * @param rawDataFile
-     *            Raw data file where the peak is detected/estimated
-     */
-    public Feature getPeak(int row, RawDataFile rawDataFile);
+  /**
+   * Returns the peak of a given raw data file on a give row of the peak list
+   * 
+   * @param row Row of the peak list
+   * @param rawDataFile Raw data file where the peak is detected/estimated
+   */
+  public Feature getPeak(int row, RawDataFile rawDataFile);
 
-    /**
-     * Returns all peaks for a raw data file
-     */
-    public Feature[] getPeaks(RawDataFile rawDataFile);
+  /**
+   * Returns all peaks for a raw data file
+   */
+  public Feature[] getPeaks(RawDataFile rawDataFile);
 
-    /**
-     * Returns all peaks on one row
-     */
-    public PeakListRow getRow(int row);
+  /**
+   * Returns all peaks on one row
+   */
+  public PeakListRow getRow(int row);
 
-    /**
-     * Returns all peak list rows
-     */
-    public PeakListRow[] getRows();
+  /**
+   * Returns all peak list rows
+   */
+  public PeakListRow[] getRows();
 
-    /**
-     * Returns all rows with average retention time within given range
-     * 
-     * @param startRT
-     *            Start of the retention time range
-     * @param endRT
-     *            End of the retention time range
-     */
-    public PeakListRow[] getRowsInsideScanRange(Range<Double> rtRange);
+  /**
+   * Creates a stream of PeakListRows
+   * 
+   * @return
+   */
+  public Stream<PeakListRow> stream();
 
-    /**
-     * Returns all rows with average m/z within given range
-     * 
-     * @param startMZ
-     *            Start of the m/z range
-     * @param endMZ
-     *            End of the m/z range
-     */
-    public PeakListRow[] getRowsInsideMZRange(Range<Double> mzRange);
+  /**
+   * Creates a parallel stream of PeakListRows
+   * 
+   * @return
+   */
+  public Stream<PeakListRow> parallelStream();
 
-    /**
-     * Returns all rows with average m/z and retention time within given range
-     * 
-     * @param startRT
-     *            Start of the retention time range
-     * @param endRT
-     *            End of the retention time range
-     * @param startMZ
-     *            Start of the m/z range
-     * @param endMZ
-     *            End of the m/z range
-     */
-    public PeakListRow[] getRowsInsideScanAndMZRange(Range<Double> rtRange,
-	    Range<Double> mzRange);
+  /**
+   * Returns all rows with average retention time within given range
+   * 
+   * @param startRT Start of the retention time range
+   * @param endRT End of the retention time range
+   */
+  public PeakListRow[] getRowsInsideScanRange(Range<Double> rtRange);
 
-    /**
-     * Returns all peaks overlapping with a retention time range
-     * 
-     * @param startRT
-     *            Start of the retention time range
-     * @param endRT
-     *            End of the retention time range
-     */
-    public Feature[] getPeaksInsideScanRange(RawDataFile file,
-	    Range<Double> rtRange);
+  /**
+   * Returns all rows with average m/z within given range
+   * 
+   * @param startMZ Start of the m/z range
+   * @param endMZ End of the m/z range
+   */
+  public PeakListRow[] getRowsInsideMZRange(Range<Double> mzRange);
 
-    /**
-     * Returns all peaks in a given m/z range
-     * 
-     * @param startMZ
-     *            Start of the m/z range
-     * @param endMZ
-     *            End of the m/z range
-     */
-    public Feature[] getPeaksInsideMZRange(RawDataFile file,
-	    Range<Double> mzRange);
+  /**
+   * Returns all rows with average m/z and retention time within given range
+   * 
+   * @param startRT Start of the retention time range
+   * @param endRT End of the retention time range
+   * @param startMZ Start of the m/z range
+   * @param endMZ End of the m/z range
+   */
+  public PeakListRow[] getRowsInsideScanAndMZRange(Range<Double> rtRange, Range<Double> mzRange);
 
-    /**
-     * Returns all peaks in a given m/z & retention time ranges
-     * 
-     * @param startRT
-     *            Start of the retention time range
-     * @param endRT
-     *            End of the retention time range
-     * @param startMZ
-     *            Start of the m/z range
-     * @param endMZ
-     *            End of the m/z range
-     */
-    public Feature[] getPeaksInsideScanAndMZRange(RawDataFile file,
-	    Range<Double> rtRange, Range<Double> mzRange);
+  /**
+   * Returns all peaks overlapping with a retention time range
+   * 
+   * @param startRT Start of the retention time range
+   * @param endRT End of the retention time range
+   */
+  public Feature[] getPeaksInsideScanRange(RawDataFile file, Range<Double> rtRange);
 
-    /**
-     * Returns maximum raw data point intensity among all peaks in this peak
-     * list
-     * 
-     * @return Maximum intensity
-     */
-    public double getDataPointMaxIntensity();
+  /**
+   * Returns all peaks in a given m/z range
+   * 
+   * @param startMZ Start of the m/z range
+   * @param endMZ End of the m/z range
+   */
+  public Feature[] getPeaksInsideMZRange(RawDataFile file, Range<Double> mzRange);
 
-    /**
-     * Add a new row to the peak list
-     */
-    public void addRow(PeakListRow row);
+  /**
+   * Returns all peaks in a given m/z & retention time ranges
+   * 
+   * @param startRT Start of the retention time range
+   * @param endRT End of the retention time range
+   * @param startMZ Start of the m/z range
+   * @param endMZ End of the m/z range
+   */
+  public Feature[] getPeaksInsideScanAndMZRange(RawDataFile file, Range<Double> rtRange,
+      Range<Double> mzRange);
 
-    /**
-     * Removes a row from this peak list
-     * 
-     */
-    public void removeRow(int row);
+  /**
+   * Returns maximum raw data point intensity among all peaks in this peak list
+   * 
+   * @return Maximum intensity
+   */
+  public double getDataPointMaxIntensity();
 
-    /**
-     * Removes a row from this peak list
-     * 
-     */
-    public void removeRow(PeakListRow row);
+  /**
+   * Add a new row to the peak list
+   */
+  public void addRow(PeakListRow row);
 
-    /**
-     * Returns a row number of given peak
-     */
-    public int getPeakRowNum(Feature peak);
+  /**
+   * Removes a row from this peak list
+   * 
+   */
+  public void removeRow(int row);
 
-    /**
-     * Returns a row containing given peak
-     */
-    public PeakListRow getPeakRow(Feature peak);
+  /**
+   * Removes a row from this peak list
+   * 
+   */
+  public void removeRow(PeakListRow row);
 
-    public void addDescriptionOfAppliedTask(PeakListAppliedMethod appliedMethod);
+  /**
+   * Returns a row number of given peak
+   */
+  public int getPeakRowNum(Feature peak);
 
-    /**
-     * Returns all tasks (descriptions) applied to this peak list
-     */
-    public PeakListAppliedMethod[] getAppliedMethods();
+  /**
+   * Returns a row containing given peak
+   */
+  public PeakListRow getPeakRow(Feature peak);
 
-    /**
-     * Returns the whole m/z range of the peak list
-     */
-    public Range<Double> getRowsMZRange();
+  public void addDescriptionOfAppliedTask(PeakListAppliedMethod appliedMethod);
 
-    /**
-     * Returns the whole retention time range of the peak list
-     */
-    public Range<Double> getRowsRTRange();
+  /**
+   * Returns all tasks (descriptions) applied to this peak list
+   */
+  public PeakListAppliedMethod[] getAppliedMethods();
+
+  /**
+   * Returns the whole m/z range of the peak list
+   */
+  public Range<Double> getRowsMZRange();
+
+  /**
+   * Returns the whole retention time range of the peak list
+   */
+  public Range<Double> getRowsRTRange();
 
 }

--- a/src/main/java/net/sf/mzmine/datamodel/impl/SimplePeakList.java
+++ b/src/main/java/net/sf/mzmine/datamodel/impl/SimplePeakList.java
@@ -3,18 +3,17 @@
  * 
  * This file is part of MZmine 2.
  * 
- * MZmine 2 is free software; you can redistribute it and/or modify it under the
- * terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 2 of the License, or (at your option) any later
- * version.
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
  * 
- * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
- * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
  * 
- * You should have received a copy of the GNU General Public License along with
- * MZmine 2; if not, write to the Free Software Foundation, Inc., 51 Franklin
- * St, Fifth Floor, Boston, MA 02110-1301 USA
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
  */
 
 package net.sf.mzmine.datamodel.impl;
@@ -26,7 +25,8 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Vector;
-
+import java.util.stream.Stream;
+import com.google.common.collect.Range;
 import net.sf.mzmine.datamodel.Feature;
 import net.sf.mzmine.datamodel.PeakList;
 import net.sf.mzmine.datamodel.PeakListRow;
@@ -35,314 +35,309 @@ import net.sf.mzmine.desktop.impl.projecttree.PeakListTreeModel;
 import net.sf.mzmine.main.MZmineCore;
 import net.sf.mzmine.project.impl.MZmineProjectImpl;
 
-import com.google.common.collect.Range;
-
 /**
  * Simple implementation of the PeakList interface.
  */
 public class SimplePeakList implements PeakList {
 
-    private String name;
-    private RawDataFile[] dataFiles;
-    private ArrayList<PeakListRow> peakListRows;
-    private double maxDataPointIntensity = 0;
-    private Vector<PeakListAppliedMethod> descriptionOfAppliedTasks;
-    private String dateCreated;
-    private Range<Double> mzRange, rtRange;
+  private String name;
+  private RawDataFile[] dataFiles;
+  private ArrayList<PeakListRow> peakListRows;
+  private double maxDataPointIntensity = 0;
+  private Vector<PeakListAppliedMethod> descriptionOfAppliedTasks;
+  private String dateCreated;
+  private Range<Double> mzRange, rtRange;
 
-    public static DateFormat dateFormat = new SimpleDateFormat(
-	    "yyyy/MM/dd HH:mm:ss");
+  public static DateFormat dateFormat = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
 
-    public SimplePeakList(String name, RawDataFile dataFile) {
-	this(name, new RawDataFile[] { dataFile });
+  public SimplePeakList(String name, RawDataFile dataFile) {
+    this(name, new RawDataFile[] {dataFile});
+  }
+
+  public SimplePeakList(String name, RawDataFile[] dataFiles) {
+    if ((dataFiles == null) || (dataFiles.length == 0)) {
+      throw (new IllegalArgumentException("Cannot create a peak list with no data files"));
+    }
+    this.name = name;
+    this.dataFiles = new RawDataFile[dataFiles.length];
+
+    RawDataFile dataFile;
+    for (int i = 0; i < dataFiles.length; i++) {
+      dataFile = dataFiles[i];
+      this.dataFiles[i] = dataFile;
+    }
+    peakListRows = new ArrayList<PeakListRow>();
+    descriptionOfAppliedTasks = new Vector<PeakListAppliedMethod>();
+
+    dateCreated = dateFormat.format(new Date());
+
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String toString() {
+    return name;
+  }
+
+
+
+  /**
+   * Returns number of raw data files participating in the alignment
+   */
+  public int getNumberOfRawDataFiles() {
+    return dataFiles.length;
+  }
+
+  /**
+   * Returns all raw data files participating in the alignment
+   */
+  public RawDataFile[] getRawDataFiles() {
+    return dataFiles;
+  }
+
+  public RawDataFile getRawDataFile(int position) {
+    return dataFiles[position];
+  }
+
+  /**
+   * Returns number of rows in the alignment result
+   */
+  public int getNumberOfRows() {
+    return peakListRows.size();
+  }
+
+  /**
+   * Returns the peak of a given raw data file on a give row of the alignment result
+   * 
+   * @param row Row of the alignment result
+   * @param rawDataFile Raw data file where the peak is detected/estimated
+   */
+  public Feature getPeak(int row, RawDataFile rawDataFile) {
+    return peakListRows.get(row).getPeak(rawDataFile);
+  }
+
+  /**
+   * Returns all peaks for a raw data file
+   */
+  public Feature[] getPeaks(RawDataFile rawDataFile) {
+    Vector<Feature> peakSet = new Vector<Feature>();
+    for (int row = 0; row < getNumberOfRows(); row++) {
+      Feature p = peakListRows.get(row).getPeak(rawDataFile);
+      if (p != null)
+        peakSet.add(p);
+    }
+    return peakSet.toArray(new Feature[0]);
+  }
+
+  /**
+   * Returns all peaks on one row
+   */
+  public PeakListRow getRow(int row) {
+    return peakListRows.get(row);
+  }
+
+  public PeakListRow[] getRows() {
+    return peakListRows.toArray(new PeakListRow[0]);
+  }
+
+  public PeakListRow[] getRowsInsideMZRange(Range<Double> mzRange) {
+    Range<Double> all = Range.all();
+    return getRowsInsideScanAndMZRange(all, mzRange);
+  }
+
+  public PeakListRow[] getRowsInsideScanRange(Range<Double> rtRange) {
+    Range<Double> all = Range.all();
+    return getRowsInsideScanAndMZRange(rtRange, all);
+  }
+
+  public PeakListRow[] getRowsInsideScanAndMZRange(Range<Double> rtRange, Range<Double> mzRange) {
+    Vector<PeakListRow> rowsInside = new Vector<PeakListRow>();
+
+    for (PeakListRow row : peakListRows) {
+      if (rtRange.contains(row.getAverageRT()) && mzRange.contains(row.getAverageMZ()))
+        rowsInside.add(row);
     }
 
-    public SimplePeakList(String name, RawDataFile[] dataFiles) {
-	if ((dataFiles == null) || (dataFiles.length == 0)) {
-	    throw (new IllegalArgumentException(
-		    "Cannot create a peak list with no data files"));
-	}
-	this.name = name;
-	this.dataFiles = new RawDataFile[dataFiles.length];
+    return rowsInside.toArray(new PeakListRow[0]);
+  }
 
-	RawDataFile dataFile;
-	for (int i = 0; i < dataFiles.length; i++) {
-	    dataFile = dataFiles[i];
-	    this.dataFiles[i] = dataFile;
-	}
-	peakListRows = new ArrayList<PeakListRow>();
-	descriptionOfAppliedTasks = new Vector<PeakListAppliedMethod>();
-
-	dateCreated = dateFormat.format(new Date());
-
+  public void addRow(PeakListRow row) {
+    List<RawDataFile> myFiles = Arrays.asList(this.getRawDataFiles());
+    for (RawDataFile testFile : row.getRawDataFiles()) {
+      if (!myFiles.contains(testFile))
+        throw (new IllegalArgumentException("Data file " + testFile + " is not in this peak list"));
     }
 
-    @Override
-    public String getName() {
-	return name;
+    peakListRows.add(row);
+    if (row.getDataPointMaxIntensity() > maxDataPointIntensity) {
+      maxDataPointIntensity = row.getDataPointMaxIntensity();
     }
 
-    @Override
-    public String toString() {
-	return name;
+    if (mzRange == null) {
+      mzRange = Range.singleton(row.getAverageMZ());
+      rtRange = Range.singleton(row.getAverageRT());
+    } else {
+      mzRange = mzRange.span(Range.singleton(row.getAverageMZ()));
+      rtRange = rtRange.span(Range.singleton(row.getAverageRT()));
+    }
+  }
+
+  /**
+   * Returns all peaks overlapping with a retention time range
+   * 
+   * @param startRT Start of the retention time range
+   * @param endRT End of the retention time range
+   * @return
+   */
+  public Feature[] getPeaksInsideScanRange(RawDataFile file, Range<Double> rtRange) {
+    Range<Double> all = Range.all();
+    return getPeaksInsideScanAndMZRange(file, rtRange, all);
+  }
+
+  /**
+   * @see net.sf.mzmine.datamodel.PeakList#getPeaksInsideMZRange(double, double)
+   */
+  public Feature[] getPeaksInsideMZRange(RawDataFile file, Range<Double> mzRange) {
+    Range<Double> all = Range.all();
+    return getPeaksInsideScanAndMZRange(file, all, mzRange);
+  }
+
+  /**
+   * @see net.sf.mzmine.datamodel.PeakList#getPeaksInsideScanAndMZRange(double, double, double,
+   *      double)
+   */
+  public Feature[] getPeaksInsideScanAndMZRange(RawDataFile file, Range<Double> rtRange,
+      Range<Double> mzRange) {
+    Vector<Feature> peaksInside = new Vector<Feature>();
+
+    Feature[] peaks = getPeaks(file);
+    for (Feature p : peaks) {
+      if (rtRange.contains(p.getRT()) && mzRange.contains(p.getMZ()))
+        peaksInside.add(p);
     }
 
-    /**
-     * Returns number of raw data files participating in the alignment
-     */
-    public int getNumberOfRawDataFiles() {
-	return dataFiles.length;
+    return peaksInside.toArray(new Feature[0]);
+  }
+
+  /**
+   * @see net.sf.mzmine.datamodel.PeakList#removeRow(net.sf.mzmine.datamodel.PeakListRow)
+   */
+  public void removeRow(PeakListRow row) {
+    peakListRows.remove(row);
+
+    // We have to update the project tree model
+    MZmineProjectImpl project =
+        (MZmineProjectImpl) MZmineCore.getProjectManager().getCurrentProject();
+    PeakListTreeModel treeModel = project.getPeakListTreeModel();
+    treeModel.removeObject(row);
+
+    updateMaxIntensity();
+  }
+
+  /**
+   * @see net.sf.mzmine.datamodel.PeakList#removeRow(net.sf.mzmine.datamodel.PeakListRow)
+   */
+  public void removeRow(int rowNum) {
+    removeRow(peakListRows.get(rowNum));
+  }
+
+  private void updateMaxIntensity() {
+    maxDataPointIntensity = 0;
+    mzRange = null;
+    rtRange = null;
+    for (PeakListRow peakListRow : peakListRows) {
+      if (peakListRow.getDataPointMaxIntensity() > maxDataPointIntensity)
+        maxDataPointIntensity = peakListRow.getDataPointMaxIntensity();
+
+      if (mzRange == null) {
+        mzRange = Range.singleton(peakListRow.getAverageMZ());
+        rtRange = Range.singleton(peakListRow.getAverageRT());
+      } else {
+        mzRange = mzRange.span(Range.singleton(peakListRow.getAverageMZ()));
+        rtRange = rtRange.span(Range.singleton(peakListRow.getAverageRT()));
+      }
+    }
+  }
+
+  @Override
+  public Stream<PeakListRow> stream() {
+    return peakListRows.stream();
+  }
+
+  @Override
+  public Stream<PeakListRow> parallelStream() {
+    return peakListRows.parallelStream();
+  }
+
+  /**
+   * @see net.sf.mzmine.datamodel.PeakList#getPeakRowNum(net.sf.mzmine.datamodel.Feature)
+   */
+  public int getPeakRowNum(Feature peak) {
+
+    PeakListRow rows[] = getRows();
+
+    for (int i = 0; i < rows.length; i++) {
+      if (rows[i].hasPeak(peak))
+        return i;
     }
 
-    /**
-     * Returns all raw data files participating in the alignment
-     */
-    public RawDataFile[] getRawDataFiles() {
-	return dataFiles;
+    return -1;
+  }
+
+  /**
+   * @see net.sf.mzmine.datamodel.PeakList#getDataPointMaxIntensity()
+   */
+  public double getDataPointMaxIntensity() {
+    return maxDataPointIntensity;
+  }
+
+  public boolean hasRawDataFile(RawDataFile hasFile) {
+    return Arrays.asList(dataFiles).contains(hasFile);
+  }
+
+  public PeakListRow getPeakRow(Feature peak) {
+    PeakListRow rows[] = getRows();
+
+    for (int i = 0; i < rows.length; i++) {
+      if (rows[i].hasPeak(peak))
+        return rows[i];
     }
 
-    public RawDataFile getRawDataFile(int position) {
-	return dataFiles[position];
-    }
+    return null;
+  }
 
-    /**
-     * Returns number of rows in the alignment result
-     */
-    public int getNumberOfRows() {
-	return peakListRows.size();
-    }
+  public void setName(String name) {
+    this.name = name;
+  }
 
-    /**
-     * Returns the peak of a given raw data file on a give row of the alignment
-     * result
-     * 
-     * @param row
-     *            Row of the alignment result
-     * @param rawDataFile
-     *            Raw data file where the peak is detected/estimated
-     */
-    public Feature getPeak(int row, RawDataFile rawDataFile) {
-	return peakListRows.get(row).getPeak(rawDataFile);
-    }
+  public void addDescriptionOfAppliedTask(PeakListAppliedMethod appliedMethod) {
+    descriptionOfAppliedTasks.add(appliedMethod);
+  }
 
-    /**
-     * Returns all peaks for a raw data file
-     */
-    public Feature[] getPeaks(RawDataFile rawDataFile) {
-	Vector<Feature> peakSet = new Vector<Feature>();
-	for (int row = 0; row < getNumberOfRows(); row++) {
-	    Feature p = peakListRows.get(row).getPeak(rawDataFile);
-	    if (p != null)
-		peakSet.add(p);
-	}
-	return peakSet.toArray(new Feature[0]);
-    }
+  public PeakListAppliedMethod[] getAppliedMethods() {
+    return descriptionOfAppliedTasks.toArray(new PeakListAppliedMethod[0]);
+  }
 
-    /**
-     * Returns all peaks on one row
-     */
-    public PeakListRow getRow(int row) {
-	return peakListRows.get(row);
-    }
+  public String getDateCreated() {
+    return dateCreated;
+  }
 
-    public PeakListRow[] getRows() {
-	return peakListRows.toArray(new PeakListRow[0]);
-    }
+  public void setDateCreated(String date) {
+    this.dateCreated = date;
+  }
 
-    public PeakListRow[] getRowsInsideMZRange(Range<Double> mzRange) {
-	Range<Double> all = Range.all();
-	return getRowsInsideScanAndMZRange(all, mzRange);
-    }
+  public Range<Double> getRowsMZRange() {
+    updateMaxIntensity(); // Update range before returning value
+    return mzRange;
+  }
 
-    public PeakListRow[] getRowsInsideScanRange(Range<Double> rtRange) {
-	Range<Double> all = Range.all();
-	return getRowsInsideScanAndMZRange(rtRange, all);
-    }
-
-    public PeakListRow[] getRowsInsideScanAndMZRange(Range<Double> rtRange,
-	    Range<Double> mzRange) {
-	Vector<PeakListRow> rowsInside = new Vector<PeakListRow>();
-
-	for (PeakListRow row : peakListRows) {
-	    if (rtRange.contains(row.getAverageRT())
-		    && mzRange.contains(row.getAverageMZ()))
-		rowsInside.add(row);
-	}
-
-	return rowsInside.toArray(new PeakListRow[0]);
-    }
-
-    public void addRow(PeakListRow row) {
-	List<RawDataFile> myFiles = Arrays.asList(this.getRawDataFiles());
-	for (RawDataFile testFile : row.getRawDataFiles()) {
-	    if (!myFiles.contains(testFile))
-		throw (new IllegalArgumentException("Data file " + testFile
-			+ " is not in this peak list"));
-	}
-
-	peakListRows.add(row);
-	if (row.getDataPointMaxIntensity() > maxDataPointIntensity) {
-	    maxDataPointIntensity = row.getDataPointMaxIntensity();
-	}
-
-	if (mzRange == null) {
-	    mzRange = Range.singleton(row.getAverageMZ());
-	    rtRange = Range.singleton(row.getAverageRT());
-	} else {
-	    mzRange = mzRange.span(Range.singleton(row.getAverageMZ()));
-	    rtRange = rtRange.span(Range.singleton(row.getAverageRT()));
-	}
-    }
-
-    /**
-     * Returns all peaks overlapping with a retention time range
-     * 
-     * @param startRT
-     *            Start of the retention time range
-     * @param endRT
-     *            End of the retention time range
-     * @return
-     */
-    public Feature[] getPeaksInsideScanRange(RawDataFile file,
-	    Range<Double> rtRange) {
-	Range<Double> all = Range.all();
-	return getPeaksInsideScanAndMZRange(file, rtRange, all);
-    }
-
-    /**
-     * @see net.sf.mzmine.datamodel.PeakList#getPeaksInsideMZRange(double,
-     *      double)
-     */
-    public Feature[] getPeaksInsideMZRange(RawDataFile file,
-	    Range<Double> mzRange) {
-	Range<Double> all = Range.all();
-	return getPeaksInsideScanAndMZRange(file, all, mzRange);
-    }
-
-    /**
-     * @see net.sf.mzmine.datamodel.PeakList#getPeaksInsideScanAndMZRange(double,
-     *      double, double, double)
-     */
-    public Feature[] getPeaksInsideScanAndMZRange(RawDataFile file,
-	    Range<Double> rtRange, Range<Double> mzRange) {
-	Vector<Feature> peaksInside = new Vector<Feature>();
-
-	Feature[] peaks = getPeaks(file);
-	for (Feature p : peaks) {
-	    if (rtRange.contains(p.getRT()) && mzRange.contains(p.getMZ()))
-		peaksInside.add(p);
-	}
-
-	return peaksInside.toArray(new Feature[0]);
-    }
-
-    /**
-     * @see net.sf.mzmine.datamodel.PeakList#removeRow(net.sf.mzmine.datamodel.PeakListRow)
-     */
-    public void removeRow(PeakListRow row) {
-	peakListRows.remove(row);
-
-	// We have to update the project tree model
-	MZmineProjectImpl project = (MZmineProjectImpl) MZmineCore
-		.getProjectManager().getCurrentProject();
-	PeakListTreeModel treeModel = project.getPeakListTreeModel();
-	treeModel.removeObject(row);
-
-	updateMaxIntensity();
-    }
-
-    /**
-     * @see net.sf.mzmine.datamodel.PeakList#removeRow(net.sf.mzmine.datamodel.PeakListRow)
-     */
-    public void removeRow(int rowNum) {
-	removeRow(peakListRows.get(rowNum));
-    }
-
-    private void updateMaxIntensity() {
-	maxDataPointIntensity = 0;
-	mzRange = null;
-	rtRange = null;
-	for (PeakListRow peakListRow : peakListRows) {
-	    if (peakListRow.getDataPointMaxIntensity() > maxDataPointIntensity)
-		maxDataPointIntensity = peakListRow.getDataPointMaxIntensity();
-
-	    if (mzRange == null) {
-		mzRange = Range.singleton(peakListRow.getAverageMZ());
-		rtRange = Range.singleton(peakListRow.getAverageRT());
-	    } else {
-		mzRange = mzRange.span(Range.singleton(peakListRow
-			.getAverageMZ()));
-		rtRange = rtRange.span(Range.singleton(peakListRow
-			.getAverageRT()));
-	    }
-	}
-    }
-
-    /**
-     * @see net.sf.mzmine.datamodel.PeakList#getPeakRowNum(net.sf.mzmine.datamodel.Feature)
-     */
-    public int getPeakRowNum(Feature peak) {
-
-	PeakListRow rows[] = getRows();
-
-	for (int i = 0; i < rows.length; i++) {
-	    if (rows[i].hasPeak(peak))
-		return i;
-	}
-
-	return -1;
-    }
-
-    /**
-     * @see net.sf.mzmine.datamodel.PeakList#getDataPointMaxIntensity()
-     */
-    public double getDataPointMaxIntensity() {
-	return maxDataPointIntensity;
-    }
-
-    public boolean hasRawDataFile(RawDataFile hasFile) {
-	return Arrays.asList(dataFiles).contains(hasFile);
-    }
-
-    public PeakListRow getPeakRow(Feature peak) {
-	PeakListRow rows[] = getRows();
-
-	for (int i = 0; i < rows.length; i++) {
-	    if (rows[i].hasPeak(peak))
-		return rows[i];
-	}
-
-	return null;
-    }
-
-    public void setName(String name) {
-	this.name = name;
-    }
-
-    public void addDescriptionOfAppliedTask(PeakListAppliedMethod appliedMethod) {
-	descriptionOfAppliedTasks.add(appliedMethod);
-    }
-
-    public PeakListAppliedMethod[] getAppliedMethods() {
-	return descriptionOfAppliedTasks.toArray(new PeakListAppliedMethod[0]);
-    }
-
-    public String getDateCreated() {
-	return dateCreated;
-    }
-
-    public void setDateCreated(String date) {
-	this.dateCreated = date;
-    }
-
-    public Range<Double> getRowsMZRange() {
-	updateMaxIntensity(); // Update range before returning value
-	return mzRange;
-    }
-
-    public Range<Double> getRowsRTRange() {
-	updateMaxIntensity(); // Update range before returning value
-	return rtRange;
-    }
+  public Range<Double> getRowsRTRange() {
+    updateMaxIntensity(); // Update range before returning value
+    return rtRange;
+  }
 
 }

--- a/src/main/java/net/sf/mzmine/datamodel/impl/SimplePeakListRow.java
+++ b/src/main/java/net/sf/mzmine/datamodel/impl/SimplePeakListRow.java
@@ -100,18 +100,16 @@ public class SimplePeakListRow implements PeakListRow {
     return peaks.get(rawData);
   }
 
-  public void addPeak(RawDataFile rawData, Feature peak) {
+  public synchronized void addPeak(RawDataFile rawData, Feature peak) {
     if (peak == null)
       throw new IllegalArgumentException("Cannot add null peak to a peak list row");
 
     // ConcurrentHashMap is already synchronized
     peaks.put(rawData, peak);
 
-    synchronized (this) {
-      if (peak.getRawDataPointsIntensityRange().upperEndpoint() > maxDataPointIntensity)
-        maxDataPointIntensity = peak.getRawDataPointsIntensityRange().upperEndpoint();
-      calculateAverageValues();
-    }
+    if (peak.getRawDataPointsIntensityRange().upperEndpoint() > maxDataPointIntensity)
+      maxDataPointIntensity = peak.getRawDataPointsIntensityRange().upperEndpoint();
+    calculateAverageValues();
   }
 
   public double getAverageMZ() {

--- a/src/main/java/net/sf/mzmine/datamodel/impl/SimplePeakListRow.java
+++ b/src/main/java/net/sf/mzmine/datamodel/impl/SimplePeakListRow.java
@@ -3,18 +3,17 @@
  * 
  * This file is part of MZmine 2.
  * 
- * MZmine 2 is free software; you can redistribute it and/or modify it under the
- * terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 2 of the License, or (at your option) any later
- * version.
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
  * 
- * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
- * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
  * 
- * You should have received a copy of the GNU General Public License along with
- * MZmine 2; if not, write to the Free Software Foundation, Inc., 51 Franklin
- * St, Fifth Floor, Boston, MA 02110-1301 USA
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
  */
 
 package net.sf.mzmine.datamodel.impl;
@@ -23,9 +22,9 @@ import java.text.Format;
 import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.HashSet;
-import java.util.Hashtable;
+import java.util.List;
 import java.util.Vector;
-
+import java.util.concurrent.ConcurrentHashMap;
 import net.sf.mzmine.datamodel.Feature;
 import net.sf.mzmine.datamodel.IsotopePattern;
 import net.sf.mzmine.datamodel.PeakIdentity;
@@ -43,335 +42,332 @@ import net.sf.mzmine.util.SortingProperty;
  */
 public class SimplePeakListRow implements PeakListRow {
 
-    private Hashtable<RawDataFile, Feature> peaks;
-    private Feature preferredPeak;
-    private Vector<PeakIdentity> identities;
-    private PeakIdentity preferredIdentity;
-    private String comment;
-    private PeakInformation information;
-    private int myID;
-    private double maxDataPointIntensity = 0;
+  // faster than Hashtable
+  private ConcurrentHashMap<RawDataFile, Feature> peaks;
+  private Feature preferredPeak;
+  private List<PeakIdentity> identities;
+  private PeakIdentity preferredIdentity;
+  private String comment;
+  private PeakInformation information;
+  private int myID;
+  private double maxDataPointIntensity = 0;
 
-    /**
-     * These variables are used for caching the average values, so we don't need
-     * to calculate them again and again
-     */
-    private double averageRT, averageMZ, averageHeight, averageArea;
-    private int rowCharge;
+  /**
+   * These variables are used for caching the average values, so we don't need to calculate them
+   * again and again
+   */
+  private double averageRT, averageMZ, averageHeight, averageArea;
+  private int rowCharge;
 
-    public SimplePeakListRow(int myID) {
-	this.myID = myID;
-	peaks = new Hashtable<RawDataFile, Feature>();
-	identities = new Vector<PeakIdentity>();
-        information = null;
-        preferredPeak = null;
+  public SimplePeakListRow(int myID) {
+    this.myID = myID;
+    peaks = new ConcurrentHashMap<RawDataFile, Feature>();
+    identities = new Vector<PeakIdentity>();
+    information = null;
+    preferredPeak = null;
+  }
+
+  /**
+   * @see net.sf.mzmine.datamodel.PeakListRow#getID()
+   */
+  public int getID() {
+    return myID;
+  }
+
+  /**
+   * Return peaks assigned to this row
+   */
+  public Feature[] getPeaks() {
+    return peaks.values().toArray(new Feature[0]);
+  }
+
+  public void removePeak(RawDataFile file) {
+    this.peaks.remove(file);
+    calculateAverageValues();
+  }
+
+  /**
+   * Returns opened raw data files with a peak on this row
+   */
+  public RawDataFile[] getRawDataFiles() {
+    return peaks.keySet().toArray(new RawDataFile[0]);
+  }
+
+  /**
+   * Returns peak for given raw data file
+   */
+  public Feature getPeak(RawDataFile rawData) {
+    return peaks.get(rawData);
+  }
+
+  public void addPeak(RawDataFile rawData, Feature peak) {
+    if (peak == null)
+      throw new IllegalArgumentException("Cannot add null peak to a peak list row");
+
+    // ConcurrentHashMap is already synchronized
+    peaks.put(rawData, peak);
+
+    synchronized (this) {
+      if (peak.getRawDataPointsIntensityRange().upperEndpoint() > maxDataPointIntensity)
+        maxDataPointIntensity = peak.getRawDataPointsIntensityRange().upperEndpoint();
+      calculateAverageValues();
+    }
+  }
+
+  public double getAverageMZ() {
+    return averageMZ;
+  }
+
+  public double getAverageRT() {
+    return averageRT;
+  }
+
+  public double getAverageHeight() {
+    return averageHeight;
+  }
+
+  public double getAverageArea() {
+    return averageArea;
+  }
+
+  public int getRowCharge() {
+    return rowCharge;
+  }
+
+  private synchronized void calculateAverageValues() {
+    double rtSum = 0, mzSum = 0, heightSum = 0, areaSum = 0;
+    int charge = 0;
+    HashSet<Integer> chargeArr = new HashSet<Integer>();
+    Enumeration<Feature> peakEnum = peaks.elements();
+    while (peakEnum.hasMoreElements()) {
+      Feature p = peakEnum.nextElement();
+      rtSum += p.getRT();
+      mzSum += p.getMZ();
+      heightSum += p.getHeight();
+      areaSum += p.getArea();
+      if (p.getCharge() > 0) {
+        chargeArr.add(p.getCharge());
+        charge = p.getCharge();
+      }
+    }
+    averageRT = rtSum / peaks.size();
+    averageMZ = mzSum / peaks.size();
+    averageHeight = heightSum / peaks.size();
+    averageArea = areaSum / peaks.size();
+    if (chargeArr.size() < 2) {
+      rowCharge = charge;
+    } else {
+      rowCharge = 0;
+    }
+  }
+
+  /**
+   * Returns number of peaks assigned to this row
+   */
+  public int getNumberOfPeaks() {
+    return peaks.size();
+  }
+
+  public String toString() {
+    StringBuffer buf = new StringBuffer();
+    Format mzFormat = MZmineCore.getConfiguration().getMZFormat();
+    Format timeFormat = MZmineCore.getConfiguration().getRTFormat();
+    buf.append("#" + myID + " ");
+    buf.append(mzFormat.format(getAverageMZ()));
+    buf.append(" m/z @");
+    buf.append(timeFormat.format(getAverageRT()));
+    if (preferredIdentity != null)
+      buf.append(" " + preferredIdentity.getName());
+    if ((comment != null) && (comment.length() > 0))
+      buf.append(" (" + comment + ")");
+    return buf.toString();
+  }
+
+  /**
+   * @see net.sf.mzmine.datamodel.PeakListRow#getComment()
+   */
+  public String getComment() {
+    return comment;
+  }
+
+  /**
+   * @see net.sf.mzmine.datamodel.PeakListRow#setComment(java.lang.String)
+   */
+  public void setComment(String comment) {
+    this.comment = comment;
+  }
+
+  /**
+   * @see net.sf.mzmine.datamodel.PeakListRow#setAverageMZ(java.lang.String)
+   */
+  public void setAverageMZ(double mz) {
+    this.averageMZ = mz;
+  }
+
+  /**
+   * @see net.sf.mzmine.datamodel.PeakListRow#setAverageRT(java.lang.String)
+   */
+  public void setAverageRT(double rt) {
+    this.averageRT = rt;
+  }
+
+  /**
+   * @see net.sf.mzmine.datamodel.PeakListRow#addCompoundIdentity(net.sf.mzmine.datamodel.PeakIdentity)
+   */
+  public synchronized void addPeakIdentity(PeakIdentity identity, boolean preferred) {
+
+    // Verify if exists already an identity with the same name
+    for (PeakIdentity testId : identities) {
+      if (testId.getName().equals(identity.getName())) {
+        return;
+      }
     }
 
-    /**
-     * @see net.sf.mzmine.datamodel.PeakListRow#getID()
-     */
-    public int getID() {
-	return myID;
+    identities.add(identity);
+    if ((preferredIdentity == null) || (preferred)) {
+      setPreferredPeakIdentity(identity);
+    }
+  }
+
+  /**
+   * @see net.sf.mzmine.datamodel.PeakListRow#addCompoundIdentity(net.sf.mzmine.datamodel.PeakIdentity)
+   */
+  public synchronized void removePeakIdentity(PeakIdentity identity) {
+    identities.remove(identity);
+    if (preferredIdentity == identity) {
+      if (identities.size() > 0) {
+        PeakIdentity[] identitiesArray = identities.toArray(new PeakIdentity[0]);
+        setPreferredPeakIdentity(identitiesArray[0]);
+      } else
+        preferredIdentity = null;
+    }
+  }
+
+  /**
+   * @see net.sf.mzmine.datamodel.PeakListRow#getPeakIdentities()
+   */
+  public PeakIdentity[] getPeakIdentities() {
+    return identities.toArray(new PeakIdentity[0]);
+  }
+
+  /**
+   * @see net.sf.mzmine.datamodel.PeakListRow#getPreferredPeakIdentity()
+   */
+  public PeakIdentity getPreferredPeakIdentity() {
+    return preferredIdentity;
+  }
+
+  /**
+   * @see net.sf.mzmine.datamodel.PeakListRow#setPreferredPeakIdentity(net.sf.mzmine.datamodel.PeakIdentity)
+   */
+  public void setPreferredPeakIdentity(PeakIdentity identity) {
+
+    if (identity == null)
+      return;
+
+    preferredIdentity = identity;
+
+    if (!identities.contains(identity)) {
+      identities.add(identity);
     }
 
-    /**
-     * Return peaks assigned to this row
-     */
-    public Feature[] getPeaks() {
-	return peaks.values().toArray(new Feature[0]);
+  }
+
+  @Override
+  public void setPeakInformation(PeakInformation information) {
+    this.information = information;
+  }
+
+  @Override
+  public PeakInformation getPeakInformation() {
+    return information;
+  }
+
+  /**
+   * @see net.sf.mzmine.datamodel.PeakListRow#getDataPointMaxIntensity()
+   */
+  public double getDataPointMaxIntensity() {
+    return maxDataPointIntensity;
+  }
+
+  public boolean hasPeak(Feature peak) {
+    return peaks.containsValue(peak);
+  }
+
+  public boolean hasPeak(RawDataFile file) {
+    return peaks.containsKey(file);
+  }
+
+  /**
+   * Returns the highest isotope pattern of a peak in this row
+   */
+  public IsotopePattern getBestIsotopePattern() {
+    Feature peaks[] = getPeaks();
+    Arrays.sort(peaks, new PeakSorter(SortingProperty.Height, SortingDirection.Descending));
+
+    for (Feature peak : peaks) {
+      IsotopePattern ip = peak.getIsotopePattern();
+      if (ip != null)
+        return ip;
     }
 
-    public void removePeak(RawDataFile file) {
-	this.peaks.remove(file);
-	calculateAverageValues();
+    return null;
+  }
+
+  /**
+   * Returns the highest peak in this row
+   */
+  public Feature getBestPeak() {
+
+    Feature peaks[] = getPeaks();
+    Arrays.sort(peaks, new PeakSorter(SortingProperty.Height, SortingDirection.Descending));
+    if (peaks.length == 0)
+      return null;
+    return peaks[0];
+  }
+
+  @Override
+  public Scan getBestFragmentation() {
+
+    Double bestTIC = 0.0;
+    Scan bestScan = null;
+    for (Feature peak : this.getPeaks()) {
+      Double theTIC = 0.0;
+      RawDataFile rawData = peak.getDataFile();
+      int bestScanNumber = peak.getMostIntenseFragmentScanNumber();
+      Scan theScan = rawData.getScan(bestScanNumber);
+      if (theScan != null) {
+        theTIC = theScan.getTIC();
+      }
+
+      if (theTIC > bestTIC) {
+        bestTIC = theTIC;
+        bestScan = theScan;
+      }
     }
+    return bestScan;
+  }
 
-    /**
-     * Returns opened raw data files with a peak on this row
-     */
-    public RawDataFile[] getRawDataFiles() {
-	return peaks.keySet().toArray(new RawDataFile[0]);
-    }
+  // DorresteinLab edit
+  /**
+   * set the ID number
+   */
 
-    /**
-     * Returns peak for given raw data file
-     */
-    public Feature getPeak(RawDataFile rawData) {
-	return peaks.get(rawData);
-    }
+  public void setID(int id) {
+    myID = id;
+    return;
+  }
+  // End DorresteinLab edit
 
-    public synchronized void addPeak(RawDataFile rawData, Feature peak) {
-
-
-	if (peak == null)
-	    throw new IllegalArgumentException(
-		    "Cannot add null peak to a peak list row");
-
-	peaks.put(rawData, peak);
-
-	if (peak.getRawDataPointsIntensityRange().upperEndpoint() > maxDataPointIntensity)
-	    maxDataPointIntensity = peak.getRawDataPointsIntensityRange()
-		    .upperEndpoint();
-	calculateAverageValues();
-    }
-
-    public double getAverageMZ() {
-	return averageMZ;
-    }
-
-    public double getAverageRT() {
-	return averageRT;
-    }
-
-    public double getAverageHeight() {
-	return averageHeight;
-    }
-
-    public double getAverageArea() {
-	return averageArea;
-    }
-
-    public int getRowCharge() {
-	return rowCharge;
-    }
-
-    private synchronized void calculateAverageValues() {
-	double rtSum = 0, mzSum = 0, heightSum = 0, areaSum = 0;
-	int charge = 0;
-	HashSet<Integer> chargeArr = new HashSet<Integer>();
-	Enumeration<Feature> peakEnum = peaks.elements();
-	while (peakEnum.hasMoreElements()) {
-	    Feature p = peakEnum.nextElement();
-	    rtSum += p.getRT();
-	    mzSum += p.getMZ();
-	    heightSum += p.getHeight();
-	    areaSum += p.getArea();
-	    if (p.getCharge() > 0) {
-		chargeArr.add(p.getCharge());
-		charge = p.getCharge();
-	    }
-	}
-	averageRT = rtSum / peaks.size();
-	averageMZ = mzSum / peaks.size();
-	averageHeight = heightSum / peaks.size();
-	averageArea = areaSum / peaks.size();
-	if (chargeArr.size() < 2) { rowCharge = charge; } else { rowCharge = 0; }
-    }
-
-    /**
-     * Returns number of peaks assigned to this row
-     */
-    public int getNumberOfPeaks() {
-	return peaks.size();
-    }
-
-    public String toString() {
-	StringBuffer buf = new StringBuffer();
-	Format mzFormat = MZmineCore.getConfiguration().getMZFormat();
-	Format timeFormat = MZmineCore.getConfiguration().getRTFormat();
-	buf.append("#" + myID + " ");
-	buf.append(mzFormat.format(getAverageMZ()));
-	buf.append(" m/z @");
-	buf.append(timeFormat.format(getAverageRT()));
-	if (preferredIdentity != null)
-	    buf.append(" " + preferredIdentity.getName());
-	if ((comment != null) && (comment.length() > 0))
-	    buf.append(" (" + comment + ")");
-	return buf.toString();
-    }
-
-    /**
-     * @see net.sf.mzmine.datamodel.PeakListRow#getComment()
-     */
-    public String getComment() {
-	return comment;
-    }
-
-    /**
-     * @see net.sf.mzmine.datamodel.PeakListRow#setComment(java.lang.String)
-     */
-    public void setComment(String comment) {
-	this.comment = comment;
-    }
-    
-    /**
-     * @see net.sf.mzmine.datamodel.PeakListRow#setAverageMZ(java.lang.String)
-     */
-    public void setAverageMZ(double mz) {
-	this.averageMZ = mz;
-    }
-
-    /**
-     * @see net.sf.mzmine.datamodel.PeakListRow#setAverageRT(java.lang.String)
-     */
-    public void setAverageRT(double rt) {
-	this.averageRT = rt;
-    }
-
-    /**
-     * @see net.sf.mzmine.datamodel.PeakListRow#addCompoundIdentity(net.sf.mzmine.datamodel.PeakIdentity)
-     */
-    public synchronized void addPeakIdentity(PeakIdentity identity,
-	    boolean preferred) {
-
-	// Verify if exists already an identity with the same name
-	for (PeakIdentity testId : identities) {
-	    if (testId.getName().equals(identity.getName())) {
-		return;
-	    }
-	}
-
-	identities.add(identity);
-	if ((preferredIdentity == null) || (preferred)) {
-	    setPreferredPeakIdentity(identity);
-	}
-    }
-
-    /**
-     * @see net.sf.mzmine.datamodel.PeakListRow#addCompoundIdentity(net.sf.mzmine.datamodel.PeakIdentity)
-     */
-    public synchronized void removePeakIdentity(PeakIdentity identity) {
-	identities.remove(identity);
-	if (preferredIdentity == identity) {
-	    if (identities.size() > 0) {
-		PeakIdentity[] identitiesArray = identities
-			.toArray(new PeakIdentity[0]);
-		setPreferredPeakIdentity(identitiesArray[0]);
-	    } else
-		preferredIdentity = null;
-	}
-    }
-
-    /**
-     * @see net.sf.mzmine.datamodel.PeakListRow#getPeakIdentities()
-     */
-    public PeakIdentity[] getPeakIdentities() {
-	return identities.toArray(new PeakIdentity[0]);
-    }
-
-    /**
-     * @see net.sf.mzmine.datamodel.PeakListRow#getPreferredPeakIdentity()
-     */
-    public PeakIdentity getPreferredPeakIdentity() {
-	return preferredIdentity;
-    }
-
-    /**
-     * @see net.sf.mzmine.datamodel.PeakListRow#setPreferredPeakIdentity(net.sf.mzmine.datamodel.PeakIdentity)
-     */
-    public void setPreferredPeakIdentity(PeakIdentity identity) {
-
-	if (identity == null)
-	    return;
-
-	preferredIdentity = identity;
-
-	if (!identities.contains(identity)) {
-	    identities.add(identity);
-	}
-
-    }
-
-    @Override
-    public void setPeakInformation(PeakInformation information) {
-        this.information = information;
-    }
-    
-    @Override
-    public PeakInformation getPeakInformation() {
-        return information;
-    }
-    
-    /**
-     * @see net.sf.mzmine.datamodel.PeakListRow#getDataPointMaxIntensity()
-     */
-    public double getDataPointMaxIntensity() {
-	return maxDataPointIntensity;
-    }
-
-    public boolean hasPeak(Feature peak) {
-	return peaks.containsValue(peak);
-    }
-
-    public boolean hasPeak(RawDataFile file) {
-	return peaks.containsKey(file);
-    }
-
-    /**
-     * Returns the highest isotope pattern of a peak in this row
-     */
-    public IsotopePattern getBestIsotopePattern() {
-	Feature peaks[] = getPeaks();
-	Arrays.sort(peaks, new PeakSorter(SortingProperty.Height,
-		SortingDirection.Descending));
-
-	for (Feature peak : peaks) {
-	    IsotopePattern ip = peak.getIsotopePattern();
-	    if (ip != null)
-		return ip;
-	}
-
-	return null;
-    }
-
-    /**
-     * Returns the highest peak in this row
-     */
-    public Feature getBestPeak() {
-
-	Feature peaks[] = getPeaks();
-	Arrays.sort(peaks, new PeakSorter(SortingProperty.Height,
-		SortingDirection.Descending));
-	if (peaks.length == 0)
-	    return null;
-	return peaks[0];
-    }
-    
-    @Override
-    public Scan getBestFragmentation() {
-
-        Double bestTIC = 0.0;
-        Scan bestScan = null;
-        for (Feature peak : this.getPeaks())
-        {
-            Double theTIC = 0.0;
-            RawDataFile rawData = peak.getDataFile();
-            int bestScanNumber = peak.getMostIntenseFragmentScanNumber();
-            Scan theScan = rawData.getScan(bestScanNumber);
-            if (theScan != null)
-            {
-                theTIC = theScan.getTIC();
-            }
-            
-            if (theTIC > bestTIC)
-            {
-               bestTIC = theTIC;
-               bestScan = theScan;
-            }
-        }
-        return bestScan;
-    }  
-    
-    //DorresteinLab edit
-    /**
-     * set the ID number
-     */
-
-    public void setID (int id){
-    	myID =id;
-    	return;
-    }
-    //End DorresteinLab edit
-    
-    // Gauthier edit
-    /**
-     * Update average values
-     */
-    public void update() {
-        this.calculateAverageValues();
-    }
-    // End Gauthier edit
+  // Gauthier edit
+  /**
+   * Update average values
+   */
+  public void update() {
+    this.calculateAverageValues();
+  }
+  // End Gauthier edit
 
 
 }
-    //End DorresteinLab edit
+// End DorresteinLab edit

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/gapfilling/peakfinder/Gap.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/gapfilling/peakfinder/Gap.java
@@ -20,7 +20,6 @@ package net.sf.mzmine.modules.peaklistmethods.gapfilling.peakfinder;
 
 import java.util.List;
 import java.util.Vector;
-import java.util.concurrent.locks.Lock;
 import com.google.common.collect.Range;
 import net.sf.mzmine.datamodel.DataPoint;
 import net.sf.mzmine.datamodel.Feature.FeatureStatus;
@@ -112,16 +111,12 @@ public class Gap {
 
   }
 
-  public void noMoreOffers() {
-    noMoreOffers(null);
-  }
-
   /**
    * Finalizes the gap, adds a peak
    * 
    * @param lock A lock for multi threading purpose. null if single threaded
    */
-  public void noMoreOffers(Lock lock) {
+  public void noMoreOffers() {
 
     // Check peak that was last constructed
     if (currentPeakDataPoints != null) {
@@ -193,20 +188,8 @@ public class Gap {
           finalMZRange, finalIntensityRange);
 
       // Fill the gap
-      if (lock == null) {
-        // single thread
-        peakListRow.addPeak(rawDataFile, newPeak);
-      } else {
-        // multi thread
-        lock.lock();
-        try {
-          peakListRow.addPeak(rawDataFile, newPeak);
-        } finally {
-          lock.unlock();
-        }
-      }
+      peakListRow.addPeak(rawDataFile, newPeak);
     }
-
   }
 
   /**

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/gapfilling/peakfinder/PeakFinderParameters.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/gapfilling/peakfinder/PeakFinderParameters.java
@@ -3,18 +3,17 @@
  * 
  * This file is part of MZmine 2.
  * 
- * MZmine 2 is free software; you can redistribute it and/or modify it under the
- * terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 2 of the License, or (at your option) any later
- * version.
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
  * 
- * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
- * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
  * 
- * You should have received a copy of the GNU General Public License along with
- * MZmine 2; if not, write to the Free Software Foundation, Inc., 51 Franklin St,
- * Fifth Floor, Boston, MA 02110-1301 USA
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
  */
 
 package net.sf.mzmine.modules.peaklistmethods.gapfilling.peakfinder;
@@ -30,31 +29,33 @@ import net.sf.mzmine.parameters.parametertypes.tolerances.RTToleranceParameter;
 
 public class PeakFinderParameters extends SimpleParameterSet {
 
-    public static final PeakListsParameter peakLists = new PeakListsParameter();
+  public static final PeakListsParameter peakLists = new PeakListsParameter();
 
-    public static final StringParameter suffix = new StringParameter(
-	    "Name suffix", "Suffix to be added to peak list name", "gap-filled");
+  public static final StringParameter suffix =
+      new StringParameter("Name suffix", "Suffix to be added to peak list name", "gap-filled");
 
-    public static final PercentParameter intTolerance = new PercentParameter(
-	    "Intensity tolerance",
-	    "Maximum allowed deviation from expected /\\ shape of a peak in chromatographic direction");
+  public static final PercentParameter intTolerance = new PercentParameter("Intensity tolerance",
+      "Maximum allowed deviation from expected /\\ shape of a peak in chromatographic direction");
 
-    public static final MZToleranceParameter MZTolerance = new MZToleranceParameter();
+  public static final MZToleranceParameter MZTolerance = new MZToleranceParameter();
 
-    public static final RTToleranceParameter RTTolerance = new RTToleranceParameter();
+  public static final RTToleranceParameter RTTolerance = new RTToleranceParameter();
 
-    public static final BooleanParameter RTCorrection = new BooleanParameter(
-	    "RT correction",
-	    "If checked, correction of the retention time will be applied to avoid the"
-	    	+"\nproblems caused by the deviation of the retention time between the samples.");
+  public static final BooleanParameter RTCorrection = new BooleanParameter("RT correction",
+      "If checked, correction of the retention time will be applied to avoid the"
+          + "\nproblems caused by the deviation of the retention time between the samples.");
 
-    public static final BooleanParameter autoRemove = new BooleanParameter(
-	    "Remove original peak list",
-	    "If checked, the original peak list will be removed");
 
-    public PeakFinderParameters() {
-	super(new Parameter[] { peakLists, suffix, intTolerance, MZTolerance,
-		RTTolerance, RTCorrection, autoRemove });
-    }
+  public static final BooleanParameter useParallel =
+      new BooleanParameter("Parallel (never combined with RT correction)",
+          "Parallel processing of gaps (RT correction is always on a single thread)");
+
+  public static final BooleanParameter autoRemove = new BooleanParameter(
+      "Remove original peak list", "If checked, the original peak list will be removed");
+
+  public PeakFinderParameters() {
+    super(new Parameter[] {peakLists, suffix, intTolerance, MZTolerance, RTTolerance, RTCorrection,
+        useParallel, autoRemove});
+  }
 
 }

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/gapfilling/peakfinder/multithreaded/MultiThreadPeakFinderParameters.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/gapfilling/peakfinder/multithreaded/MultiThreadPeakFinderParameters.java
@@ -41,15 +41,11 @@ public class MultiThreadPeakFinderParameters extends SimpleParameterSet {
 
   public static final RTToleranceParameter RTTolerance = new RTToleranceParameter();
 
-  public static final BooleanParameter useLock =
-      new BooleanParameter("Use lock for multi threading", "");
-
   public static final BooleanParameter autoRemove = new BooleanParameter(
       "Remove original peak list", "If checked, the original peak list will be removed");
 
   public MultiThreadPeakFinderParameters() {
-    super(new Parameter[] {peakLists, suffix, intTolerance, MZTolerance, RTTolerance, useLock,
-        autoRemove});
+    super(new Parameter[] {peakLists, suffix, intTolerance, MZTolerance, RTTolerance, autoRemove});
   }
 
 }

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/gapfilling/peakfinder/multithreaded/MultiThreadPeakFinderTask.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/gapfilling/peakfinder/multithreaded/MultiThreadPeakFinderTask.java
@@ -20,7 +20,6 @@ package net.sf.mzmine.modules.peaklistmethods.gapfilling.peakfinder.multithreade
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.locks.Lock;
 import java.util.logging.Logger;
 import com.google.common.collect.Range;
 import net.sf.mzmine.datamodel.Feature;
@@ -50,19 +49,15 @@ class MultiThreadPeakFinderTask extends AbstractTask {
   private int start;
   private int endexcl;
 
-  private Lock lock;
-
   // takes care of adding the final result
   private SubTaskFinishListener listener;
 
   private int taskIndex;
 
   MultiThreadPeakFinderTask(MZmineProject project, PeakList peakList, PeakList processedPeakList,
-      ParameterSet parameters, int start, int endexcl, Lock lock, SubTaskFinishListener listener,
+      ParameterSet parameters, int start, int endexcl, SubTaskFinishListener listener,
       int taskIndex) {
 
-    // central lock that blocks only when peaks are added to the processedPeakList
-    this.lock = lock;
     this.listener = listener;
     this.taskIndex = taskIndex;
 
@@ -123,7 +118,6 @@ class MultiThreadPeakFinderTask extends AbstractTask {
         } else {
           newRow.addPeak(dataFile, sourcePeak);
         }
-
       }
 
       // Stop processing this file if there are no gaps
@@ -137,7 +131,6 @@ class MultiThreadPeakFinderTask extends AbstractTask {
 
       // Process each scan
       for (int scanNumber : scanNumbers) {
-
         // Canceled?
         if (isCanceled()) {
           return;
@@ -156,7 +149,7 @@ class MultiThreadPeakFinderTask extends AbstractTask {
 
       // Finalize gaps
       for (Gap gap : gaps) {
-        gap.noMoreOffers(lock);
+        gap.noMoreOffers();
       }
     }
 


### PR DESCRIPTION
Hey Tomas,
Hey Ming,

after revising my multithreaded PeakFinder and ming’s great changes to the SameRange gap-fill, this pull request adds stream methods `stream` and `parallelStream` to PeakList. Ming’s SameRangeTask is not included. I am going to send you some small ideas/adaptions for the SameRangeTask. 

To further discuss parallel processing in MZmine, see #465.

- `peakList.parallelStream().forEach(sourceRow ->`
- Removed locking from MultithreadedPeakFinder
- Changed to ConcurrentHashMap<RawDataFile, Feature>
  - Seems to be faster than Hashtable
- Option to use parallelStream (RawDataFiles) in basic PeakFinder
  - Another option to perform parallel gap fill


Cheers,
Robin
