### PR TITLE
Added getTaskPriority method for standard priority of a task

### DIFF
--- a/src/main/java/net/sf/mzmine/main/MZmineModulesList.java
+++ b/src/main/java/net/sf/mzmine/main/MZmineModulesList.java
@@ -55,7 +55,7 @@ import net.sf.mzmine.modules.peaklistmethods.identification.onlinedbsearch.Onlin
 import net.sf.mzmine.modules.peaklistmethods.identification.sirius.SiriusProcessingModule;
 import net.sf.mzmine.modules.peaklistmethods.io.casmiimport.CasmiImportModule;
 import net.sf.mzmine.modules.peaklistmethods.io.csvexport.CSVExportModule;
-import net.sf.mzmine.modules.peaklistmethods.io.gnpsexport.GNPSExportModule;
+import net.sf.mzmine.modules.peaklistmethods.io.gnpsexport.GNPSExportAndSubmitModule;
 import net.sf.mzmine.modules.peaklistmethods.io.metaboanalystexport.MetaboAnalystExportModule;
 import net.sf.mzmine.modules.peaklistmethods.io.mgfexport.MGFExportModule;
 import net.sf.mzmine.modules.peaklistmethods.io.mspexport.MSPExportModule;
@@ -151,7 +151,7 @@ public class MZmineModulesList {
       CSVExportModule.class, MetaboAnalystExportModule.class, MzTabExportModule.class,
       SQLExportModule.class, XMLExportModule.class, CasmiImportModule.class,
       MzTabImportModule.class, XMLImportModule.class, MSPExportModule.class, MGFExportModule.class,
-      GNPSExportModule.class, SiriusExportModule.class,
+      GNPSExportAndSubmitModule.class, SiriusExportModule.class,
 
       // Gap filling
       PeakFinderModule.class, MultiThreadPeakFinderModule.class, SameRangeGapFillerModule.class,

--- a/src/main/java/net/sf/mzmine/modules/batchmode/BatchModeModule.java
+++ b/src/main/java/net/sf/mzmine/modules/batchmode/BatchModeModule.java
@@ -22,22 +22,17 @@ import java.io.File;
 import java.util.Collection;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
 import javax.annotation.Nonnull;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
-
+import org.w3c.dom.Document;
 import net.sf.mzmine.datamodel.MZmineProject;
-import net.sf.mzmine.main.MZmineCore;
 import net.sf.mzmine.modules.MZmineModuleCategory;
 import net.sf.mzmine.modules.MZmineProcessingModule;
 import net.sf.mzmine.parameters.ParameterSet;
 import net.sf.mzmine.taskcontrol.Task;
-import net.sf.mzmine.taskcontrol.TaskPriority;
 import net.sf.mzmine.taskcontrol.TaskStatus;
 import net.sf.mzmine.util.ExitCode;
-
-import org.w3c.dom.Document;
 
 /**
  * Batch mode module
@@ -70,9 +65,9 @@ public class BatchModeModule implements MZmineProcessingModule {
      * We do not add the task to the tasks collection, but instead directly submit to the task
      * controller, because we need to set the priority to HIGH. If the priority is not HIGH and the
      * maximum number of concurrent tasks is set to 1 in the MZmine preferences, then this BatchTask
-     * would block all other tasks.
+     * would block all other tasks. See getTaskPriority in BatchTask
      */
-    MZmineCore.getTaskController().addTask(newTask, TaskPriority.HIGH);
+    tasks.add(newTask);
 
     return ExitCode.OK;
   }

--- a/src/main/java/net/sf/mzmine/modules/batchmode/BatchTask.java
+++ b/src/main/java/net/sf/mzmine/modules/batchmode/BatchTask.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Logger;
-
 import net.sf.mzmine.datamodel.MZmineProject;
 import net.sf.mzmine.datamodel.MZmineProjectListener;
 import net.sf.mzmine.datamodel.PeakList;
@@ -36,6 +35,7 @@ import net.sf.mzmine.parameters.parametertypes.selectors.PeakListsParameter;
 import net.sf.mzmine.parameters.parametertypes.selectors.RawDataFilesParameter;
 import net.sf.mzmine.taskcontrol.AbstractTask;
 import net.sf.mzmine.taskcontrol.Task;
+import net.sf.mzmine.taskcontrol.TaskPriority;
 import net.sf.mzmine.taskcontrol.TaskStatus;
 import net.sf.mzmine.util.ExitCode;
 
@@ -64,6 +64,7 @@ public class BatchTask extends AbstractTask {
     previousCreatedPeakLists = new ArrayList<>();
   }
 
+  @Override
   public void run() {
 
     setStatus(TaskStatus.PROCESSING);
@@ -235,12 +236,20 @@ public class BatchTask extends AbstractTask {
 
   }
 
+  @Override
+  public TaskPriority getTaskPriority() {
+    // to not block mzmine when run with single thread
+    return TaskPriority.HIGH;
+  }
+
+  @Override
   public double getFinishedPercentage() {
     if (totalSteps == 0)
       return 0;
     return (double) processedSteps / totalSteps;
   }
 
+  @Override
   public String getTaskDescription() {
     return "Batch of " + totalSteps + " steps";
   }

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/dataanalysis/clustering/ClusteringTask.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/dataanalysis/clustering/ClusteringTask.java
@@ -22,12 +22,9 @@ import java.text.DecimalFormat;
 import java.util.List;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
-
 import javax.swing.JFrame;
 import javax.swing.JTextField;
-
 import org.jfree.data.xy.AbstractXYDataset;
-
 import jmprojection.PCA;
 import jmprojection.Preprocess;
 import jmprojection.ProjectionStatus;
@@ -43,6 +40,7 @@ import net.sf.mzmine.modules.peaklistmethods.dataanalysis.clustering.hierarchica
 import net.sf.mzmine.modules.peaklistmethods.dataanalysis.projectionplots.ProjectionPlotDataset;
 import net.sf.mzmine.modules.peaklistmethods.dataanalysis.projectionplots.ProjectionPlotWindow;
 import net.sf.mzmine.parameters.ParameterSet;
+import net.sf.mzmine.taskcontrol.TaskPriority;
 import net.sf.mzmine.taskcontrol.TaskStatus;
 import net.sf.mzmine.util.PeakMeasurementType;
 import weka.core.Attribute;
@@ -103,10 +101,12 @@ public class ClusteringTask extends AbstractXYDataset implements ProjectionPlotD
     return datasetTitle;
   }
 
+  @Override
   public String getXLabel() {
     return "1st projected dimension";
   }
 
+  @Override
   public String getYLabel() {
     return "2nd projected dimension";
   }
@@ -121,18 +121,22 @@ public class ClusteringTask extends AbstractXYDataset implements ProjectionPlotD
     return 1;
   }
 
+  @Override
   public int getItemCount(int series) {
     return component1Coords.length;
   }
 
+  @Override
   public Number getX(int series, int item) {
     return component1Coords[item];
   }
 
+  @Override
   public Number getY(int series, int item) {
     return component2Coords[item];
   }
 
+  @Override
   public String getRawDataFile(int item) {
     if (typeOfData == ClusteringDataType.VARIABLES) {
       String name = "ID: " + this.selectedRows[item].getID();
@@ -148,6 +152,7 @@ public class ClusteringTask extends AbstractXYDataset implements ProjectionPlotD
     }
   }
 
+  @Override
   public int getGroupNumber(int item) {
     if (typeOfData == ClusteringDataType.VARIABLES) {
       return groupsForSelectedVariables[item];
@@ -156,6 +161,7 @@ public class ClusteringTask extends AbstractXYDataset implements ProjectionPlotD
     }
   }
 
+  @Override
   public Object getGroupParameterValue(int groupNumber) {
     if (parameterValuesForGroups == null) {
       return null;
@@ -166,10 +172,12 @@ public class ClusteringTask extends AbstractXYDataset implements ProjectionPlotD
     return parameterValuesForGroups[groupNumber];
   }
 
+  @Override
   public int getNumberOfGroups() {
     return finalNumberOfGroups;
   }
 
+  @Override
   public void run() {
 
     status = TaskStatus.PROCESSING;
@@ -255,7 +263,7 @@ public class ClusteringTask extends AbstractXYDataset implements ProjectionPlotD
         }
 
         ClusteringReportWindow reportWindow = new ClusteringReportWindow(sampleNames,
-            (Integer[]) clusteringResult.toArray(new Integer[0]), "Clustering Report");
+            clusteringResult.toArray(new Integer[0]), "Clustering Report");
         reportWindow.setVisible(true);
       } else {
         String[] variableNames = new String[selectedRows.length];
@@ -269,7 +277,7 @@ public class ClusteringTask extends AbstractXYDataset implements ProjectionPlotD
         }
 
         ClusteringReportWindow reportWindow = new ClusteringReportWindow(variableNames,
-            (Integer[]) clusteringResult.toArray(new Integer[0]), "Clustering Report");
+            clusteringResult.toArray(new Integer[0]), "Clustering Report");
         reportWindow.setVisible(true);
 
       }
@@ -464,6 +472,7 @@ public class ClusteringTask extends AbstractXYDataset implements ProjectionPlotD
     return data;
   }
 
+  @Override
   public void cancel() {
     if (projectionStatus != null) {
       projectionStatus.cancel();
@@ -472,10 +481,12 @@ public class ClusteringTask extends AbstractXYDataset implements ProjectionPlotD
     status = TaskStatus.CANCELED;
   }
 
+  @Override
   public String getErrorMessage() {
     return errorMessage;
   }
 
+  @Override
   public TaskStatus getStatus() {
     return status;
   }
@@ -514,5 +525,10 @@ public class ClusteringTask extends AbstractXYDataset implements ProjectionPlotD
       progress++;
       return ((double) progress / 100);
     }
+  }
+
+  @Override
+  public TaskPriority getTaskPriority() {
+    return TaskPriority.NORMAL;
   }
 }

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/dataanalysis/projectionplots/CDADataset.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/dataanalysis/projectionplots/CDADataset.java
@@ -20,9 +20,7 @@ package net.sf.mzmine.modules.peaklistmethods.dataanalysis.projectionplots;
 
 import java.util.Vector;
 import java.util.logging.Logger;
-
 import org.jfree.data.xy.AbstractXYDataset;
-
 import jmprojection.CDA;
 import jmprojection.Preprocess;
 import jmprojection.ProjectionStatus;
@@ -33,6 +31,7 @@ import net.sf.mzmine.datamodel.PeakListRow;
 import net.sf.mzmine.datamodel.RawDataFile;
 import net.sf.mzmine.parameters.ParameterSet;
 import net.sf.mzmine.parameters.UserParameter;
+import net.sf.mzmine.taskcontrol.TaskPriority;
 import net.sf.mzmine.taskcontrol.TaskStatus;
 import net.sf.mzmine.util.PeakMeasurementType;
 
@@ -124,10 +123,17 @@ public class CDADataset extends AbstractXYDataset implements ProjectionPlotDatas
 
   }
 
+  @Override
+  public TaskPriority getTaskPriority() {
+    return TaskPriority.NORMAL;
+  }
+
+  @Override
   public String toString() {
     return datasetTitle;
   }
 
+  @Override
   public String getXLabel() {
     if (xAxisDimension == 1)
       return "1st projected dimension";
@@ -138,6 +144,7 @@ public class CDADataset extends AbstractXYDataset implements ProjectionPlotDatas
     return "" + xAxisDimension + "th projected dimension";
   }
 
+  @Override
   public String getYLabel() {
     if (yAxisDimension == 1)
       return "1st projected dimension";
@@ -158,26 +165,32 @@ public class CDADataset extends AbstractXYDataset implements ProjectionPlotDatas
     return 1;
   }
 
+  @Override
   public int getItemCount(int series) {
     return component1Coords.length;
   }
 
+  @Override
   public Number getX(int series, int item) {
     return component1Coords[item];
   }
 
+  @Override
   public Number getY(int series, int item) {
     return component2Coords[item];
   }
 
+  @Override
   public String getRawDataFile(int item) {
     return selectedRawDataFiles[item].getName();
   }
 
+  @Override
   public int getGroupNumber(int item) {
     return groupsForSelectedRawDataFiles[item];
   }
 
+  @Override
   public Object getGroupParameterValue(int groupNumber) {
     if (parameterValuesForGroups == null)
       return null;
@@ -186,10 +199,12 @@ public class CDADataset extends AbstractXYDataset implements ProjectionPlotDatas
     return parameterValuesForGroups[groupNumber];
   }
 
+  @Override
   public int getNumberOfGroups() {
     return numberOfGroups;
   }
 
+  @Override
   public void run() {
 
     status = TaskStatus.PROCESSING;
@@ -256,24 +271,29 @@ public class CDADataset extends AbstractXYDataset implements ProjectionPlotDatas
 
   }
 
+  @Override
   public void cancel() {
     if (projectionStatus != null)
       projectionStatus.cancel();
     status = TaskStatus.CANCELED;
   }
 
+  @Override
   public String getErrorMessage() {
     return errorMessage;
   }
 
+  @Override
   public TaskStatus getStatus() {
     return status;
   }
 
+  @Override
   public String getTaskDescription() {
     return "CDA projection";
   }
 
+  @Override
   public double getFinishedPercentage() {
     if (projectionStatus == null)
       return 0;

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/dataanalysis/projectionplots/PCADataset.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/dataanalysis/projectionplots/PCADataset.java
@@ -20,9 +20,7 @@ package net.sf.mzmine.modules.peaklistmethods.dataanalysis.projectionplots;
 
 import java.util.Vector;
 import java.util.logging.Logger;
-
 import org.jfree.data.xy.AbstractXYDataset;
-
 import jmprojection.PCA;
 import jmprojection.Preprocess;
 import jmprojection.ProjectionStatus;
@@ -33,6 +31,7 @@ import net.sf.mzmine.datamodel.PeakListRow;
 import net.sf.mzmine.datamodel.RawDataFile;
 import net.sf.mzmine.parameters.ParameterSet;
 import net.sf.mzmine.parameters.UserParameter;
+import net.sf.mzmine.taskcontrol.TaskPriority;
 import net.sf.mzmine.taskcontrol.TaskStatus;
 import net.sf.mzmine.util.PeakMeasurementType;
 
@@ -123,10 +122,17 @@ public class PCADataset extends AbstractXYDataset implements ProjectionPlotDatas
 
   }
 
+  @Override
+  public TaskPriority getTaskPriority() {
+    return TaskPriority.NORMAL;
+  }
+
+  @Override
   public String toString() {
     return datasetTitle;
   }
 
+  @Override
   public String getXLabel() {
     if (xAxisPC == 1)
       return "1st PC";
@@ -137,6 +143,7 @@ public class PCADataset extends AbstractXYDataset implements ProjectionPlotDatas
     return "" + xAxisPC + "th PC";
   }
 
+  @Override
   public String getYLabel() {
     if (yAxisPC == 1)
       return "1st PC";
@@ -157,26 +164,32 @@ public class PCADataset extends AbstractXYDataset implements ProjectionPlotDatas
     return 1;
   }
 
+  @Override
   public int getItemCount(int series) {
     return component1Coords.length;
   }
 
+  @Override
   public Number getX(int series, int item) {
     return component1Coords[item];
   }
 
+  @Override
   public Number getY(int series, int item) {
     return component2Coords[item];
   }
 
+  @Override
   public String getRawDataFile(int item) {
     return selectedRawDataFiles[item].getName();
   }
 
+  @Override
   public int getGroupNumber(int item) {
     return groupsForSelectedRawDataFiles[item];
   }
 
+  @Override
   public Object getGroupParameterValue(int groupNumber) {
     if (parameterValuesForGroups == null)
       return null;
@@ -185,10 +198,12 @@ public class PCADataset extends AbstractXYDataset implements ProjectionPlotDatas
     return parameterValuesForGroups[groupNumber];
   }
 
+  @Override
   public int getNumberOfGroups() {
     return numberOfGroups;
   }
 
+  @Override
   public void run() {
 
     status = TaskStatus.PROCESSING;
@@ -260,24 +275,29 @@ public class PCADataset extends AbstractXYDataset implements ProjectionPlotDatas
 
   }
 
+  @Override
   public void cancel() {
     if (projectionStatus != null)
       projectionStatus.cancel();
     status = TaskStatus.CANCELED;
   }
 
+  @Override
   public String getErrorMessage() {
     return errorMessage;
   }
 
+  @Override
   public TaskStatus getStatus() {
     return status;
   }
 
+  @Override
   public String getTaskDescription() {
     return "PCA projection";
   }
 
+  @Override
   public double getFinishedPercentage() {
     if (projectionStatus == null)
       return 0;

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/dataanalysis/projectionplots/SammonsDataset.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/dataanalysis/projectionplots/SammonsDataset.java
@@ -20,9 +20,7 @@ package net.sf.mzmine.modules.peaklistmethods.dataanalysis.projectionplots;
 
 import java.util.Vector;
 import java.util.logging.Logger;
-
 import org.jfree.data.xy.AbstractXYDataset;
-
 import jmprojection.Preprocess;
 import jmprojection.ProjectionStatus;
 import jmprojection.Sammons;
@@ -33,6 +31,7 @@ import net.sf.mzmine.datamodel.PeakListRow;
 import net.sf.mzmine.datamodel.RawDataFile;
 import net.sf.mzmine.parameters.ParameterSet;
 import net.sf.mzmine.parameters.UserParameter;
+import net.sf.mzmine.taskcontrol.TaskPriority;
 import net.sf.mzmine.taskcontrol.TaskStatus;
 import net.sf.mzmine.util.PeakMeasurementType;
 
@@ -128,6 +127,7 @@ public class SammonsDataset extends AbstractXYDataset implements ProjectionPlotD
     return datasetTitle;
   }
 
+  @Override
   public String getXLabel() {
     if (xAxisDimension == 1)
       return "1st projected dimension";
@@ -138,6 +138,7 @@ public class SammonsDataset extends AbstractXYDataset implements ProjectionPlotD
     return "" + xAxisDimension + "th projected dimension";
   }
 
+  @Override
   public String getYLabel() {
     if (yAxisDimension == 1)
       return "1st projected dimension";
@@ -158,26 +159,32 @@ public class SammonsDataset extends AbstractXYDataset implements ProjectionPlotD
     return 1;
   }
 
+  @Override
   public int getItemCount(int series) {
     return component1Coords.length;
   }
 
+  @Override
   public Number getX(int series, int item) {
     return component1Coords[item];
   }
 
+  @Override
   public Number getY(int series, int item) {
     return component2Coords[item];
   }
 
+  @Override
   public String getRawDataFile(int item) {
     return selectedRawDataFiles[item].getName();
   }
 
+  @Override
   public int getGroupNumber(int item) {
     return groupsForSelectedRawDataFiles[item];
   }
 
+  @Override
   public Object getGroupParameterValue(int groupNumber) {
     if (parameterValuesForGroups == null)
       return null;
@@ -186,6 +193,7 @@ public class SammonsDataset extends AbstractXYDataset implements ProjectionPlotD
     return parameterValuesForGroups[groupNumber];
   }
 
+  @Override
   public int getNumberOfGroups() {
     return numberOfGroups;
   }
@@ -296,4 +304,8 @@ public class SammonsDataset extends AbstractXYDataset implements ProjectionPlotD
     this.status = newStatus;
   }
 
+  @Override
+  public TaskPriority getTaskPriority() {
+    return TaskPriority.NORMAL;
+  }
 }

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/csvexport/CSVExportParameters.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/csvexport/CSVExportParameters.java
@@ -18,7 +18,7 @@
 
 package net.sf.mzmine.modules.peaklistmethods.io.csvexport;
 
-import net.sf.mzmine.modules.peaklistmethods.io.gnpsexport.GNPSExportParameters.RowFilter;
+import net.sf.mzmine.modules.peaklistmethods.io.gnpsexport.GNPSExportAndSubmitParameters.RowFilter;
 import net.sf.mzmine.parameters.Parameter;
 import net.sf.mzmine.parameters.impl.SimpleParameterSet;
 import net.sf.mzmine.parameters.parametertypes.BooleanParameter;

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/csvexport/CSVExportTask.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/csvexport/CSVExportTask.java
@@ -33,7 +33,7 @@ import net.sf.mzmine.datamodel.PeakList;
 import net.sf.mzmine.datamodel.PeakListRow;
 import net.sf.mzmine.datamodel.RawDataFile;
 import net.sf.mzmine.main.MZmineCore;
-import net.sf.mzmine.modules.peaklistmethods.io.gnpsexport.GNPSExportParameters.RowFilter;
+import net.sf.mzmine.modules.peaklistmethods.io.gnpsexport.GNPSExportAndSubmitParameters.RowFilter;
 import net.sf.mzmine.parameters.ParameterSet;
 import net.sf.mzmine.taskcontrol.AbstractTask;
 import net.sf.mzmine.taskcontrol.TaskStatus;

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/gnpsexport/GNPSExportAndSubmitModule.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/gnpsexport/GNPSExportAndSubmitModule.java
@@ -48,7 +48,7 @@ import net.sf.mzmine.util.ExitCode;
  * @author Robin Schmid (robinschmid@uni-muenster.de)
  *
  */
-public class GNPSExportModule implements MZmineProcessingModule {
+public class GNPSExportAndSubmitModule implements MZmineProcessingModule {
   private final Logger LOG = Logger.getLogger(getClass().getName());
 
   private static final String MODULE_NAME = "Export for/Submit to GNPS";
@@ -66,6 +66,12 @@ public class GNPSExportModule implements MZmineProcessingModule {
       Collection<Task> tasks) {
     // add gnps export task
     GNPSExportAndSubmitTask task = new GNPSExportAndSubmitTask(parameters);
+    /*
+     * We do not add the task to the tasks collection, but instead directly submit to the task
+     * controller, because we need to set the priority to HIGH. If the priority is not HIGH and the
+     * maximum number of concurrent tasks is set to 1 in the MZmine preferences, then this BatchTask
+     * would block all other tasks.
+     */
     tasks.add(task);
 
     return ExitCode.OK;
@@ -83,7 +89,7 @@ public class GNPSExportModule implements MZmineProcessingModule {
 
   @Override
   public Class<? extends ParameterSet> getParameterSetClass() {
-    return GNPSExportParameters.class;
+    return GNPSExportAndSubmitParameters.class;
   }
 
 }

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/gnpsexport/GNPSExportAndSubmitParameters.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/gnpsexport/GNPSExportAndSubmitParameters.java
@@ -43,7 +43,7 @@ import net.sf.mzmine.parameters.parametertypes.submodules.OptionalModuleParamete
 import net.sf.mzmine.util.ExitCode;
 
 
-public class GNPSExportParameters extends SimpleParameterSet {
+public class GNPSExportAndSubmitParameters extends SimpleParameterSet {
 
   /**
    * Define which rows to export
@@ -102,7 +102,7 @@ public class GNPSExportParameters extends SimpleParameterSet {
   public static final BooleanParameter OPEN_FOLDER =
       new BooleanParameter("Open folder", "Opens the export folder", false);
 
-  public GNPSExportParameters() {
+  public GNPSExportAndSubmitParameters() {
     super(new Parameter[] {PEAK_LISTS, FILENAME, MASS_LIST, FILTER, SUBMIT, OPEN_FOLDER});
   }
 

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/gnpsexport/GNPSExportTask.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/gnpsexport/GNPSExportTask.java
@@ -66,11 +66,11 @@ public class GNPSExportTask extends AbstractTask {
 
   GNPSExportTask(ParameterSet parameters) {
     this.peakLists =
-        parameters.getParameter(GNPSExportParameters.PEAK_LISTS).getValue().getMatchingPeakLists();
+        parameters.getParameter(GNPSExportAndSubmitParameters.PEAK_LISTS).getValue().getMatchingPeakLists();
 
-    this.fileName = parameters.getParameter(GNPSExportParameters.FILENAME).getValue();
+    this.fileName = parameters.getParameter(GNPSExportAndSubmitParameters.FILENAME).getValue();
 
-    this.massListName = parameters.getParameter(GNPSExportParameters.MASS_LIST).getValue();
+    this.massListName = parameters.getParameter(GNPSExportAndSubmitParameters.MASS_LIST).getValue();
   }
 
   @Override

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/gnpsexport/GNPSmgfExportTask.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/gnpsexport/GNPSmgfExportTask.java
@@ -48,7 +48,7 @@ import net.sf.mzmine.datamodel.Scan;
 import net.sf.mzmine.datamodel.impl.SimpleFeature;
 import net.sf.mzmine.datamodel.impl.SimplePeakListRow;
 import net.sf.mzmine.main.MZmineCore;
-import net.sf.mzmine.modules.peaklistmethods.io.gnpsexport.GNPSExportParameters.RowFilter;
+import net.sf.mzmine.modules.peaklistmethods.io.gnpsexport.GNPSExportAndSubmitParameters.RowFilter;
 import net.sf.mzmine.parameters.ParameterSet;
 import net.sf.mzmine.taskcontrol.AbstractTask;
 import net.sf.mzmine.taskcontrol.TaskStatus;
@@ -84,11 +84,11 @@ public class GNPSmgfExportTask extends AbstractTask {
 
   GNPSmgfExportTask(ParameterSet parameters) {
     this.peakLists =
-        parameters.getParameter(GNPSExportParameters.PEAK_LISTS).getValue().getMatchingPeakLists();
+        parameters.getParameter(GNPSExportAndSubmitParameters.PEAK_LISTS).getValue().getMatchingPeakLists();
 
-    this.fileName = parameters.getParameter(GNPSExportParameters.FILENAME).getValue();
-    this.massListName = parameters.getParameter(GNPSExportParameters.MASS_LIST).getValue();
-    this.filter = parameters.getParameter(GNPSExportParameters.FILTER).getValue();
+    this.fileName = parameters.getParameter(GNPSExportAndSubmitParameters.FILENAME).getValue();
+    this.massListName = parameters.getParameter(GNPSExportAndSubmitParameters.MASS_LIST).getValue();
+    this.filter = parameters.getParameter(GNPSExportAndSubmitParameters.FILTER).getValue();
   }
 
   @Override

--- a/src/main/java/net/sf/mzmine/modules/visualization/msms/MsMsDataSet.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/msms/MsMsDataSet.java
@@ -19,7 +19,8 @@
 package net.sf.mzmine.modules.visualization.msms;
 
 import java.awt.Color;
-
+import org.jfree.data.xy.AbstractXYDataset;
+import com.google.common.collect.Range;
 import net.sf.mzmine.datamodel.DataPoint;
 import net.sf.mzmine.datamodel.RawDataFile;
 import net.sf.mzmine.datamodel.Scan;
@@ -28,10 +29,6 @@ import net.sf.mzmine.parameters.parametertypes.tolerances.MZTolerance;
 import net.sf.mzmine.taskcontrol.Task;
 import net.sf.mzmine.taskcontrol.TaskPriority;
 import net.sf.mzmine.taskcontrol.TaskStatus;
-
-import org.jfree.data.xy.AbstractXYDataset;
-
-import com.google.common.collect.Range;
 
 /**
  * 
@@ -183,7 +180,7 @@ class MsMsDataSet extends AbstractXYDataset implements Task {
       }
 
       // Calculate normalized intensity
-      double normIntensity = (double) intensityValues[index] / maxIntensityVal;
+      double normIntensity = intensityValues[index] / maxIntensityVal;
       if (normIntensity > 1) {
         normIntensity = 1;
       }
@@ -204,22 +201,27 @@ class MsMsDataSet extends AbstractXYDataset implements Task {
 
   }
 
+  @Override
   public int getSeriesCount() {
     return 1;
   }
 
+  @Override
   public Comparable<?> getSeriesKey(int series) {
     return rawDataFile.getName();
   }
 
+  @Override
   public int getItemCount(int series) {
     return totalmsmsScans;
   }
 
+  @Override
   public Number getX(int series, int item) {
     return rtValues[item];
   }
 
+  @Override
   public Number getY(int series, int item) {
     return mzValues[item];
   }
@@ -383,7 +385,7 @@ class MsMsDataSet extends AbstractXYDataset implements Task {
     if (totalScans == 0) {
       return 0;
     }
-    return (double) 0.5 * (allProcessedScans / totalScans)
+    return 0.5 * (allProcessedScans / totalScans)
         + 0.5 * (100 * processedColors / totalEntries) / 100;
   }
 
@@ -397,4 +399,8 @@ class MsMsDataSet extends AbstractXYDataset implements Task {
     return "Updating MS/MS visualizer of " + rawDataFile;
   }
 
+  @Override
+  public TaskPriority getTaskPriority() {
+    return TaskPriority.NORMAL;
+  }
 }

--- a/src/main/java/net/sf/mzmine/modules/visualization/neutralloss/NeutralLossDataSet.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/neutralloss/NeutralLossDataSet.java
@@ -22,18 +22,16 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Vector;
-
+import org.jfree.chart.labels.XYToolTipGenerator;
+import org.jfree.data.xy.AbstractXYDataset;
+import org.jfree.data.xy.XYDataset;
+import com.google.common.collect.Range;
 import net.sf.mzmine.datamodel.DataPoint;
 import net.sf.mzmine.datamodel.RawDataFile;
 import net.sf.mzmine.datamodel.Scan;
 import net.sf.mzmine.taskcontrol.Task;
+import net.sf.mzmine.taskcontrol.TaskPriority;
 import net.sf.mzmine.taskcontrol.TaskStatus;
-
-import org.jfree.chart.labels.XYToolTipGenerator;
-import org.jfree.data.xy.AbstractXYDataset;
-import org.jfree.data.xy.XYDataset;
-
-import com.google.common.collect.Range;
 
 class NeutralLossDataSet extends AbstractXYDataset implements Task, XYToolTipGenerator {
 
@@ -79,6 +77,7 @@ class NeutralLossDataSet extends AbstractXYDataset implements Task, XYToolTipGen
 
   }
 
+  @Override
   public void run() {
 
     setStatus(TaskStatus.PROCESSING);
@@ -193,6 +192,7 @@ class NeutralLossDataSet extends AbstractXYDataset implements Task, XYToolTipGen
   /**
    * @see org.jfree.data.general.AbstractSeriesDataset#getSeriesCount()
    */
+  @Override
   public int getSeriesCount() {
     return dataSeries.size();
   }
@@ -200,6 +200,7 @@ class NeutralLossDataSet extends AbstractXYDataset implements Task, XYToolTipGen
   /**
    * @see org.jfree.data.general.AbstractSeriesDataset#getSeriesKey(int)
    */
+  @Override
   public Comparable<Integer> getSeriesKey(int series) {
     return series;
   }
@@ -207,6 +208,7 @@ class NeutralLossDataSet extends AbstractXYDataset implements Task, XYToolTipGen
   /**
    * @see org.jfree.data.xy.XYDataset#getItemCount(int)
    */
+  @Override
   public int getItemCount(int series) {
     return dataSeries.get(series).size();
   }
@@ -214,6 +216,7 @@ class NeutralLossDataSet extends AbstractXYDataset implements Task, XYToolTipGen
   /**
    * @see org.jfree.data.xy.XYDataset#getX(int, int)
    */
+  @Override
   public Number getX(int series, int item) {
     NeutralLossDataPoint point = dataSeries.get(series).get(item);
     if (xAxisType.equals(NeutralLossParameters.xAxisPrecursor)) {
@@ -227,6 +230,7 @@ class NeutralLossDataSet extends AbstractXYDataset implements Task, XYToolTipGen
   /**
    * @see org.jfree.data.xy.XYDataset#getY(int, int)
    */
+  @Override
   public Number getY(int series, int item) {
     NeutralLossDataPoint point = dataSeries.get(series).get(item);
     return point.getNeutralLoss();
@@ -259,18 +263,22 @@ class NeutralLossDataSet extends AbstractXYDataset implements Task, XYToolTipGen
    * @see org.jfree.chart.labels.XYToolTipGenerator#generateToolTip(org.jfree.data.xy.XYDataset,
    *      int, int)
    */
+  @Override
   public String generateToolTip(XYDataset dataset, int series, int item) {
     return dataSeries.get(series).get(item).getName();
   }
 
+  @Override
   public void cancel() {
     setStatus(TaskStatus.CANCELED);
   }
 
+  @Override
   public String getErrorMessage() {
     return null;
   }
 
+  @Override
   public double getFinishedPercentage() {
     if (totalScans == 0)
       return 0;
@@ -278,10 +286,12 @@ class NeutralLossDataSet extends AbstractXYDataset implements Task, XYToolTipGen
       return ((double) processedScans / totalScans);
   }
 
+  @Override
   public TaskStatus getStatus() {
     return status;
   }
 
+  @Override
   public String getTaskDescription() {
     return "Updating neutral loss visualizer of " + rawDataFile;
   }
@@ -297,4 +307,8 @@ class NeutralLossDataSet extends AbstractXYDataset implements Task, XYToolTipGen
     return status == TaskStatus.CANCELED;
   }
 
+  @Override
+  public TaskPriority getTaskPriority() {
+    return TaskPriority.NORMAL;
+  }
 }

--- a/src/main/java/net/sf/mzmine/modules/visualization/tic/TICDataSet.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/tic/TICDataSet.java
@@ -23,9 +23,10 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
 import javax.swing.SwingUtilities;
-
+import org.jfree.data.xy.AbstractXYZDataset;
+import com.google.common.collect.Range;
+import com.google.common.primitives.Ints;
 import net.sf.mzmine.datamodel.DataPoint;
 import net.sf.mzmine.datamodel.RawDataFile;
 import net.sf.mzmine.datamodel.Scan;
@@ -34,11 +35,6 @@ import net.sf.mzmine.taskcontrol.Task;
 import net.sf.mzmine.taskcontrol.TaskPriority;
 import net.sf.mzmine.taskcontrol.TaskStatus;
 import net.sf.mzmine.util.ScanUtils;
-
-import org.jfree.data.xy.AbstractXYZDataset;
-
-import com.google.common.collect.Range;
-import com.google.common.primitives.Ints;
 
 /**
  * TIC visualizer data set. One data set is created per file shown in this visualizer. We need to
@@ -402,4 +398,8 @@ public class TICDataSet extends AbstractXYZDataset implements Task {
     status = TaskStatus.CANCELED;
   }
 
+  @Override
+  public TaskPriority getTaskPriority() {
+    return TaskPriority.NORMAL;
+  }
 }

--- a/src/main/java/net/sf/mzmine/modules/visualization/twod/TwoDDataSet.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/twod/TwoDDataSet.java
@@ -21,7 +21,8 @@ package net.sf.mzmine.modules.visualization.twod;
 import java.lang.ref.SoftReference;
 import java.util.ArrayList;
 import java.util.Arrays;
-
+import org.jfree.data.xy.AbstractXYDataset;
+import com.google.common.collect.Range;
 import net.sf.mzmine.datamodel.DataPoint;
 import net.sf.mzmine.datamodel.RawDataFile;
 import net.sf.mzmine.datamodel.Scan;
@@ -33,10 +34,6 @@ import net.sf.mzmine.taskcontrol.TaskStatus;
 import net.sf.mzmine.util.DataPointSorter;
 import net.sf.mzmine.util.SortingDirection;
 import net.sf.mzmine.util.SortingProperty;
-
-import org.jfree.data.xy.AbstractXYDataset;
-
-import com.google.common.collect.Range;
 
 class TwoDDataSet extends AbstractXYDataset implements Task {
 
@@ -109,6 +106,7 @@ class TwoDDataSet extends AbstractXYDataset implements Task {
   /**
    * @see org.jfree.data.general.AbstractSeriesDataset#getSeriesCount()
    */
+  @Override
   public int getSeriesCount() {
     return 2;
   }
@@ -116,6 +114,7 @@ class TwoDDataSet extends AbstractXYDataset implements Task {
   /**
    * @see org.jfree.data.general.AbstractSeriesDataset#getSeriesKey(int)
    */
+  @Override
   public Comparable<?> getSeriesKey(int series) {
     return rawDataFile.getName();
   }
@@ -123,6 +122,7 @@ class TwoDDataSet extends AbstractXYDataset implements Task {
   /**
    * @see org.jfree.data.xy.XYDataset#getItemCount(int)
    */
+  @Override
   public int getItemCount(int series) {
     return 2;
   }
@@ -130,6 +130,7 @@ class TwoDDataSet extends AbstractXYDataset implements Task {
   /**
    * @see org.jfree.data.xy.XYDataset#getX(int, int)
    */
+  @Override
   public Number getX(int series, int item) {
     if (series == 0)
       return totalRTRange.lowerEndpoint();
@@ -140,6 +141,7 @@ class TwoDDataSet extends AbstractXYDataset implements Task {
   /**
    * @see org.jfree.data.xy.XYDataset#getY(int, int)
    */
+  @Override
   public Number getY(int series, int item) {
     if (item == 0)
       return totalMZRange.lowerEndpoint();
@@ -364,4 +366,8 @@ class TwoDDataSet extends AbstractXYDataset implements Task {
     return "Updating 2D visualizer of " + rawDataFile;
   }
 
+  @Override
+  public TaskPriority getTaskPriority() {
+    return TaskPriority.NORMAL;
+  }
 }

--- a/src/main/java/net/sf/mzmine/taskcontrol/AbstractTask.java
+++ b/src/main/java/net/sf/mzmine/taskcontrol/AbstractTask.java
@@ -85,6 +85,11 @@ public abstract class AbstractTask implements Task {
     this.errorMessage = errorMessage;
   }
 
+  @Override
+  public TaskPriority getTaskPriority() {
+    return TaskPriority.NORMAL;
+  }
+
   /**
    * Returns the TaskStatus of this Task
    * 

--- a/src/main/java/net/sf/mzmine/taskcontrol/Task.java
+++ b/src/main/java/net/sf/mzmine/taskcontrol/Task.java
@@ -33,6 +33,13 @@ public interface Task extends Runnable {
   public String getErrorMessage();
 
   /**
+   * The standard TaskPriority assing to this task
+   * 
+   * @return
+   */
+  public TaskPriority getTaskPriority();
+
+  /**
    * Cancel a running task by user request.
    */
   public void cancel();

--- a/src/main/java/net/sf/mzmine/taskcontrol/TaskController.java
+++ b/src/main/java/net/sf/mzmine/taskcontrol/TaskController.java
@@ -31,7 +31,7 @@ public interface TaskController {
 
   public void addTask(Task task, TaskPriority priority);
 
-  public void addTasks(Task tasks[], TaskPriority priority);
+  public void addTasks(Task tasks[], TaskPriority[] priority);
 
   public void setTaskPriority(Task task, TaskPriority priority);
 


### PR DESCRIPTION
This PR fixes issue #527 .
GNPS export/submit is not frozen on single core. 

Hey Tomas,

this is a small fix. I have added the method getTaskPriority to Task and AbstractTask will just return TaskPriority.NORMAL. Any other task can now implement this method to change the default priority. This specifies whether a task should restrain the max number of tasks or not. 

I think this change is more straight forward than adding a task with a specific task priority manually.
This:
`tasks.add(newTask);`
instead of:
`MZmineCore.getTaskController().addTask(newTask, TaskPriority.HIGH);`

I made sure that I dont change the Google statistics tracking.

Cheers,
Robin

