### PR TITLE
Sort peak lists in join aligner

### DIFF
--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/alignment/join/JoinAlignerParameters.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/alignment/join/JoinAlignerParameters.java
@@ -33,6 +33,9 @@ public class JoinAlignerParameters extends SimpleParameterSet {
 
   public static final PeakListsParameter peakLists = new PeakListsParameter();
 
+  public static final BooleanParameter OrderPeakLists = new BooleanParameter("Order peak lists",
+      "Orders the peak lists to yield the same result with the same parameters.");
+
   public static final StringParameter peakListName =
       new StringParameter("Peak list name", "Peak list name", "Aligned peak list");
 
@@ -58,8 +61,8 @@ public class JoinAlignerParameters extends SimpleParameterSet {
           new IsotopePatternScoreParameters());
 
   public JoinAlignerParameters() {
-    super(new Parameter[] {peakLists, peakListName, MZTolerance, MZWeight, RTTolerance, RTWeight,
-        SameChargeRequired, SameIDRequired, compareIsotopePattern});
+    super(new Parameter[] {peakLists, OrderPeakLists, peakListName, MZTolerance, MZWeight,
+        RTTolerance, RTWeight, SameChargeRequired, SameIDRequired, compareIsotopePattern});
   }
 
 }


### PR DESCRIPTION
Hey Tomas,

on Ming's suggestion, I have added an option to the join aligner to sort the peak lists prior to alignment. This should help in getting the same alignment results when reprocessing the data with the same parameters. 

The sort peak list module seems to be unfunctional in headless mode. Apart from that it might be a good idea to provide this option in the join aligner.

What do you think?

Cheers,
Robin