### PR TITLE
central m/z calculation after deconvolution

### DIFF
--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/DeconvolutionModule.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/DeconvolutionModule.java
@@ -18,10 +18,9 @@
 
 package net.sf.mzmine.modules.peaklistmethods.peakpicking.deconvolution;
 
+import java.util.Arrays;
 import java.util.Collection;
-
 import javax.annotation.Nonnull;
-
 import net.sf.mzmine.datamodel.MZmineProject;
 import net.sf.mzmine.datamodel.PeakList;
 import net.sf.mzmine.modules.MZmineModuleCategory;
@@ -29,6 +28,9 @@ import net.sf.mzmine.modules.MZmineProcessingModule;
 import net.sf.mzmine.parameters.ParameterSet;
 import net.sf.mzmine.taskcontrol.Task;
 import net.sf.mzmine.util.ExitCode;
+import net.sf.mzmine.util.maths.CenterFunction;
+import net.sf.mzmine.util.maths.CenterMeasure;
+import net.sf.mzmine.util.maths.Weighting;
 
 public class DeconvolutionModule implements MZmineProcessingModule {
 
@@ -64,11 +66,33 @@ public class DeconvolutionModule implements MZmineProcessingModule {
   @Nonnull
   public ExitCode runModule(@Nonnull MZmineProject project, @Nonnull final ParameterSet parameters,
       @Nonnull final Collection<Task> tasks) {
+    PeakList[] peakLists = parameters.getParameter(DeconvolutionParameters.PEAK_LISTS).getValue()
+        .getMatchingPeakLists();
 
-    for (final PeakList peakList : parameters.getParameter(DeconvolutionParameters.PEAK_LISTS)
-        .getValue().getMatchingPeakLists()) {
+    // function to calculate center mz
+    CenterFunction mzCenterFunction =
+        parameters.getParameter(DeconvolutionParameters.MZ_CENTER_FUNCTION).getValue();
 
-      tasks.add(new DeconvolutionTask(project, peakList, parameters));
+    // use a LOG weighted, noise corrected, maximum weight capped function
+    if (mzCenterFunction.getMeasure().equals(CenterMeasure.AUTO)) {
+      // data point with lowest intensity
+      // weight = LOG(value) - LOG(noise) (maxed to maxWeight)
+      double noise = Arrays.stream(peakLists).flatMap(pkl -> Arrays.stream(pkl.getRows()))
+          .map(r -> r.getPeaks()[0])
+          .mapToDouble(peak -> peak.getRawDataPointsIntensityRange().lowerEndpoint())
+          .filter(v -> v != 0).min().orElse(0);
+
+      // maxWeight 4 corresponds to a linear range of 4 orders of magnitude
+      // everything higher than this will be capped to this weight
+      // do not overestimate influence of very high data points on mass accuracy
+      double maxWeight = 4;
+
+      // use a LOG weighted, noise corrected, maximum weight capped function
+      mzCenterFunction = new CenterFunction(CenterMeasure.AVG, Weighting.LOG10, noise, maxWeight);
+    }
+
+    for (final PeakList peakList : peakLists) {
+      tasks.add(new DeconvolutionTask(project, peakList, parameters, mzCenterFunction));
     }
 
     return ExitCode.OK;

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/DeconvolutionParameters.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/DeconvolutionParameters.java
@@ -18,20 +18,22 @@
 
 package net.sf.mzmine.modules.peaklistmethods.peakpicking.deconvolution;
 
-import net.sf.mzmine.modules.peaklistmethods.peakpicking.deconvolution.baseline.BaselinePeakDetector;
 import net.sf.mzmine.modules.peaklistmethods.peakpicking.deconvolution.ADAPpeakpicking.ADAPDetector;
+import net.sf.mzmine.modules.peaklistmethods.peakpicking.deconvolution.baseline.BaselinePeakDetector;
 import net.sf.mzmine.modules.peaklistmethods.peakpicking.deconvolution.centwave.CentWaveDetector;
 import net.sf.mzmine.modules.peaklistmethods.peakpicking.deconvolution.minimumsearch.MinimumSearchPeakDetector;
 import net.sf.mzmine.modules.peaklistmethods.peakpicking.deconvolution.noiseamplitude.NoiseAmplitudePeakDetector;
 import net.sf.mzmine.modules.peaklistmethods.peakpicking.deconvolution.savitzkygolay.SavitzkyGolayPeakDetector;
 import net.sf.mzmine.parameters.Parameter;
-import net.sf.mzmine.parameters.parametertypes.DoubleParameter;
 import net.sf.mzmine.parameters.impl.SimpleParameterSet;
 import net.sf.mzmine.parameters.parametertypes.BooleanParameter;
+import net.sf.mzmine.parameters.parametertypes.CenterMeasureParameter;
+import net.sf.mzmine.parameters.parametertypes.DoubleParameter;
 import net.sf.mzmine.parameters.parametertypes.ModuleComboParameter;
+import net.sf.mzmine.parameters.parametertypes.OptionalParameter;
 import net.sf.mzmine.parameters.parametertypes.StringParameter;
 import net.sf.mzmine.parameters.parametertypes.selectors.PeakListsParameter;
-import net.sf.mzmine.parameters.parametertypes.OptionalParameter;
+import net.sf.mzmine.util.maths.CenterMeasure;
 
 public class DeconvolutionParameters extends SimpleParameterSet {
 
@@ -47,6 +49,12 @@ public class DeconvolutionParameters extends SimpleParameterSet {
   public static final ModuleComboParameter<PeakResolver> PEAK_RESOLVER =
       new ModuleComboParameter<PeakResolver>("Algorithm", "Peak recognition description",
           RESOLVERS);
+
+  /**
+   * The function to determin the mz center (median, avg, weighted avg)
+   */
+  public static final CenterMeasureParameter MZ_CENTER_FUNCTION =
+      new CenterMeasureParameter(CenterMeasure.MEDIAN);
 
   public static final BooleanParameter AUTO_REMOVE = new BooleanParameter(
       "Remove original peak list",
@@ -64,7 +72,7 @@ public class DeconvolutionParameters extends SimpleParameterSet {
               + "will be done on the full retention time range of the chromatogram."));
 
   public DeconvolutionParameters() {
-    super(new Parameter[] {PEAK_LISTS, SUFFIX, PEAK_RESOLVER, mzRangeMSMS, RetentionTimeMSMS,
-        AUTO_REMOVE});
+    super(new Parameter[] {PEAK_LISTS, SUFFIX, PEAK_RESOLVER, MZ_CENTER_FUNCTION, mzRangeMSMS,
+        RetentionTimeMSMS, AUTO_REMOVE});
   }
 }

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/DeconvolutionParameters.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/DeconvolutionParameters.java
@@ -34,6 +34,7 @@ import net.sf.mzmine.parameters.parametertypes.OptionalParameter;
 import net.sf.mzmine.parameters.parametertypes.StringParameter;
 import net.sf.mzmine.parameters.parametertypes.selectors.PeakListsParameter;
 import net.sf.mzmine.util.maths.CenterMeasure;
+import net.sf.mzmine.util.maths.Weighting;
 
 public class DeconvolutionParameters extends SimpleParameterSet {
 
@@ -54,7 +55,9 @@ public class DeconvolutionParameters extends SimpleParameterSet {
    * The function to determin the mz center (median, avg, weighted avg)
    */
   public static final CenterMeasureParameter MZ_CENTER_FUNCTION =
-      new CenterMeasureParameter("m/z center calculation", CenterMeasure.MEDIAN);
+      new CenterMeasureParameter("m/z center calculation", CenterMeasure.values(),
+          new Weighting[] {Weighting.NONE, Weighting.LOG10, Weighting.SQRT}, CenterMeasure.MEDIAN,
+          Weighting.NONE);
 
   public static final BooleanParameter AUTO_REMOVE = new BooleanParameter(
       "Remove original peak list",

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/DeconvolutionParameters.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/DeconvolutionParameters.java
@@ -34,7 +34,6 @@ import net.sf.mzmine.parameters.parametertypes.OptionalParameter;
 import net.sf.mzmine.parameters.parametertypes.StringParameter;
 import net.sf.mzmine.parameters.parametertypes.selectors.PeakListsParameter;
 import net.sf.mzmine.util.maths.CenterMeasure;
-import net.sf.mzmine.util.maths.Weighting;
 
 public class DeconvolutionParameters extends SimpleParameterSet {
 
@@ -54,10 +53,9 @@ public class DeconvolutionParameters extends SimpleParameterSet {
   /**
    * The function to determin the mz center (median, avg, weighted avg)
    */
-  public static final CenterMeasureParameter MZ_CENTER_FUNCTION =
-      new CenterMeasureParameter("m/z center calculation", CenterMeasure.values(),
-          new Weighting[] {Weighting.NONE, Weighting.LOG10, Weighting.SQRT}, CenterMeasure.MEDIAN,
-          Weighting.NONE);
+  public static final CenterMeasureParameter MZ_CENTER_FUNCTION = new CenterMeasureParameter(
+      "m/z center calculation", "Median, average or an automatic log10-weighted approach",
+      CenterMeasure.values(), null, CenterMeasure.MEDIAN, null);
 
   public static final BooleanParameter AUTO_REMOVE = new BooleanParameter(
       "Remove original peak list",

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/DeconvolutionParameters.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/DeconvolutionParameters.java
@@ -54,7 +54,7 @@ public class DeconvolutionParameters extends SimpleParameterSet {
    * The function to determin the mz center (median, avg, weighted avg)
    */
   public static final CenterMeasureParameter MZ_CENTER_FUNCTION =
-      new CenterMeasureParameter(CenterMeasure.MEDIAN);
+      new CenterMeasureParameter("m/z center calculation", CenterMeasure.MEDIAN);
 
   public static final BooleanParameter AUTO_REMOVE = new BooleanParameter(
       "Remove original peak list",

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/DeconvolutionTask.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/DeconvolutionTask.java
@@ -67,7 +67,7 @@ public class DeconvolutionTask extends AbstractTask {
   private double msmsRange, RTRangeMSMS;
 
   // function to find center mz of all feature data points
-  private CenterFunction mzCenterFunction;
+  private final CenterFunction mzCenterFunction;
 
   /**
    * Create the task.
@@ -76,7 +76,7 @@ public class DeconvolutionTask extends AbstractTask {
    * @param parameterSet task parameters.
    */
   public DeconvolutionTask(final MZmineProject project, final PeakList list,
-      final ParameterSet parameterSet) {
+      final ParameterSet parameterSet, CenterFunction mzCenterFunction) {
 
     // Initialize.
     this.project = project;
@@ -85,6 +85,7 @@ public class DeconvolutionTask extends AbstractTask {
     newPeakList = null;
     processedRows = 0;
     totalRows = 0;
+    this.mzCenterFunction = mzCenterFunction;
   }
 
   @Override
@@ -202,6 +203,7 @@ public class DeconvolutionTask extends AbstractTask {
    * Deconvolve a chromatogram into separate peaks.
    * 
    * @param peakList holds the chromatogram to deconvolve.
+   * @param mzCenterFunction2
    * @return a new peak list holding the resolved peaks.
    * @throws RSessionWrapperException
    */
@@ -227,11 +229,6 @@ public class DeconvolutionTask extends AbstractTask {
           parameters.getParameter(RetentionTimeMSMS).getEmbeddedParameter().getValue();
     else
       this.RTRangeMSMS = 0;
-
-    mzCenterFunction =
-        parameters.getParameter(DeconvolutionParameters.MZ_CENTER_FUNCTION).getValue();
-
-
 
     // Create new peak list.
     final PeakList resolvedPeaks =

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/DeconvolutionTask.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/DeconvolutionTask.java
@@ -20,12 +20,11 @@ package net.sf.mzmine.modules.peaklistmethods.peakpicking.deconvolution;
 
 import static net.sf.mzmine.modules.peaklistmethods.peakpicking.deconvolution.DeconvolutionParameters.AUTO_REMOVE;
 import static net.sf.mzmine.modules.peaklistmethods.peakpicking.deconvolution.DeconvolutionParameters.PEAK_RESOLVER;
+import static net.sf.mzmine.modules.peaklistmethods.peakpicking.deconvolution.DeconvolutionParameters.RetentionTimeMSMS;
 import static net.sf.mzmine.modules.peaklistmethods.peakpicking.deconvolution.DeconvolutionParameters.SUFFIX;
 import static net.sf.mzmine.modules.peaklistmethods.peakpicking.deconvolution.DeconvolutionParameters.mzRangeMSMS;
-import static net.sf.mzmine.modules.peaklistmethods.peakpicking.deconvolution.DeconvolutionParameters.RetentionTimeMSMS;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
 import net.sf.mzmine.datamodel.Feature;
 import net.sf.mzmine.datamodel.MZmineProject;
 import net.sf.mzmine.datamodel.PeakList;
@@ -43,6 +42,7 @@ import net.sf.mzmine.taskcontrol.TaskStatus;
 import net.sf.mzmine.util.R.REngineType;
 import net.sf.mzmine.util.R.RSessionWrapper;
 import net.sf.mzmine.util.R.RSessionWrapperException;
+import net.sf.mzmine.util.maths.CenterFunction;
 
 public class DeconvolutionTask extends AbstractTask {
 
@@ -65,6 +65,9 @@ public class DeconvolutionTask extends AbstractTask {
   private String errorMsg;
   private boolean setMSMSRange, setMSMSRT;
   private double msmsRange, RTRangeMSMS;
+
+  // function to find center mz of all feature data points
+  private CenterFunction mzCenterFunction;
 
   /**
    * Create the task.
@@ -225,6 +228,10 @@ public class DeconvolutionTask extends AbstractTask {
     else
       this.RTRangeMSMS = 0;
 
+    mzCenterFunction =
+        parameters.getParameter(DeconvolutionParameters.MZ_CENTER_FUNCTION).getValue();
+
+
 
     // Create new peak list.
     final PeakList resolvedPeaks =
@@ -256,7 +263,7 @@ public class DeconvolutionTask extends AbstractTask {
       final PeakResolver resolverModule = resolver.getModule();
       final ParameterSet resolverParams = resolver.getParameterSet();
       final Feature[] peaks = resolverModule.resolvePeaks(chromatogram, resolverParams, rSession,
-          msmsRange, RTRangeMSMS);
+          mzCenterFunction, msmsRange, RTRangeMSMS);
 
       // Add peaks to the new peak list.
       for (final Feature peak : peaks) {

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/PeakResolver.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/PeakResolver.java
@@ -24,6 +24,7 @@ import net.sf.mzmine.parameters.ParameterSet;
 import net.sf.mzmine.util.R.REngineType;
 import net.sf.mzmine.util.R.RSessionWrapper;
 import net.sf.mzmine.util.R.RSessionWrapperException;
+import net.sf.mzmine.util.maths.CenterFunction;
 
 public interface PeakResolver extends MZmineModule {
 
@@ -53,6 +54,8 @@ public interface PeakResolver extends MZmineModule {
    * obtained from the chromatogram itself. The size of these arrays must be same, and must be equal
    * to the number of scans covered by given chromatogram.
    * 
+   * @param mzCenterFunction
+   * 
    * @param rTRangeMSMS
    * @param msmsRange
    * @param rTRangeMSMS
@@ -63,7 +66,7 @@ public interface PeakResolver extends MZmineModule {
    * @throws RSessionWrapperException
    */
   public Feature[] resolvePeaks(Feature chromatogram, ParameterSet parameters,
-      RSessionWrapper rSession, double msmsRange, double rTRangeMSMS)
-      throws RSessionWrapperException;
+      RSessionWrapper rSession, CenterFunction mzCenterFunction, double msmsRange,
+      double rTRangeMSMS) throws RSessionWrapperException;
 
 }

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/PeakResolverSetupDialog.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/PeakResolverSetupDialog.java
@@ -28,7 +28,6 @@ import java.awt.event.ActionEvent;
 import java.util.ArrayList;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
 import javax.swing.Box;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
@@ -37,9 +36,7 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JSeparator;
 import javax.swing.SwingConstants;
-
 import org.jfree.data.xy.XYDataset;
-
 import net.sf.mzmine.datamodel.Feature;
 import net.sf.mzmine.datamodel.PeakList;
 import net.sf.mzmine.datamodel.PeakListRow;
@@ -53,6 +50,8 @@ import net.sf.mzmine.util.GUIUtils;
 import net.sf.mzmine.util.R.REngineType;
 import net.sf.mzmine.util.R.RSessionWrapper;
 import net.sf.mzmine.util.R.RSessionWrapperException;
+import net.sf.mzmine.util.maths.CenterFunction;
+import net.sf.mzmine.util.maths.CenterMeasure;
 
 /**
  * This class extends ParameterSetupDialog class.
@@ -239,9 +238,11 @@ public class PeakResolverSetupDialog extends ParameterSetupDialog {
           } else {
             rSession = null;
           }
+          CenterFunction mzCenterFunction = new CenterFunction(CenterMeasure.MEDIAN);
           // preview doesn't show msms scans
           // set it to be default searching range
-          resolvedPeaks = peakResolver.resolvePeaks(previewPeak, parameters, rSession, 0, 0);
+          resolvedPeaks =
+              peakResolver.resolvePeaks(previewPeak, parameters, rSession, mzCenterFunction, 0, 0);
 
           // Turn off R instance.
           if (rSession != null)

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/ResolvedPeak.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/ResolvedPeak.java
@@ -28,9 +28,9 @@ import net.sf.mzmine.datamodel.RawDataFile;
 import net.sf.mzmine.datamodel.Scan;
 import net.sf.mzmine.datamodel.impl.SimpleDataPoint;
 import net.sf.mzmine.datamodel.impl.SimplePeakInformation;
-import net.sf.mzmine.util.MathUtils;
 import net.sf.mzmine.util.PeakUtils;
 import net.sf.mzmine.util.ScanUtils;
+import net.sf.mzmine.util.maths.CenterFunction;
 
 /**
  * ResolvedPeak
@@ -72,8 +72,8 @@ public class ResolvedPeak implements Feature {
    * (inclusive). The selected region MUST NOT contain any zero-intensity data points, otherwise
    * exception is thrown.
    */
-  public ResolvedPeak(Feature chromatogram, int regionStart, int regionEnd, double msmsRange,
-      double RTRangeMSMS) {
+  public ResolvedPeak(Feature chromatogram, int regionStart, int regionEnd,
+      CenterFunction mzCenterFunction, double msmsRange, double RTRangeMSMS) {
 
     assert regionEnd > regionStart;
 
@@ -134,8 +134,8 @@ public class ResolvedPeak implements Feature {
       }
     }
 
-    // Calculate median m/z
-    mz = MathUtils.calcQuantile(dataPointMZValues, 0.5f);
+    // Calculate m/z as median, average or weighted-average
+    mz = mzCenterFunction.calcCenter(dataPointMZValues, dataPointIntensityValues);
 
     // Update area
     area = 0;

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/baseline/BaselinePeakDetector.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/baseline/BaselinePeakDetector.java
@@ -21,12 +21,10 @@ package net.sf.mzmine.modules.peaklistmethods.peakpicking.deconvolution.baseline
 import static net.sf.mzmine.modules.peaklistmethods.peakpicking.deconvolution.baseline.BaselinePeakDetectorParameters.BASELINE_LEVEL;
 import static net.sf.mzmine.modules.peaklistmethods.peakpicking.deconvolution.baseline.BaselinePeakDetectorParameters.MIN_PEAK_HEIGHT;
 import static net.sf.mzmine.modules.peaklistmethods.peakpicking.deconvolution.baseline.BaselinePeakDetectorParameters.PEAK_DURATION;
-
 import java.util.ArrayList;
 import java.util.List;
-
 import javax.annotation.Nonnull;
-
+import com.google.common.collect.Range;
 import net.sf.mzmine.datamodel.DataPoint;
 import net.sf.mzmine.datamodel.Feature;
 import net.sf.mzmine.datamodel.RawDataFile;
@@ -35,8 +33,7 @@ import net.sf.mzmine.modules.peaklistmethods.peakpicking.deconvolution.ResolvedP
 import net.sf.mzmine.parameters.ParameterSet;
 import net.sf.mzmine.util.R.REngineType;
 import net.sf.mzmine.util.R.RSessionWrapper;
-
-import com.google.common.collect.Range;
+import net.sf.mzmine.util.maths.CenterFunction;
 
 /**
  * This class implements a simple peak deconvolution algorithm. Continuous peaks above a given
@@ -44,13 +41,15 @@ import com.google.common.collect.Range;
  */
 public class BaselinePeakDetector implements PeakResolver {
 
+  @Override
   public @Nonnull String getName() {
     return "Baseline cut-off";
   }
 
   @Override
   public Feature[] resolvePeaks(final Feature chromatogram, ParameterSet parameters,
-      RSessionWrapper rSession, double msmsRange, double rTRangeMSMS) {
+      RSessionWrapper rSession, CenterFunction mzCenterFunction, double msmsRange,
+      double rTRangeMSMS) {
 
     int scanNumbers[] = chromatogram.getScanNumbers();
     final int scanCount = scanNumbers.length;
@@ -109,7 +108,7 @@ public class BaselinePeakDetector implements PeakResolver {
 
           // Create a new ResolvedPeak and add it.
           resolvedPeaks.add(new ResolvedPeak(chromatogram, currentRegionStart, currentRegionEnd,
-              msmsRange, rTRangeMSMS));
+              mzCenterFunction, msmsRange, rTRangeMSMS));
         }
 
         // Find next peak region, starting from next data point.

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/centwave/CentWaveDetector.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/centwave/CentWaveDetector.java
@@ -28,14 +28,12 @@ import static net.sf.mzmine.modules.peaklistmethods.peakpicking.deconvolution.ce
 import static net.sf.mzmine.modules.peaklistmethods.peakpicking.deconvolution.centwave.CentWaveDetectorParameters.PEAK_DURATION;
 import static net.sf.mzmine.modules.peaklistmethods.peakpicking.deconvolution.centwave.CentWaveDetectorParameters.PEAK_SCALES;
 import static net.sf.mzmine.modules.peaklistmethods.peakpicking.deconvolution.centwave.CentWaveDetectorParameters.SN_THRESHOLD;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Logger;
-
 import javax.annotation.Nonnull;
-
+import com.google.common.collect.Range;
 import net.sf.mzmine.datamodel.DataPoint;
 import net.sf.mzmine.datamodel.Feature;
 import net.sf.mzmine.datamodel.RawDataFile;
@@ -46,8 +44,7 @@ import net.sf.mzmine.parameters.ParameterSet;
 import net.sf.mzmine.util.R.REngineType;
 import net.sf.mzmine.util.R.RSessionWrapper;
 import net.sf.mzmine.util.R.RSessionWrapperException;
-
-import com.google.common.collect.Range;
+import net.sf.mzmine.util.maths.CenterFunction;
 
 /**
  * Use XCMS findPeaks.centWave to identify peaks.
@@ -102,8 +99,8 @@ public class CentWaveDetector implements PeakResolver {
 
   @Override
   public Feature[] resolvePeaks(final Feature chromatogram, final ParameterSet parameters,
-      RSessionWrapper rSession, double msmsRange, double rTRangeMSMS)
-      throws RSessionWrapperException {
+      RSessionWrapper rSession, CenterFunction mzCenterFunction, double msmsRange,
+      double rTRangeMSMS) throws RSessionWrapperException {
 
     int scanNumbers[] = chromatogram.getScanNumbers();
     final int scanCount = scanNumbers.length;
@@ -164,7 +161,8 @@ public class CentWaveDetector implements PeakResolver {
             if ((end > start)
                 && (peakDuration.contains(retentionTimes[end] - retentionTimes[start]))) {
 
-              resolvedPeaks.add(new ResolvedPeak(chromatogram, start, end, msmsRange, rTRangeMSMS));
+              resolvedPeaks.add(new ResolvedPeak(chromatogram, start, end, mzCenterFunction,
+                  msmsRange, rTRangeMSMS));
             }
 
             start = end;

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/help/help.html
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/help/help.html
@@ -30,8 +30,12 @@ PEAK_LISTS, SUFFIX, PEAK_RESOLVER, MZ_CENTER_FUNCTION, mzRangeMSMS,
 <dd>Selection of algorithm for peak recognition</dd>
 
 <dt>m/z center calculation</dt>
-<dd>Define measure for center m/z calculation as median, average (weighting=NONE) or weighted-average. 
-This function is applied to all data points (m/z, intensity) of the new feature. </dd>
+<dd>Define measure for center m/z calculation as median, average or auto (noise level corrected, maximum capped log10-weighted average). 
+This function is applied to all data points (m/z, intensity) of the new feature to find the center m/z.
+</dd>
+<dd> Auto: weight = log10(intensity) - log10(noiseLevel) the maximum weight is 4 </br>
+The noise level is the lowest intensity found in all chromatograms of all selected peakLists. 
+</dd>
 
 <dt>m/z range for MS2 scan pairing (Da)</dt>
 <dd>All MS2 scans within m/z and RT range are allocated to the new feature (ranges as +-value around center)</dd>

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/help/help.html
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/help/help.html
@@ -16,13 +16,28 @@ Following the detection of chromatograms by the Chromatogram builder, chromatogr
 The Deconvolution module provides several algorithms for this purpose.
 </p>
 
+PEAK_LISTS, SUFFIX, PEAK_RESOLVER, MZ_CENTER_FUNCTION, mzRangeMSMS,
+        RetentionTimeMSMS, AUTO_REMOVE}
+
+
 <h4>Method parameters</h4>
 <dl>
 <dt>Suffix</dt>
 <dd>This string is added to the end of the name of each processed peak list</dd>
 
+
 <dt>Algorithm</dt>
 <dd>Selection of algorithm for peak recognition</dd>
+
+<dt>m/z center calculation</dt>
+<dd>Define measure for center m/z calculation as median, average (weighting=NONE) or weighted-average. 
+This function is applied to all data points (m/z, intensity) of the new feature. </dd>
+
+<dt>m/z range for MS2 scan pairing (Da)</dt>
+<dd>All MS2 scans within m/z and RT range are allocated to the new feature (ranges as +-value around center)</dd>
+
+<dt>RT range for MS2 scan pairing (min)</dt>
+<dd>All MS2 scans within m/z and RT range are allocated to the new feature (ranges as +-value around center)</dd>
 
 <dt>Remove original peak list</dt>
 <dd>If checked, original chromatogram will be removed and only deconvoluted version remains</dd>

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/minimumsearch/MinimumSearchPeakDetector.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/minimumsearch/MinimumSearchPeakDetector.java
@@ -24,14 +24,10 @@ import static net.sf.mzmine.modules.peaklistmethods.peakpicking.deconvolution.mi
 import static net.sf.mzmine.modules.peaklistmethods.peakpicking.deconvolution.minimumsearch.MinimumSearchPeakDetectorParameters.MIN_RELATIVE_HEIGHT;
 import static net.sf.mzmine.modules.peaklistmethods.peakpicking.deconvolution.minimumsearch.MinimumSearchPeakDetectorParameters.PEAK_DURATION;
 import static net.sf.mzmine.modules.peaklistmethods.peakpicking.deconvolution.minimumsearch.MinimumSearchPeakDetectorParameters.SEARCH_RT_RANGE;
-
 import java.util.ArrayList;
 import java.util.List;
-
 import javax.annotation.Nonnull;
-
 import com.google.common.collect.Range;
-
 import net.sf.mzmine.datamodel.DataPoint;
 import net.sf.mzmine.datamodel.Feature;
 import net.sf.mzmine.datamodel.RawDataFile;
@@ -41,6 +37,7 @@ import net.sf.mzmine.parameters.ParameterSet;
 import net.sf.mzmine.util.MathUtils;
 import net.sf.mzmine.util.R.REngineType;
 import net.sf.mzmine.util.R.RSessionWrapper;
+import net.sf.mzmine.util.maths.CenterFunction;
 
 /**
  * This peak recognition method searches for local minima in the chromatogram. If a local minimum is
@@ -56,7 +53,8 @@ public class MinimumSearchPeakDetector implements PeakResolver {
 
   @Override
   public Feature[] resolvePeaks(final Feature chromatogram, ParameterSet parameters,
-      RSessionWrapper rSession, double msmsRange, double rTRangeMSMS) {
+      RSessionWrapper rSession, CenterFunction mzCenterFunction, double msmsRange,
+      double rTRangeMSMS) {
     int scanNumbers[] = chromatogram.getScanNumbers();
     final int scanCount = scanNumbers.length;
     double retentionTimes[] = new double[scanCount];
@@ -125,7 +123,7 @@ public class MinimumSearchPeakDetector implements PeakResolver {
                   retentionTimes[currentRegionEnd] - retentionTimes[currentRegionStart])) {
 
             resolvedPeaks.add(new ResolvedPeak(chromatogram, currentRegionStart, currentRegionEnd,
-                msmsRange, rTRangeMSMS));
+                mzCenterFunction, msmsRange, rTRangeMSMS));
           }
 
           // Set the next region start to current region end - 1
@@ -184,7 +182,7 @@ public class MinimumSearchPeakDetector implements PeakResolver {
                     retentionTimes[currentRegionEnd] - retentionTimes[currentRegionStart])) {
 
               resolvedPeaks.add(new ResolvedPeak(chromatogram, currentRegionStart, currentRegionEnd,
-                  msmsRange, rTRangeMSMS));
+                  mzCenterFunction, msmsRange, rTRangeMSMS));
             }
 
             // Set the next region start to current region end-1

--- a/src/main/java/net/sf/mzmine/parameters/parametertypes/CenterMeasureComponent.java
+++ b/src/main/java/net/sf/mzmine/parameters/parametertypes/CenterMeasureComponent.java
@@ -24,7 +24,7 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import net.sf.mzmine.util.maths.CenterFunction;
 import net.sf.mzmine.util.maths.CenterMeasure;
-import net.sf.mzmine.util.maths.Transform;
+import net.sf.mzmine.util.maths.Weighting;
 
 /**
  * Parameter for center measure: median, avg, weighted avg
@@ -35,23 +35,23 @@ public class CenterMeasureComponent extends JPanel {
   private static final long serialVersionUID = 1L;
 
   private final JComboBox<CenterMeasure> comboCenterMeasure;
-  private final JComboBox<Transform> comboTransform;
+  private final JComboBox<Weighting> comboTransform;
   private JLabel labelTrans;
 
   public CenterMeasureComponent() {
-    this(CenterMeasure.values(), Transform.values());
+    this(CenterMeasure.values(), Weighting.values());
   }
 
   public CenterMeasureComponent(CenterMeasure choices[]) {
-    this(choices, Transform.values());
+    this(choices, Weighting.values());
   }
 
-  public CenterMeasureComponent(Transform[] avgTransform) {
+  public CenterMeasureComponent(Weighting[] avgTransform) {
     this(CenterMeasure.values(), avgTransform);
   }
 
-  public CenterMeasureComponent(CenterMeasure choices[], Transform[] avgTransform) {
-    this(choices, avgTransform, CenterMeasure.values()[0], Transform.values()[0]);
+  public CenterMeasureComponent(CenterMeasure choices[], Weighting[] avgTransform) {
+    this(choices, avgTransform, CenterMeasure.values()[0], Weighting.values()[0]);
   }
 
   /**
@@ -61,8 +61,8 @@ public class CenterMeasureComponent extends JPanel {
    * @param selected selected center measure
    * @param selWeighting selected weighting
    */
-  public CenterMeasureComponent(CenterMeasure choices[], Transform[] avgTransform,
-      CenterMeasure selected, Transform selWeighting) {
+  public CenterMeasureComponent(CenterMeasure choices[], Weighting[] avgTransform,
+      CenterMeasure selected, Weighting selWeighting) {
     setBorder(BorderFactory.createEmptyBorder(0, 4, 0, 0));
     comboCenterMeasure = new JComboBox<>(choices);
     add(comboCenterMeasure);
@@ -90,13 +90,13 @@ public class CenterMeasureComponent extends JPanel {
 
   public CenterFunction getSelectedFunction() {
     CenterMeasure measure = (CenterMeasure) comboCenterMeasure.getSelectedItem();
-    Transform trans = Transform.NONE;
+    Weighting trans = Weighting.NONE;
     if (comboTransform.isVisible())
-      trans = (Transform) comboTransform.getSelectedItem();
+      trans = (Weighting) comboTransform.getSelectedItem();
     return new CenterFunction(measure, trans);
   }
 
-  public void setSelectedItem(CenterMeasure newValue, Transform transform) {
+  public void setSelectedItem(CenterMeasure newValue, Weighting transform) {
     comboCenterMeasure.setSelectedItem(newValue);
     comboTransform.setSelectedItem(transform);
   }

--- a/src/main/java/net/sf/mzmine/parameters/parametertypes/CenterMeasureComponent.java
+++ b/src/main/java/net/sf/mzmine/parameters/parametertypes/CenterMeasureComponent.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2006-2018 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+package net.sf.mzmine.parameters.parametertypes;
+
+import java.awt.event.ItemListener;
+import javax.swing.BorderFactory;
+import javax.swing.JComboBox;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import net.sf.mzmine.util.maths.CenterFunction;
+import net.sf.mzmine.util.maths.CenterMeasure;
+import net.sf.mzmine.util.maths.Transform;
+
+/**
+ * Parameter for center measure: median, avg, weighted avg
+ * 
+ */
+public class CenterMeasureComponent extends JPanel {
+
+  private static final long serialVersionUID = 1L;
+
+  private final JComboBox<CenterMeasure> comboCenterMeasure;
+  private final JComboBox<Transform> comboTransform;
+  private JLabel labelTrans;
+
+  public CenterMeasureComponent() {
+    this(CenterMeasure.values(), Transform.values());
+  }
+
+  public CenterMeasureComponent(CenterMeasure choices[]) {
+    this(choices, Transform.values());
+  }
+
+  public CenterMeasureComponent(Transform[] avgTransform) {
+    this(CenterMeasure.values(), avgTransform);
+  }
+
+  public CenterMeasureComponent(CenterMeasure choices[], Transform[] avgTransform) {
+    this(choices, avgTransform, CenterMeasure.values()[0], Transform.values()[0]);
+  }
+
+  /**
+   * 
+   * @param choices
+   * @param avgTransform
+   * @param selected selected center measure
+   * @param selWeighting selected weighting
+   */
+  public CenterMeasureComponent(CenterMeasure choices[], Transform[] avgTransform,
+      CenterMeasure selected, Transform selWeighting) {
+    setBorder(BorderFactory.createEmptyBorder(0, 4, 0, 0));
+    comboCenterMeasure = new JComboBox<>(choices);
+    add(comboCenterMeasure);
+    labelTrans = new JLabel("weighting: ");
+    add(labelTrans);
+    comboTransform = new JComboBox<>(avgTransform);
+    comboTransform.setSelectedItem(selWeighting);
+    add(comboTransform);
+
+    // do not show weighting for median
+    comboCenterMeasure.addItemListener(il -> {
+      boolean visible = comboCenterMeasure.getSelectedItem().equals(CenterMeasure.AVG);
+      comboTransform.setVisible(visible);
+      labelTrans.setVisible(visible);
+      revalidate();
+      repaint();
+    });
+    comboCenterMeasure.setSelectedItem(selected);
+  }
+
+  @Override
+  public void setToolTipText(String toolTip) {
+    comboCenterMeasure.setToolTipText(toolTip);
+  }
+
+  public CenterFunction getSelectedFunction() {
+    CenterMeasure measure = (CenterMeasure) comboCenterMeasure.getSelectedItem();
+    Transform trans = Transform.NONE;
+    if (comboTransform.isVisible())
+      trans = (Transform) comboTransform.getSelectedItem();
+    return new CenterFunction(measure, trans);
+  }
+
+  public void setSelectedItem(CenterMeasure newValue, Transform transform) {
+    comboCenterMeasure.setSelectedItem(newValue);
+    comboTransform.setSelectedItem(transform);
+  }
+
+  @Override
+  public void setEnabled(boolean enabled) {
+    comboCenterMeasure.setEnabled(enabled);
+    comboTransform.setEnabled(enabled);
+  }
+
+  public void addItemListener(ItemListener il) {
+    comboCenterMeasure.addItemListener(il);
+    comboTransform.addItemListener(il);
+  }
+
+  public void setSelectedItem(CenterFunction newValue) {
+    comboTransform.setSelectedItem(newValue.getWeightTransform());
+    comboCenterMeasure.setSelectedItem(newValue.getMeasure());
+  }
+}

--- a/src/main/java/net/sf/mzmine/parameters/parametertypes/CenterMeasureComponent.java
+++ b/src/main/java/net/sf/mzmine/parameters/parametertypes/CenterMeasureComponent.java
@@ -35,7 +35,7 @@ public class CenterMeasureComponent extends JPanel {
   private static final long serialVersionUID = 1L;
 
   private final JComboBox<CenterMeasure> comboCenterMeasure;
-  private final JComboBox<Weighting> comboTransform;
+  private JComboBox<Weighting> comboTransform;
   private JLabel labelTrans;
 
   public CenterMeasureComponent() {
@@ -67,18 +67,21 @@ public class CenterMeasureComponent extends JPanel {
     comboCenterMeasure = new JComboBox<>(choices);
     comboCenterMeasure.setSelectedItem(selected);
     add(comboCenterMeasure);
-    labelTrans = new JLabel("weighting: ");
-    add(labelTrans);
-    comboTransform = new JComboBox<>(avgTransform);
-    comboTransform.setSelectedItem(selWeighting);
-    add(comboTransform);
 
-    // do not show weighting for median
-    comboCenterMeasure.addItemListener(il -> {
+    if (avgTransform != null && avgTransform.length > 0) {
+      labelTrans = new JLabel("weighting: ");
+      add(labelTrans);
+      comboTransform = new JComboBox<>(avgTransform);
+      comboTransform.setSelectedItem(selWeighting);
+      add(comboTransform);
+
+      // do not show weighting for median
+      comboCenterMeasure.addItemListener(il -> {
+        checkWeightingComponentsVisibility();
+      });
+      //
       checkWeightingComponentsVisibility();
-    });
-    //
-    checkWeightingComponentsVisibility();
+    }
   }
 
   private void checkWeightingComponentsVisibility() {
@@ -97,7 +100,7 @@ public class CenterMeasureComponent extends JPanel {
   public CenterFunction getSelectedFunction() {
     CenterMeasure measure = (CenterMeasure) comboCenterMeasure.getSelectedItem();
     Weighting trans = Weighting.NONE;
-    if (comboTransform.isVisible())
+    if (comboTransform != null && comboTransform.isVisible())
       trans = (Weighting) comboTransform.getSelectedItem();
     return new CenterFunction(measure, trans);
   }
@@ -119,7 +122,8 @@ public class CenterMeasureComponent extends JPanel {
   }
 
   public void setSelectedItem(CenterFunction newValue) {
-    comboTransform.setSelectedItem(newValue.getWeightTransform());
     comboCenterMeasure.setSelectedItem(newValue.getMeasure());
+    if (comboTransform != null)
+      comboTransform.setSelectedItem(newValue.getWeightTransform());
   }
 }

--- a/src/main/java/net/sf/mzmine/parameters/parametertypes/CenterMeasureComponent.java
+++ b/src/main/java/net/sf/mzmine/parameters/parametertypes/CenterMeasureComponent.java
@@ -65,6 +65,7 @@ public class CenterMeasureComponent extends JPanel {
       CenterMeasure selected, Weighting selWeighting) {
     setBorder(BorderFactory.createEmptyBorder(0, 4, 0, 0));
     comboCenterMeasure = new JComboBox<>(choices);
+    comboCenterMeasure.setSelectedItem(selected);
     add(comboCenterMeasure);
     labelTrans = new JLabel("weighting: ");
     add(labelTrans);
@@ -74,13 +75,18 @@ public class CenterMeasureComponent extends JPanel {
 
     // do not show weighting for median
     comboCenterMeasure.addItemListener(il -> {
-      boolean visible = comboCenterMeasure.getSelectedItem().equals(CenterMeasure.AVG);
-      comboTransform.setVisible(visible);
-      labelTrans.setVisible(visible);
-      revalidate();
-      repaint();
+      checkWeightingComponentsVisibility();
     });
-    comboCenterMeasure.setSelectedItem(selected);
+    //
+    checkWeightingComponentsVisibility();
+  }
+
+  private void checkWeightingComponentsVisibility() {
+    boolean visible = comboCenterMeasure.getSelectedItem().equals(CenterMeasure.AVG);
+    comboTransform.setVisible(visible);
+    labelTrans.setVisible(visible);
+    revalidate();
+    repaint();
   }
 
   @Override

--- a/src/main/java/net/sf/mzmine/parameters/parametertypes/CenterMeasureParameter.java
+++ b/src/main/java/net/sf/mzmine/parameters/parametertypes/CenterMeasureParameter.java
@@ -44,29 +44,33 @@ public class CenterMeasureParameter
   private Weighting selectedWeighting;
 
 
-  public CenterMeasureParameter(String name) {
-    this(name, CenterMeasure.values(), Weighting.values());
+  public CenterMeasureParameter(String name, String description) {
+    this(name, description, CenterMeasure.values(), Weighting.values());
   }
 
-  public CenterMeasureParameter(String name, CenterMeasure choices[]) {
-    this(name, choices, Weighting.values());
+  public CenterMeasureParameter(String name, String description, CenterMeasure choices[]) {
+    this(name, description, choices, Weighting.values());
   }
 
-  public CenterMeasureParameter(String name, Weighting[] avgTransform) {
-    this(name, CenterMeasure.values(), avgTransform);
+  public CenterMeasureParameter(String name, String description, Weighting[] avgTransform) {
+    this(name, description, CenterMeasure.values(), avgTransform);
   }
 
-  public CenterMeasureParameter(String name, CenterMeasure choices[], Weighting[] avgTransform) {
-    this(name, choices, avgTransform, CenterMeasure.values()[0], Weighting.values()[0]);
+  public CenterMeasureParameter(String name, String description, CenterMeasure choices[],
+      Weighting[] avgTransform) {
+    this(name, description, choices, avgTransform, CenterMeasure.values()[0],
+        Weighting.values()[0]);
   }
 
-  public CenterMeasureParameter(String name, CenterMeasure selectedMeasure) {
-    this(name, CenterMeasure.values(), Weighting.values(), selectedMeasure, Weighting.NONE);
+  public CenterMeasureParameter(String name, String description, CenterMeasure selectedMeasure) {
+    this(name, description, CenterMeasure.values(), Weighting.values(), selectedMeasure,
+        Weighting.NONE);
   }
 
-  public CenterMeasureParameter(String name, CenterMeasure selectedMeasure,
+  public CenterMeasureParameter(String name, String description, CenterMeasure selectedMeasure,
       Weighting selectedWeighting) {
-    this(name, CenterMeasure.values(), Weighting.values(), selectedMeasure, selectedWeighting);
+    this(name, description, CenterMeasure.values(), Weighting.values(), selectedMeasure,
+        selectedWeighting);
   }
 
   /**
@@ -76,15 +80,15 @@ public class CenterMeasureParameter
    * @param selected selected center measure
    * @param selWeighting selected weighting
    */
-  public CenterMeasureParameter(String name, CenterMeasure choices[], Weighting[] weighting,
-      CenterMeasure selectedMeasure, Weighting selectedWeighting) {
+  public CenterMeasureParameter(String name, String description, CenterMeasure choices[],
+      Weighting[] weighting, CenterMeasure selectedMeasure, Weighting selectedWeighting) {
     this.name = name;
-    this.description = "Center measure (weighting options for average calculation)";
+    this.description = description;
     this.weighting = weighting;
     this.choices = choices;
     this.selectedMeasure = selectedMeasure;
-    this.selectedWeighting = selectedWeighting;
-    value = new CenterFunction(selectedMeasure, selectedWeighting);
+    this.selectedWeighting = selectedWeighting == null ? Weighting.NONE : selectedWeighting;
+    value = new CenterFunction(this.selectedMeasure, this.selectedWeighting);
   }
 
   /**
@@ -97,9 +101,7 @@ public class CenterMeasureParameter
 
   @Override
   public CenterMeasureComponent createEditingComponent() {
-    CenterMeasureComponent comboComponent =
-        new CenterMeasureComponent(choices, weighting, selectedMeasure, selectedWeighting);
-    return comboComponent;
+    return new CenterMeasureComponent(choices, weighting, selectedMeasure, selectedWeighting);
   }
 
   @Override
@@ -114,7 +116,7 @@ public class CenterMeasureParameter
 
   @Override
   public CenterMeasureParameter cloneParameter() {
-    CenterMeasureParameter copy = new CenterMeasureParameter(name, choices, weighting,
+    CenterMeasureParameter copy = new CenterMeasureParameter(name, description, choices, weighting,
         value.getMeasure(), value.getWeightTransform());
     copy.value = this.value;
     return copy;

--- a/src/main/java/net/sf/mzmine/parameters/parametertypes/CenterMeasureParameter.java
+++ b/src/main/java/net/sf/mzmine/parameters/parametertypes/CenterMeasureParameter.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2006-2018 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package net.sf.mzmine.parameters.parametertypes;
+
+import java.util.Collection;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.w3c.dom.Element;
+import net.sf.mzmine.parameters.UserParameter;
+import net.sf.mzmine.util.maths.CenterFunction;
+import net.sf.mzmine.util.maths.CenterMeasure;
+import net.sf.mzmine.util.maths.Transform;
+
+/**
+ * Parameter for center measure: median, avg, weighted avg
+ * 
+ */
+public class CenterMeasureParameter
+    implements UserParameter<CenterFunction, CenterMeasureComponent> {
+
+  private Logger logger = Logger.getLogger(getClass().getName());
+
+  private String name, description;
+  private CenterFunction value;
+  private CenterMeasure[] choices;
+  private Transform[] weighting;
+  private CenterMeasure selectedMeasure;
+  private Transform selectedWeighting;
+
+
+  public CenterMeasureParameter() {
+    this(CenterMeasure.values(), Transform.values());
+  }
+
+  public CenterMeasureParameter(CenterMeasure choices[]) {
+    this(choices, Transform.values());
+  }
+
+  public CenterMeasureParameter(Transform[] avgTransform) {
+    this(CenterMeasure.values(), avgTransform);
+  }
+
+  public CenterMeasureParameter(CenterMeasure choices[], Transform[] avgTransform) {
+    this(choices, avgTransform, CenterMeasure.values()[0], Transform.values()[0]);
+  }
+
+  /**
+   * 
+   * @param choices
+   * @param avgTransform
+   * @param selected selected center measure
+   * @param selWeighting selected weighting
+   */
+  public CenterMeasureParameter(CenterMeasure choices[], Transform[] weighting,
+      CenterMeasure selectedMeasure, Transform selectedWeighting) {
+    this.name = "Center measure";
+    this.description = "Center measure (weighting options for average calculation)";
+    this.weighting = weighting;
+    this.choices = choices;
+    this.selectedMeasure = selectedMeasure;
+    this.selectedWeighting = selectedWeighting;
+    value = new CenterFunction(selectedMeasure, selectedWeighting);
+  }
+
+  /**
+   * @see net.sf.mzmine.data.Parameter#getDescription()
+   */
+  @Override
+  public String getDescription() {
+    return description;
+  }
+
+  @Override
+  public CenterMeasureComponent createEditingComponent() {
+    CenterMeasureComponent comboComponent =
+        new CenterMeasureComponent(choices, weighting, selectedMeasure, selectedWeighting);
+    return comboComponent;
+  }
+
+  @Override
+  public CenterFunction getValue() {
+    return value;
+  }
+
+  @Override
+  public void setValue(CenterFunction value) {
+    this.value = value;
+  }
+
+  @Override
+  public CenterMeasureParameter cloneParameter() {
+    CenterMeasureParameter copy = new CenterMeasureParameter(choices, weighting, value.getMeasure(),
+        value.getWeightTransform());
+    copy.value = this.value;
+    return copy;
+  }
+
+  @Override
+  public void setValueFromComponent(CenterMeasureComponent component) {
+    // never null
+    value = component.getSelectedFunction();
+  }
+
+  @Override
+  public void setValueToComponent(CenterMeasureComponent component, CenterFunction newValue) {
+    component.setSelectedItem(newValue);
+  }
+
+  @Override
+  public void loadValueFromXML(Element xmlElement) {
+    try {
+      CenterMeasure measure = CenterMeasure.valueOf(xmlElement.getAttribute("measure"));
+      Transform weighting = Transform.valueOf(xmlElement.getAttribute("weighting"));
+      value = new CenterFunction(measure, weighting);
+    } catch (Exception e) {
+      logger.log(Level.WARNING, "center measure cannot be loaded from xml", e);
+    }
+  }
+
+  @Override
+  public void saveValueToXML(Element xmlElement) {
+    if (value == null)
+      return;
+    xmlElement.setTextContent("CenterFunction");
+    xmlElement.setAttribute("measure", value.getMeasure().name());
+    xmlElement.setAttribute("weighting", value.getWeightTransform().name());
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String toString() {
+    return name;
+  }
+
+  @Override
+  public boolean checkValue(Collection<String> errorMessages) {
+    if (value == null) {
+      errorMessages.add(name + " is not set properly");
+      return false;
+    }
+    return true;
+  }
+
+}

--- a/src/main/java/net/sf/mzmine/parameters/parametertypes/CenterMeasureParameter.java
+++ b/src/main/java/net/sf/mzmine/parameters/parametertypes/CenterMeasureParameter.java
@@ -25,7 +25,7 @@ import org.w3c.dom.Element;
 import net.sf.mzmine.parameters.UserParameter;
 import net.sf.mzmine.util.maths.CenterFunction;
 import net.sf.mzmine.util.maths.CenterMeasure;
-import net.sf.mzmine.util.maths.Transform;
+import net.sf.mzmine.util.maths.Weighting;
 
 /**
  * Parameter for center measure: median, avg, weighted avg
@@ -39,25 +39,33 @@ public class CenterMeasureParameter
   private String name, description;
   private CenterFunction value;
   private CenterMeasure[] choices;
-  private Transform[] weighting;
+  private Weighting[] weighting;
   private CenterMeasure selectedMeasure;
-  private Transform selectedWeighting;
+  private Weighting selectedWeighting;
 
 
   public CenterMeasureParameter() {
-    this(CenterMeasure.values(), Transform.values());
+    this(CenterMeasure.values(), Weighting.values());
   }
 
   public CenterMeasureParameter(CenterMeasure choices[]) {
-    this(choices, Transform.values());
+    this(choices, Weighting.values());
   }
 
-  public CenterMeasureParameter(Transform[] avgTransform) {
+  public CenterMeasureParameter(Weighting[] avgTransform) {
     this(CenterMeasure.values(), avgTransform);
   }
 
-  public CenterMeasureParameter(CenterMeasure choices[], Transform[] avgTransform) {
-    this(choices, avgTransform, CenterMeasure.values()[0], Transform.values()[0]);
+  public CenterMeasureParameter(CenterMeasure choices[], Weighting[] avgTransform) {
+    this(choices, avgTransform, CenterMeasure.values()[0], Weighting.values()[0]);
+  }
+
+  public CenterMeasureParameter(CenterMeasure selectedMeasure) {
+    this(CenterMeasure.values(), Weighting.values(), selectedMeasure, Weighting.NONE);
+  }
+
+  public CenterMeasureParameter(CenterMeasure selectedMeasure, Weighting selectedWeighting) {
+    this(CenterMeasure.values(), Weighting.values(), selectedMeasure, selectedWeighting);
   }
 
   /**
@@ -67,8 +75,8 @@ public class CenterMeasureParameter
    * @param selected selected center measure
    * @param selWeighting selected weighting
    */
-  public CenterMeasureParameter(CenterMeasure choices[], Transform[] weighting,
-      CenterMeasure selectedMeasure, Transform selectedWeighting) {
+  public CenterMeasureParameter(CenterMeasure choices[], Weighting[] weighting,
+      CenterMeasure selectedMeasure, Weighting selectedWeighting) {
     this.name = "Center measure";
     this.description = "Center measure (weighting options for average calculation)";
     this.weighting = weighting;
@@ -126,7 +134,7 @@ public class CenterMeasureParameter
   public void loadValueFromXML(Element xmlElement) {
     try {
       CenterMeasure measure = CenterMeasure.valueOf(xmlElement.getAttribute("measure"));
-      Transform weighting = Transform.valueOf(xmlElement.getAttribute("weighting"));
+      Weighting weighting = Weighting.valueOf(xmlElement.getAttribute("weighting"));
       value = new CenterFunction(measure, weighting);
     } catch (Exception e) {
       logger.log(Level.WARNING, "center measure cannot be loaded from xml", e);

--- a/src/main/java/net/sf/mzmine/parameters/parametertypes/CenterMeasureParameter.java
+++ b/src/main/java/net/sf/mzmine/parameters/parametertypes/CenterMeasureParameter.java
@@ -44,28 +44,29 @@ public class CenterMeasureParameter
   private Weighting selectedWeighting;
 
 
-  public CenterMeasureParameter() {
-    this(CenterMeasure.values(), Weighting.values());
+  public CenterMeasureParameter(String name) {
+    this(name, CenterMeasure.values(), Weighting.values());
   }
 
-  public CenterMeasureParameter(CenterMeasure choices[]) {
-    this(choices, Weighting.values());
+  public CenterMeasureParameter(String name, CenterMeasure choices[]) {
+    this(name, choices, Weighting.values());
   }
 
-  public CenterMeasureParameter(Weighting[] avgTransform) {
-    this(CenterMeasure.values(), avgTransform);
+  public CenterMeasureParameter(String name, Weighting[] avgTransform) {
+    this(name, CenterMeasure.values(), avgTransform);
   }
 
-  public CenterMeasureParameter(CenterMeasure choices[], Weighting[] avgTransform) {
-    this(choices, avgTransform, CenterMeasure.values()[0], Weighting.values()[0]);
+  public CenterMeasureParameter(String name, CenterMeasure choices[], Weighting[] avgTransform) {
+    this(name, choices, avgTransform, CenterMeasure.values()[0], Weighting.values()[0]);
   }
 
-  public CenterMeasureParameter(CenterMeasure selectedMeasure) {
-    this(CenterMeasure.values(), Weighting.values(), selectedMeasure, Weighting.NONE);
+  public CenterMeasureParameter(String name, CenterMeasure selectedMeasure) {
+    this(name, CenterMeasure.values(), Weighting.values(), selectedMeasure, Weighting.NONE);
   }
 
-  public CenterMeasureParameter(CenterMeasure selectedMeasure, Weighting selectedWeighting) {
-    this(CenterMeasure.values(), Weighting.values(), selectedMeasure, selectedWeighting);
+  public CenterMeasureParameter(String name, CenterMeasure selectedMeasure,
+      Weighting selectedWeighting) {
+    this(name, CenterMeasure.values(), Weighting.values(), selectedMeasure, selectedWeighting);
   }
 
   /**
@@ -75,9 +76,9 @@ public class CenterMeasureParameter
    * @param selected selected center measure
    * @param selWeighting selected weighting
    */
-  public CenterMeasureParameter(CenterMeasure choices[], Weighting[] weighting,
+  public CenterMeasureParameter(String name, CenterMeasure choices[], Weighting[] weighting,
       CenterMeasure selectedMeasure, Weighting selectedWeighting) {
-    this.name = "Center measure";
+    this.name = name;
     this.description = "Center measure (weighting options for average calculation)";
     this.weighting = weighting;
     this.choices = choices;
@@ -113,8 +114,8 @@ public class CenterMeasureParameter
 
   @Override
   public CenterMeasureParameter cloneParameter() {
-    CenterMeasureParameter copy = new CenterMeasureParameter(choices, weighting, value.getMeasure(),
-        value.getWeightTransform());
+    CenterMeasureParameter copy = new CenterMeasureParameter(name, choices, weighting,
+        value.getMeasure(), value.getWeightTransform());
     copy.value = this.value;
     return copy;
   }

--- a/src/main/java/net/sf/mzmine/util/MathUtils.java
+++ b/src/main/java/net/sf/mzmine/util/MathUtils.java
@@ -21,7 +21,7 @@ package net.sf.mzmine.util;
 import java.util.Arrays;
 import java.util.stream.DoubleStream;
 import net.sf.mzmine.util.maths.CenterMeasure;
-import net.sf.mzmine.util.maths.Transform;
+import net.sf.mzmine.util.maths.Weighting;
 
 /**
  * Mathematical calculation-related helper class
@@ -52,11 +52,11 @@ public class MathUtils {
    * @param center
    * @param values
    * @param weights
-   * @param transform only used for center measure AVG (can also be Transform.NONE)
+   * @param transform only used for center measure AVG (can also be Weighting.NONE)
    * @return
    */
   public static double calcCenter(CenterMeasure center, double[] values, double[] weights,
-      Transform transform) {
+      Weighting transform) {
     switch (center) {
       case AVG:
         return calcWeightedAvg(values, weights, transform);
@@ -199,7 +199,7 @@ public class MathUtils {
   }
 
   /**
-   * Weighted average without weight transformation
+   * Weighted average with linear weights
    * 
    * @param values
    * @param weights
@@ -207,7 +207,7 @@ public class MathUtils {
    * @throws Exception
    */
   public static double calcWeightedAvg(double[] values, double[] weights) {
-    return calcWeightedAvg(values, weights, Transform.NONE);
+    return calcWeightedAvg(values, weights, Weighting.LINEAR);
   }
 
   /**
@@ -219,15 +219,13 @@ public class MathUtils {
    * @return the weighted average (or Double.NaN if no values supplied or the lengths of the arrays
    *         was different)
    */
-  public static double calcWeightedAvg(double[] values, double[] weights, Transform transform) {
+  public static double calcWeightedAvg(double[] values, double[] weights, Weighting transform) {
     if (values == null || weights == null || values.length != weights.length)
       return Double.NaN;
 
     // transform
-    double[] realWeights = weights;
-    if (!transform.equals(Transform.NONE)) {
-      realWeights = transform.transform(weights);
-    }
+    double[] realWeights = transform.transform(weights);
+
     // sum of weights
     double weightSum = DoubleStream.of(realWeights).sum();
 

--- a/src/main/java/net/sf/mzmine/util/MathUtils.java
+++ b/src/main/java/net/sf/mzmine/util/MathUtils.java
@@ -224,7 +224,10 @@ public class MathUtils {
       return Double.NaN;
 
     // transform
-    double[] realWeights = transform.transform(weights);
+    double[] realWeights = weights;
+
+    if (transform != null)
+      realWeights = transform.transform(weights);
 
     // sum of weights
     double weightSum = DoubleStream.of(realWeights).sum();

--- a/src/main/java/net/sf/mzmine/util/maths/CenterFunction.java
+++ b/src/main/java/net/sf/mzmine/util/maths/CenterFunction.java
@@ -5,13 +5,13 @@ import net.sf.mzmine.util.MathUtils;
 public class CenterFunction {
   private final CenterMeasure measure;
   // weight transform is only applied to avg
-  private final Transform weightTransform;
+  private final Weighting weightTransform;
 
   public CenterFunction(CenterMeasure measure) {
-    this(measure, Transform.NONE);
+    this(measure, Weighting.NONE);
   }
 
-  public CenterFunction(CenterMeasure measure, Transform weightTransform) {
+  public CenterFunction(CenterMeasure measure, Weighting weightTransform) {
     super();
     this.measure = measure;
     this.weightTransform = weightTransform;
@@ -21,7 +21,7 @@ public class CenterFunction {
     return measure;
   }
 
-  public Transform getWeightTransform() {
+  public Weighting getWeightTransform() {
     return weightTransform;
   }
 

--- a/src/main/java/net/sf/mzmine/util/maths/CenterFunction.java
+++ b/src/main/java/net/sf/mzmine/util/maths/CenterFunction.java
@@ -1,11 +1,17 @@
 package net.sf.mzmine.util.maths;
 
+import javax.annotation.Nullable;
 import net.sf.mzmine.util.MathUtils;
 
 public class CenterFunction {
   private final CenterMeasure measure;
   // weight transform is only applied to avg
   private final Weighting weightTransform;
+
+  // divide weight== noiseLevel will be 1
+  private @Nullable Double noiseLevel = null;
+  // cap weight to a max
+  private @Nullable Double maxWeight = null;
 
   public CenterFunction(CenterMeasure measure) {
     this(measure, Weighting.NONE);
@@ -17,12 +23,37 @@ public class CenterFunction {
     this.weightTransform = weightTransform;
   }
 
+  public CenterFunction(CenterMeasure measure, Weighting weightTransform, double noiseLevel,
+      double maxWeight) {
+    this(measure, weightTransform);
+    this.noiseLevel = noiseLevel;
+    this.maxWeight = maxWeight;
+  }
+
   public CenterMeasure getMeasure() {
     return measure;
   }
 
   public Weighting getWeightTransform() {
     return weightTransform;
+  }
+
+  /**
+   * Cap weight at a maximum. null for no maxWeight
+   * 
+   * @param maxWeight
+   */
+  public void setMaxWeight(Double maxWeight) {
+    this.maxWeight = maxWeight;
+  }
+
+  /**
+   * noise level will have weight 1. null No noise level
+   * 
+   * @param noiseLevel
+   */
+  public void setNoiseLevel(Double noiseLevel) {
+    this.noiseLevel = noiseLevel;
   }
 
 
@@ -47,6 +78,6 @@ public class CenterFunction {
    * @return
    */
   public double calcCenter(double[] values, double[] weights) {
-    return MathUtils.calcCenter(measure, values, weights, weightTransform);
+    return MathUtils.calcCenter(measure, values, weights, weightTransform, noiseLevel, maxWeight);
   }
 }

--- a/src/main/java/net/sf/mzmine/util/maths/CenterFunction.java
+++ b/src/main/java/net/sf/mzmine/util/maths/CenterFunction.java
@@ -1,0 +1,52 @@
+package net.sf.mzmine.util.maths;
+
+import net.sf.mzmine.util.MathUtils;
+
+public class CenterFunction {
+  private final CenterMeasure measure;
+  // weight transform is only applied to avg
+  private final Transform weightTransform;
+
+  public CenterFunction(CenterMeasure measure) {
+    this(measure, Transform.NONE);
+  }
+
+  public CenterFunction(CenterMeasure measure, Transform weightTransform) {
+    super();
+    this.measure = measure;
+    this.weightTransform = weightTransform;
+  }
+
+  public CenterMeasure getMeasure() {
+    return measure;
+  }
+
+  public Transform getWeightTransform() {
+    return weightTransform;
+  }
+
+
+  /**
+   * median or non-weighted average
+   * 
+   * @param center
+   * @param values
+   * @return
+   */
+  public double calcCenter(double[] values) {
+    return MathUtils.calcCenter(measure, values);
+  }
+
+  /**
+   * median or weighted average
+   * 
+   * @param center
+   * @param values
+   * @param weights
+   * @param transform only used for center measure AVG (can also be Transform.NONE)
+   * @return
+   */
+  public double calcCenter(double[] values, double[] weights) {
+    return MathUtils.calcCenter(measure, values, weights, weightTransform);
+  }
+}

--- a/src/main/java/net/sf/mzmine/util/maths/CenterMeasure.java
+++ b/src/main/java/net/sf/mzmine/util/maths/CenterMeasure.java
@@ -1,0 +1,5 @@
+package net.sf.mzmine.util.maths;
+
+public enum CenterMeasure {
+  MEDIAN, AVG;
+}

--- a/src/main/java/net/sf/mzmine/util/maths/CenterMeasure.java
+++ b/src/main/java/net/sf/mzmine/util/maths/CenterMeasure.java
@@ -1,5 +1,5 @@
 package net.sf.mzmine.util.maths;
 
 public enum CenterMeasure {
-  MEDIAN, AVG;
+  AUTO, MEDIAN, AVG;
 }

--- a/src/main/java/net/sf/mzmine/util/maths/Transform.java
+++ b/src/main/java/net/sf/mzmine/util/maths/Transform.java
@@ -1,9 +1,69 @@
 package net.sf.mzmine.util.maths;
 
-@FunctionalInterface
-public interface Transform {
+import java.util.stream.DoubleStream;
 
-  public static final Transform LOG = Math::log;
+public enum Transform {
 
-  public double transform(double v);
+  // no transform
+  NONE("none", v -> v),
+  // LOG
+  LOG10("LOG10", Math::log), LOG2("LOG2", Math::log),
+  /**
+   * Sqare-root
+   */
+  SQRT("SQRT", "sqare root", Math::sqrt),
+  /**
+   * cube-root
+   */
+  CBRT("CBRT", "cube root", Math::cbrt);
+
+  //
+  private String label;
+  private TransformFunction f;
+  private String description;
+
+  Transform(String label, TransformFunction f) {
+    this(label, label, f);
+  }
+
+  Transform(String label, String description, TransformFunction f) {
+    this.label = label;
+    this.description = description;
+    this.f = f;
+  }
+
+  /**
+   * Transform value
+   * 
+   * @param v
+   * @return
+   */
+  public double transform(double v) {
+    return f.transform(v);
+  }
+
+  /**
+   * Transform array
+   * 
+   * @param values
+   * @return
+   */
+  public double[] transform(double[] values) {
+    return DoubleStream.of(values).map(v -> f.transform(v)).toArray();
+  }
+
+  public String getLabel() {
+    return label;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+
+
+  @FunctionalInterface
+  private interface TransformFunction {
+    public double transform(double v);
+  }
 }

--- a/src/main/java/net/sf/mzmine/util/maths/Transform.java
+++ b/src/main/java/net/sf/mzmine/util/maths/Transform.java
@@ -1,0 +1,9 @@
+package net.sf.mzmine.util.maths;
+
+@FunctionalInterface
+public interface Transform {
+
+  public static final Transform LOG = Math::log;
+
+  public double transform(double v);
+}

--- a/src/main/java/net/sf/mzmine/util/maths/Weighting.java
+++ b/src/main/java/net/sf/mzmine/util/maths/Weighting.java
@@ -7,9 +7,9 @@ public enum Weighting {
   NONE("NONE", v -> 1),
   // linear -> no transform
   LINEAR("LINEAR", v -> v),
-  // LOG
-  LOG10("LOG10", Math::log), //
-  LOG2("LOG2", Math::log),
+  // LOG: put to zero weight if it was zero
+  LOG10("LOG10", v -> v == 0 ? 0 : Math.log10(v)), //
+  LOG2("LOG2", v -> v == 0 ? 0 : Math.log(v) / Math.log(2)),
   /**
    * Sqare-root
    */

--- a/src/main/java/net/sf/mzmine/util/maths/Weighting.java
+++ b/src/main/java/net/sf/mzmine/util/maths/Weighting.java
@@ -2,12 +2,14 @@ package net.sf.mzmine.util.maths;
 
 import java.util.stream.DoubleStream;
 
-public enum Transform {
-
-  // no transform
-  NONE("none", v -> v),
+public enum Weighting {
+  // no weighting
+  NONE("NONE", v -> 1),
+  // linear -> no transform
+  LINEAR("LINEAR", v -> v),
   // LOG
-  LOG10("LOG10", Math::log), LOG2("LOG2", Math::log),
+  LOG10("LOG10", Math::log), //
+  LOG2("LOG2", Math::log),
   /**
    * Sqare-root
    */
@@ -22,11 +24,11 @@ public enum Transform {
   private TransformFunction f;
   private String description;
 
-  Transform(String label, TransformFunction f) {
+  Weighting(String label, TransformFunction f) {
     this(label, label, f);
   }
 
-  Transform(String label, String description, TransformFunction f) {
+  Weighting(String label, String description, TransformFunction f) {
     this.label = label;
     this.description = description;
     this.f = f;

--- a/src/main/java/net/sf/mzmine/util/maths/Weighting.java
+++ b/src/main/java/net/sf/mzmine/util/maths/Weighting.java
@@ -45,13 +45,46 @@ public enum Weighting {
   }
 
   /**
+   * e.g., lOG(weight)-LOG(noise)
+   * 
+   * @param weight
+   * @param noiseLevel
+   * @param maxWeight
+   * @return
+   */
+  public double transform(double weight, Double noiseLevel, Double maxWeight) {
+    // e.g., lOG(weight)-LOG(noise)
+    double real = 0;
+    if (noiseLevel != null)
+      real = f.transform(weight) - f.transform(noiseLevel);
+    else
+      real = f.transform(weight);
+
+    if (maxWeight != null)
+      real = Math.min(real, maxWeight);
+    return Math.max(0, real);
+  }
+
+  /**
    * Transform array
    * 
    * @param values
    * @return
    */
-  public double[] transform(double[] values) {
-    return DoubleStream.of(values).map(v -> f.transform(v)).toArray();
+  public double[] transform(double[] weights) {
+    return DoubleStream.of(weights).map(this::transform).toArray();
+  }
+
+  /**
+   * Transform array with noiseLevel and maxHeight
+   * 
+   * @param weights
+   * @param noiseLevel
+   * @param maxWeight
+   * @return
+   */
+  public double[] transform(double[] weights, Double noiseLevel, Double maxWeight) {
+    return DoubleStream.of(weights).map(v -> transform(v, noiseLevel, maxWeight)).toArray();
   }
 
   public String getLabel() {
@@ -62,10 +95,9 @@ public enum Weighting {
     return description;
   }
 
-
-
   @FunctionalInterface
   private interface TransformFunction {
     public double transform(double v);
   }
+
 }


### PR DESCRIPTION
Hey Tomas,

this PR adds a CenterMeasureParameter to the deconvolution. To avoid breakage of old batch files, this parameter is automatically set to the current MZmine standard (median).

However, this is a convenient way to set the function how mzmine calculates the central m/z value of all data points in a feature. 

- median is a good choice if you have many data points
- average or weighted average is good if ...
  - ... a feature has few data points
  - ... the mass accuracy drastically decreases for low abundant data points (LOG10 weighted-avg)


This PR also includes fix #510 


Cheers 
Robin

![image](https://user-images.githubusercontent.com/10366914/49057874-64a9ed80-f1b6-11e8-8efc-ff8b63b02f94.png)
![image](https://user-images.githubusercontent.com/10366914/49058199-d59dd500-f1b7-11e8-98dd-6249de1a60d3.png)

