### PR TITLE
BUG fix: median mz calc was broken

### DIFF
--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/ResolvedPeak.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/ResolvedPeak.java
@@ -19,21 +19,18 @@
 package net.sf.mzmine.modules.peaklistmethods.peakpicking.deconvolution;
 
 import java.util.Arrays;
-
 import javax.annotation.Nonnull;
-
+import com.google.common.collect.Range;
 import net.sf.mzmine.datamodel.DataPoint;
 import net.sf.mzmine.datamodel.Feature;
 import net.sf.mzmine.datamodel.IsotopePattern;
 import net.sf.mzmine.datamodel.RawDataFile;
 import net.sf.mzmine.datamodel.Scan;
 import net.sf.mzmine.datamodel.impl.SimpleDataPoint;
+import net.sf.mzmine.datamodel.impl.SimplePeakInformation;
 import net.sf.mzmine.util.MathUtils;
 import net.sf.mzmine.util.PeakUtils;
 import net.sf.mzmine.util.ScanUtils;
-
-import com.google.common.collect.Range;
-import net.sf.mzmine.datamodel.impl.SimplePeakInformation;
 
 /**
  * ResolvedPeak
@@ -114,7 +111,7 @@ public class ResolvedPeak implements Feature {
          */
       }
 
-      // dataPointMZValues[i] = dp.getMZ();
+      dataPointMZValues[i] = dp.getMZ();
       dataPointIntensityValues[i] = dp.getIntensity();
 
       if (rawDataPointsIntensityRange == null) {
@@ -192,6 +189,7 @@ public class ResolvedPeak implements Feature {
   /**
    * This method returns a representative datapoint of this peak in a given scan
    */
+  @Override
   public DataPoint getDataPoint(int scanNumber) {
     int index = Arrays.binarySearch(scanNumbers, scanNumber);
     if (index < 0)
@@ -204,6 +202,7 @@ public class ResolvedPeak implements Feature {
   /**
    * This method returns m/z value of the chromatogram
    */
+  @Override
   public double getMZ() {
     return mz;
   }
@@ -213,103 +212,128 @@ public class ResolvedPeak implements Feature {
    * 
    * @return String information
    */
+  @Override
   public String toString() {
     return PeakUtils.peakToString(this);
   }
 
+  @Override
   public double getArea() {
     return area;
   }
 
+  @Override
   public double getHeight() {
     return height;
   }
 
+  @Override
   public int getMostIntenseFragmentScanNumber() {
     return fragmentScan;
   }
 
+  @Override
   public @Nonnull FeatureStatus getFeatureStatus() {
     return FeatureStatus.DETECTED;
   }
 
+  @Override
   public double getRT() {
     return rt;
   }
 
+  @Override
   public @Nonnull Range<Double> getRawDataPointsIntensityRange() {
     return rawDataPointsIntensityRange;
   }
 
+  @Override
   public @Nonnull Range<Double> getRawDataPointsMZRange() {
     return rawDataPointsMZRange;
   }
 
+  @Override
   public @Nonnull Range<Double> getRawDataPointsRTRange() {
     return rawDataPointsRTRange;
   }
 
+  @Override
   public int getRepresentativeScanNumber() {
     return representativeScan;
   }
 
+  @Override
   public @Nonnull int[] getScanNumbers() {
     return scanNumbers;
   }
 
+  @Override
   public @Nonnull RawDataFile getDataFile() {
     return dataFile;
   }
 
+  @Override
   public IsotopePattern getIsotopePattern() {
     return isotopePattern;
   }
 
+  @Override
   public void setIsotopePattern(@Nonnull IsotopePattern isotopePattern) {
     this.isotopePattern = isotopePattern;
   }
 
+  @Override
   public int getCharge() {
     return charge;
   }
 
+  @Override
   public void setCharge(int charge) {
     this.charge = charge;
   }
 
+  @Override
   public Double getFWHM() {
     return fwhm;
   }
 
+  @Override
   public void setFWHM(Double fwhm) {
     this.fwhm = fwhm;
   }
 
+  @Override
   public Double getTailingFactor() {
     return tf;
   }
 
+  @Override
   public void setTailingFactor(Double tf) {
     this.tf = tf;
   }
 
+  @Override
   public Double getAsymmetryFactor() {
     return af;
   }
 
+  @Override
   public void setAsymmetryFactor(Double af) {
     this.af = af;
   }
 
   // dulab Edit
+  @Override
   public void outputChromToFile() {
     int nothing = -1;
   }
 
+  @Override
   public void setPeakInformation(SimplePeakInformation peakInfoIn) {
     this.peakInfo = peakInfoIn;
   }
 
+  @Override
   public SimplePeakInformation getPeakInformation() {
     return peakInfo;
   }


### PR DESCRIPTION
Hey Tomas,

this was a serious bug. The calculation of the median mz after peak deconvolution was broken for nearly two years. (Based on my tracking) Owen commented out a very important line of code.

All the features after deconvolution had the same average m/z like their chromatogram. 
We should get this out as a new version asap. 

As the m/z of some features was totally off, molecular formula prediction, SIRIUS and many more modules showed high (>20 ppm) differences for features which actually where at 1 ppm.


Glad to have tracked it down, my results are much better now.

Cheers,
Robin