### PR TITLE
Msms data model change

### DIFF
--- a/src/main/java/net/sf/mzmine/datamodel/Feature.java
+++ b/src/main/java/net/sf/mzmine/datamodel/Feature.java
@@ -20,7 +20,6 @@ package net.sf.mzmine.datamodel;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-
 import com.google.common.collect.Range;
 import net.sf.mzmine.datamodel.impl.SimplePeakInformation;
 
@@ -119,6 +118,11 @@ public interface Feature {
    * Returns the number of scan that represents the fragmentation of this peak in MS2 level.
    */
   public int getMostIntenseFragmentScanNumber();
+
+  /**
+   * Returns all scan numbers that represent fragmentations of this peak in MS2 level.
+   */
+  public int[] getAllMS2FragmentScanNumbers();
 
   /**
    * Returns the isotope pattern of this peak or null if no pattern is attached

--- a/src/main/java/net/sf/mzmine/datamodel/PeakListRow.java
+++ b/src/main/java/net/sf/mzmine/datamodel/PeakListRow.java
@@ -185,6 +185,11 @@ public interface PeakListRow {
   public Scan getBestFragmentation();
 
   /**
+   * Returns all fragmentation scans of this row
+   */
+  public Scan[] getAllMS2Fragmentations();
+
+  /**
    * Returns the most intense isotope pattern in this row. If there are no isotope patterns present
    * in the row, returns null.
    */

--- a/src/main/java/net/sf/mzmine/datamodel/impl/SimpleFeature.java
+++ b/src/main/java/net/sf/mzmine/datamodel/impl/SimpleFeature.java
@@ -19,12 +19,9 @@
 package net.sf.mzmine.datamodel.impl;
 
 import java.util.Arrays;
-
 import javax.annotation.Nonnull;
-
 import com.google.common.collect.Range;
 import com.google.common.primitives.Doubles;
-
 import io.github.msdk.datamodel.Chromatogram;
 import net.sf.mzmine.datamodel.DataPoint;
 import net.sf.mzmine.datamodel.Feature;
@@ -61,6 +58,9 @@ public class SimpleFeature implements Feature {
   // Number of most intense fragment scan
   private int fragmentScanNumber;
 
+  // Numbers of all MS2 fragment scans
+  private int[] allMS2FragmentScanNumbers;
+
   // Isotope pattern. Null by default but can be set later by deisotoping
   // method.
   private IsotopePattern isotopePattern;
@@ -72,8 +72,8 @@ public class SimpleFeature implements Feature {
    */
   public SimpleFeature(RawDataFile dataFile, double MZ, double RT, double height, double area,
       int[] scanNumbers, DataPoint[] dataPointsPerScan, FeatureStatus peakStatus,
-      int representativeScan, int fragmentScanNumber, Range<Double> rtRange, Range<Double> mzRange,
-      Range<Double> intensityRange) {
+      int representativeScan, int fragmentScanNumber, int[] allMS2FragmentScanNumbers,
+      Range<Double> rtRange, Range<Double> mzRange, Range<Double> intensityRange) {
 
     if (dataPointsPerScan.length == 0) {
       throw new IllegalArgumentException("Cannot create a SimplePeak instance with no data points");
@@ -88,6 +88,7 @@ public class SimpleFeature implements Feature {
     this.peakStatus = peakStatus;
     this.representativeScan = representativeScan;
     this.fragmentScanNumber = fragmentScanNumber;
+    this.allMS2FragmentScanNumbers = allMS2FragmentScanNumbers;
     this.rtRange = rtRange;
     this.mzRange = mzRange;
     this.intensityRange = intensityRange;
@@ -130,6 +131,7 @@ public class SimpleFeature implements Feature {
 
     this.representativeScan = p.getRepresentativeScanNumber();
     this.fragmentScanNumber = p.getMostIntenseFragmentScanNumber();
+    this.allMS2FragmentScanNumbers = p.getAllMS2FragmentScanNumbers();
 
   }
 
@@ -168,6 +170,8 @@ public class SimpleFeature implements Feature {
 
     this.representativeScan = RawDataFileUtils.getClosestScanNumber(dataFile, this.rt);
     this.fragmentScanNumber = ScanUtils.findBestFragmentScan(dataFile, this.rtRange, this.mzRange);
+    this.allMS2FragmentScanNumbers =
+        ScanUtils.findAllMS2FragmentScans(dataFile, this.rtRange, this.mzRange);
 
     for (int i = 0; i < scanNumbers.length; i++) {
       if (height < dataPointsPerScan[i].getIntensity()) {
@@ -180,6 +184,7 @@ public class SimpleFeature implements Feature {
   /**
    * This method returns the status of the peak
    */
+  @Override
   public @Nonnull FeatureStatus getFeatureStatus() {
     return peakStatus;
   }
@@ -187,6 +192,7 @@ public class SimpleFeature implements Feature {
   /**
    * This method returns M/Z value of the peak
    */
+  @Override
   public double getMZ() {
     return mz;
   }
@@ -202,6 +208,7 @@ public class SimpleFeature implements Feature {
   /**
    * This method returns retention time of the peak
    */
+  @Override
   public double getRT() {
     return rt;
   }
@@ -209,6 +216,7 @@ public class SimpleFeature implements Feature {
   /**
    * This method returns the raw height of the peak
    */
+  @Override
   public double getHeight() {
     return height;
   }
@@ -225,6 +233,7 @@ public class SimpleFeature implements Feature {
   /**
    * This method returns the raw area of the peak
    */
+  @Override
   public double getArea() {
     return area;
   }
@@ -239,6 +248,7 @@ public class SimpleFeature implements Feature {
   /**
    * This method returns numbers of scans that contain this peak
    */
+  @Override
   public @Nonnull int[] getScanNumbers() {
     return scanNumbers;
   }
@@ -246,6 +256,7 @@ public class SimpleFeature implements Feature {
   /**
    * This method returns a representative datapoint of this peak in a given scan
    */
+  @Override
   public DataPoint getDataPoint(int scanNumber) {
     int index = Arrays.binarySearch(scanNumbers, scanNumber);
     if (index < 0)
@@ -256,6 +267,7 @@ public class SimpleFeature implements Feature {
   /**
    * @see net.sf.mzmine.datamodel.Feature#getDataFile()
    */
+  @Override
   public @Nonnull RawDataFile getDataFile() {
     return dataFile;
   }
@@ -278,6 +290,7 @@ public class SimpleFeature implements Feature {
   /**
    * @see net.sf.mzmine.datamodel.Feature#getRawDataPointsIntensityRange()
    */
+  @Override
   public @Nonnull Range<Double> getRawDataPointsIntensityRange() {
     return intensityRange;
   }
@@ -285,6 +298,7 @@ public class SimpleFeature implements Feature {
   /**
    * @see net.sf.mzmine.datamodel.Feature#getRawDataPointsMZRange()
    */
+  @Override
   public @Nonnull Range<Double> getRawDataPointsMZRange() {
     return mzRange;
   }
@@ -292,6 +306,7 @@ public class SimpleFeature implements Feature {
   /**
    * @see net.sf.mzmine.datamodel.Feature#getRawDataPointsRTRange()
    */
+  @Override
   public @Nonnull Range<Double> getRawDataPointsRTRange() {
     return rtRange;
   }
@@ -299,26 +314,37 @@ public class SimpleFeature implements Feature {
   /**
    * @see net.sf.mzmine.datamodel.Feature#getRepresentativeScanNumber()
    */
+  @Override
   public int getRepresentativeScanNumber() {
     return representativeScan;
   }
 
+  @Override
   public int getMostIntenseFragmentScanNumber() {
     return fragmentScanNumber;
   }
 
+  @Override
+  public int[] getAllMS2FragmentScanNumbers() {
+    return allMS2FragmentScanNumbers;
+  }
+
+  @Override
   public IsotopePattern getIsotopePattern() {
     return isotopePattern;
   }
 
+  @Override
   public void setIsotopePattern(@Nonnull IsotopePattern isotopePattern) {
     this.isotopePattern = isotopePattern;
   }
 
+  @Override
   public int getCharge() {
     return charge;
   }
 
+  @Override
   public void setCharge(int charge) {
     this.charge = charge;
   }
@@ -326,6 +352,7 @@ public class SimpleFeature implements Feature {
   /**
    * This method returns the full width at half maximum (FWHM) of the peak
    */
+  @Override
   public Double getFWHM() {
     return fwhm;
   }
@@ -333,6 +360,7 @@ public class SimpleFeature implements Feature {
   /**
    * @param fwhm The full width at half maximum (FWHM) to set.
    */
+  @Override
   public void setFWHM(Double fwhm) {
     this.fwhm = fwhm;
   }
@@ -340,6 +368,7 @@ public class SimpleFeature implements Feature {
   /**
    * This method returns the tailing factor of the peak
    */
+  @Override
   public Double getTailingFactor() {
     return tf;
   }
@@ -347,6 +376,7 @@ public class SimpleFeature implements Feature {
   /**
    * @param tf The tailing factor to set.
    */
+  @Override
   public void setTailingFactor(Double tf) {
     this.tf = tf;
   }
@@ -354,6 +384,7 @@ public class SimpleFeature implements Feature {
   /**
    * This method returns the asymmetry factor of the peak
    */
+  @Override
   public Double getAsymmetryFactor() {
     return af;
   }
@@ -361,19 +392,23 @@ public class SimpleFeature implements Feature {
   /**
    * @param af The asymmetry factor to set.
    */
+  @Override
   public void setAsymmetryFactor(Double af) {
     this.af = af;
   }
 
   // dulab Edit
+  @Override
   public void outputChromToFile() {
 
   }
 
+  @Override
   public void setPeakInformation(SimplePeakInformation peakInfoIn) {
     this.peakInfo = peakInfoIn;
   }
 
+  @Override
   public SimplePeakInformation getPeakInformation() {
     return peakInfo;
   }

--- a/src/main/java/net/sf/mzmine/datamodel/impl/SimplePeakListRow.java
+++ b/src/main/java/net/sf/mzmine/datamodel/impl/SimplePeakListRow.java
@@ -19,6 +19,7 @@
 package net.sf.mzmine.datamodel.impl;
 
 import java.text.Format;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.HashSet;
@@ -70,6 +71,7 @@ public class SimplePeakListRow implements PeakListRow {
   /**
    * @see net.sf.mzmine.datamodel.PeakListRow#getID()
    */
+  @Override
   public int getID() {
     return myID;
   }
@@ -77,10 +79,12 @@ public class SimplePeakListRow implements PeakListRow {
   /**
    * Return peaks assigned to this row
    */
+  @Override
   public Feature[] getPeaks() {
     return peaks.values().toArray(new Feature[0]);
   }
 
+  @Override
   public void removePeak(RawDataFile file) {
     this.peaks.remove(file);
     calculateAverageValues();
@@ -89,6 +93,7 @@ public class SimplePeakListRow implements PeakListRow {
   /**
    * Returns opened raw data files with a peak on this row
    */
+  @Override
   public RawDataFile[] getRawDataFiles() {
     return peaks.keySet().toArray(new RawDataFile[0]);
   }
@@ -96,10 +101,12 @@ public class SimplePeakListRow implements PeakListRow {
   /**
    * Returns peak for given raw data file
    */
+  @Override
   public Feature getPeak(RawDataFile rawData) {
     return peaks.get(rawData);
   }
 
+  @Override
   public synchronized void addPeak(RawDataFile rawData, Feature peak) {
     if (peak == null)
       throw new IllegalArgumentException("Cannot add null peak to a peak list row");
@@ -112,22 +119,27 @@ public class SimplePeakListRow implements PeakListRow {
     calculateAverageValues();
   }
 
+  @Override
   public double getAverageMZ() {
     return averageMZ;
   }
 
+  @Override
   public double getAverageRT() {
     return averageRT;
   }
 
+  @Override
   public double getAverageHeight() {
     return averageHeight;
   }
 
+  @Override
   public double getAverageArea() {
     return averageArea;
   }
 
+  @Override
   public int getRowCharge() {
     return rowCharge;
   }
@@ -162,10 +174,12 @@ public class SimplePeakListRow implements PeakListRow {
   /**
    * Returns number of peaks assigned to this row
    */
+  @Override
   public int getNumberOfPeaks() {
     return peaks.size();
   }
 
+  @Override
   public String toString() {
     StringBuffer buf = new StringBuffer();
     Format mzFormat = MZmineCore.getConfiguration().getMZFormat();
@@ -184,6 +198,7 @@ public class SimplePeakListRow implements PeakListRow {
   /**
    * @see net.sf.mzmine.datamodel.PeakListRow#getComment()
    */
+  @Override
   public String getComment() {
     return comment;
   }
@@ -191,6 +206,7 @@ public class SimplePeakListRow implements PeakListRow {
   /**
    * @see net.sf.mzmine.datamodel.PeakListRow#setComment(java.lang.String)
    */
+  @Override
   public void setComment(String comment) {
     this.comment = comment;
   }
@@ -198,6 +214,7 @@ public class SimplePeakListRow implements PeakListRow {
   /**
    * @see net.sf.mzmine.datamodel.PeakListRow#setAverageMZ(java.lang.String)
    */
+  @Override
   public void setAverageMZ(double mz) {
     this.averageMZ = mz;
   }
@@ -205,6 +222,7 @@ public class SimplePeakListRow implements PeakListRow {
   /**
    * @see net.sf.mzmine.datamodel.PeakListRow#setAverageRT(java.lang.String)
    */
+  @Override
   public void setAverageRT(double rt) {
     this.averageRT = rt;
   }
@@ -212,6 +230,7 @@ public class SimplePeakListRow implements PeakListRow {
   /**
    * @see net.sf.mzmine.datamodel.PeakListRow#addCompoundIdentity(net.sf.mzmine.datamodel.PeakIdentity)
    */
+  @Override
   public synchronized void addPeakIdentity(PeakIdentity identity, boolean preferred) {
 
     // Verify if exists already an identity with the same name
@@ -230,6 +249,7 @@ public class SimplePeakListRow implements PeakListRow {
   /**
    * @see net.sf.mzmine.datamodel.PeakListRow#addCompoundIdentity(net.sf.mzmine.datamodel.PeakIdentity)
    */
+  @Override
   public synchronized void removePeakIdentity(PeakIdentity identity) {
     identities.remove(identity);
     if (preferredIdentity == identity) {
@@ -244,6 +264,7 @@ public class SimplePeakListRow implements PeakListRow {
   /**
    * @see net.sf.mzmine.datamodel.PeakListRow#getPeakIdentities()
    */
+  @Override
   public PeakIdentity[] getPeakIdentities() {
     return identities.toArray(new PeakIdentity[0]);
   }
@@ -251,6 +272,7 @@ public class SimplePeakListRow implements PeakListRow {
   /**
    * @see net.sf.mzmine.datamodel.PeakListRow#getPreferredPeakIdentity()
    */
+  @Override
   public PeakIdentity getPreferredPeakIdentity() {
     return preferredIdentity;
   }
@@ -258,6 +280,7 @@ public class SimplePeakListRow implements PeakListRow {
   /**
    * @see net.sf.mzmine.datamodel.PeakListRow#setPreferredPeakIdentity(net.sf.mzmine.datamodel.PeakIdentity)
    */
+  @Override
   public void setPreferredPeakIdentity(PeakIdentity identity) {
 
     if (identity == null)
@@ -284,14 +307,17 @@ public class SimplePeakListRow implements PeakListRow {
   /**
    * @see net.sf.mzmine.datamodel.PeakListRow#getDataPointMaxIntensity()
    */
+  @Override
   public double getDataPointMaxIntensity() {
     return maxDataPointIntensity;
   }
 
+  @Override
   public boolean hasPeak(Feature peak) {
     return peaks.containsValue(peak);
   }
 
+  @Override
   public boolean hasPeak(RawDataFile file) {
     return peaks.containsKey(file);
   }
@@ -299,6 +325,7 @@ public class SimplePeakListRow implements PeakListRow {
   /**
    * Returns the highest isotope pattern of a peak in this row
    */
+  @Override
   public IsotopePattern getBestIsotopePattern() {
     Feature peaks[] = getPeaks();
     Arrays.sort(peaks, new PeakSorter(SortingProperty.Height, SortingDirection.Descending));
@@ -315,6 +342,7 @@ public class SimplePeakListRow implements PeakListRow {
   /**
    * Returns the highest peak in this row
    */
+  @Override
   public Feature getBestPeak() {
 
     Feature peaks[] = getPeaks();
@@ -346,11 +374,36 @@ public class SimplePeakListRow implements PeakListRow {
     return bestScan;
   }
 
+  @Override
+  public Scan[] getAllMS2Fragmentations() {
+
+    ArrayList<Scan> allMS2ScansList = new ArrayList<Scan>();
+    for (Feature peak : this.getPeaks()) {
+      RawDataFile rawData = peak.getDataFile();
+      int scanNumbers[] = peak.getAllMS2FragmentScanNumbers();
+      if (scanNumbers != null) {
+        for (int scanNumber : scanNumbers) {
+          Scan scan = rawData.getScan(scanNumber);
+          if (scan != null) {
+            allMS2ScansList.add(scan);
+          }
+        }
+      }
+    }
+
+    Scan[] allMSScans = new Scan[allMS2ScansList.size()];
+    for (int i = 0; i < allMS2ScansList.size(); i++) {
+      allMSScans[i] = allMS2ScansList.get(i);
+    }
+    return allMSScans;
+  }
+
   // DorresteinLab edit
   /**
    * set the ID number
    */
 
+  @Override
   public void setID(int id) {
     myID = id;
     return;

--- a/src/main/java/net/sf/mzmine/modules/masslistmethods/ADAPchromatogrambuilder/ADAPChromatogram.java
+++ b/src/main/java/net/sf/mzmine/modules/masslistmethods/ADAPchromatogrambuilder/ADAPChromatogram.java
@@ -21,31 +21,28 @@
 
 package net.sf.mzmine.modules.masslistmethods.ADAPchromatogrambuilder;
 
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.PrintWriter;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map.Entry;
 import java.util.Vector;
-import java.util.List;
-import java.util.ArrayList;
-import java.util.Collections;
-
 import javax.annotation.Nonnull;
-
 import com.google.common.collect.Range;
 import com.google.common.primitives.Ints;
-
 import net.sf.mzmine.datamodel.DataPoint;
 import net.sf.mzmine.datamodel.Feature;
 import net.sf.mzmine.datamodel.IsotopePattern;
 import net.sf.mzmine.datamodel.RawDataFile;
 import net.sf.mzmine.datamodel.Scan;
+import net.sf.mzmine.datamodel.impl.SimplePeakInformation;
 import net.sf.mzmine.main.MZmineCore;
 import net.sf.mzmine.util.ScanUtils;
-
-import java.io.PrintWriter;
-import java.io.FileNotFoundException;
-import java.io.*;
-import net.sf.mzmine.datamodel.impl.SimplePeakInformation;
 
 
 
@@ -243,6 +240,7 @@ public class ADAPChromatogram implements Feature {
 
   }
 
+  @Override
   public DataPoint getDataPoint(int scanNumber) {
     return dataPointsMap.get(scanNumber);
   }
@@ -257,6 +255,7 @@ public class ADAPChromatogram implements Feature {
   /**
    * This method returns m/z value of the chromatogram
    */
+  @Override
   public double getMZ() {
     return mz;
   }
@@ -274,62 +273,83 @@ public class ADAPChromatogram implements Feature {
    * 
    * @return String information
    */
+  @Override
   public String toString() {
     return "Chromatogram " + MZmineCore.getConfiguration().getMZFormat().format(mz) + " m/z";
   }
 
+  @Override
   public double getArea() {
     return area;
   }
 
+  @Override
   public double getHeight() {
     return height;
   }
 
+  @Override
   public int getMostIntenseFragmentScanNumber() {
     return fragmentScan;
   }
 
+  @Override
+  public int[] getAllMS2FragmentScanNumbers() {
+    // TODO
+    return null;
+  }
+
+  @Override
   public @Nonnull FeatureStatus getFeatureStatus() {
     return FeatureStatus.DETECTED;
   }
 
+  @Override
   public double getRT() {
     return rt;
   }
 
+  @Override
   public @Nonnull Range<Double> getRawDataPointsIntensityRange() {
     return rawDataPointsIntensityRange;
   }
 
+  @Override
   public @Nonnull Range<Double> getRawDataPointsMZRange() {
     return rawDataPointsMZRange;
   }
 
+  @Override
   public @Nonnull Range<Double> getRawDataPointsRTRange() {
     return rawDataPointsRTRange;
   }
 
+  @Override
   public int getRepresentativeScanNumber() {
     return representativeScan;
   }
 
+  @Override
   public @Nonnull int[] getScanNumbers() {
     return scanNumbers;
   }
 
+  @Override
   public @Nonnull RawDataFile getDataFile() {
     return dataFile;
   }
 
+  @Override
   public IsotopePattern getIsotopePattern() {
     return isotopePattern;
   }
 
+  @Override
   public void setIsotopePattern(@Nonnull IsotopePattern isotopePattern) {
     this.isotopePattern = isotopePattern;
   }
 
+  @Override
   public void outputChromToFile() {
     // int allScanNumbers[] = Ints.toArray(dataPointsMap.keySet());
     int allScanNumbers[] = getScanNumbers();
@@ -495,43 +515,54 @@ public class ADAPChromatogram implements Feature {
     }
   }
 
+  @Override
   public int getCharge() {
     return charge;
   }
 
+  @Override
   public void setCharge(int charge) {
     this.charge = charge;
   }
 
+  @Override
   public Double getFWHM() {
     return fwhm;
   }
 
+  @Override
   public void setFWHM(Double fwhm) {
     this.fwhm = fwhm;
   }
 
+  @Override
   public Double getTailingFactor() {
     return tf;
   }
 
+  @Override
   public void setTailingFactor(Double tf) {
     this.tf = tf;
   }
 
+  @Override
   public Double getAsymmetryFactor() {
     return af;
   }
 
+  @Override
   public void setAsymmetryFactor(Double af) {
     this.af = af;
   }
 
+  @Override
   public void setPeakInformation(SimplePeakInformation peakInfoIn) {
     this.peakInfo = peakInfoIn;
   }
 
+  @Override
   public SimplePeakInformation getPeakInformation() {
     return peakInfo;
   }
+
 }

--- a/src/main/java/net/sf/mzmine/modules/masslistmethods/ADAPchromatogrambuilder/ADAPChromatogram.java
+++ b/src/main/java/net/sf/mzmine/modules/masslistmethods/ADAPchromatogrambuilder/ADAPChromatogram.java
@@ -66,6 +66,9 @@ public class ADAPChromatogram implements Feature {
   // Top intensity scan, fragment scan
   private int representativeScan = -1, fragmentScan = -1;
 
+  // All MS2 fragment scan numbers
+  private int[] allMS2FragmentScanNumbers = new int[] {-1};
+
   // Ranges of raw data points
   private Range<Double> rawDataPointsIntensityRange, rawDataPointsMZRange, rawDataPointsRTRange;
 
@@ -295,8 +298,7 @@ public class ADAPChromatogram implements Feature {
 
   @Override
   public int[] getAllMS2FragmentScanNumbers() {
-    // TODO
-    return null;
+    return allMS2FragmentScanNumbers;
   }
 
   @Override
@@ -455,6 +457,9 @@ public class ADAPChromatogram implements Feature {
     // Update fragment scan
     fragmentScan =
         ScanUtils.findBestFragmentScan(dataFile, dataFile.getDataRTRange(1), rawDataPointsMZRange);
+
+    allMS2FragmentScanNumbers = ScanUtils.findAllMS2FragmentScans(dataFile,
+        dataFile.getDataRTRange(1), rawDataPointsMZRange);
 
     if (fragmentScan > 0) {
       Scan fragmentScanObject = dataFile.getScan(fragmentScan);

--- a/src/main/java/net/sf/mzmine/modules/masslistmethods/ADAPchromatogrambuilder/ADAPChromatogram.java
+++ b/src/main/java/net/sf/mzmine/modules/masslistmethods/ADAPchromatogrambuilder/ADAPChromatogram.java
@@ -67,7 +67,7 @@ public class ADAPChromatogram implements Feature {
   private int representativeScan = -1, fragmentScan = -1;
 
   // All MS2 fragment scan numbers
-  private int[] allMS2FragmentScanNumbers = new int[] {-1};
+  private int[] allMS2FragmentScanNumbers = new int[] {};
 
   // Ranges of raw data points
   private Range<Double> rawDataPointsIntensityRange, rawDataPointsMZRange, rawDataPointsRTRange;

--- a/src/main/java/net/sf/mzmine/modules/masslistmethods/chromatogrambuilder/Chromatogram.java
+++ b/src/main/java/net/sf/mzmine/modules/masslistmethods/chromatogrambuilder/Chromatogram.java
@@ -22,12 +22,9 @@ import java.util.Arrays;
 import java.util.Hashtable;
 import java.util.Map.Entry;
 import java.util.Vector;
-
 import javax.annotation.Nonnull;
-
 import com.google.common.collect.Range;
 import com.google.common.primitives.Ints;
-
 import net.sf.mzmine.datamodel.DataPoint;
 import net.sf.mzmine.datamodel.Feature;
 import net.sf.mzmine.datamodel.IsotopePattern;
@@ -58,6 +55,9 @@ public class Chromatogram implements Feature {
   // Top intensity scan, fragment scan
   private int representativeScan = -1, fragmentScan = -1;
 
+  // All MS2 fragment scan numbers
+  private int[] allMS2FragmentScanNumbers = new int[] {-1};
+
   // Ranges of raw data points
   private Range<Double> rawDataPointsIntensityRange, rawDataPointsMZRange, rawDataPointsRTRange;
 
@@ -82,6 +82,7 @@ public class Chromatogram implements Feature {
 
   private final int scanNumbers[];
 
+  @Override
   public void outputChromToFile() {
     System.out.println("does nothing");
   }
@@ -115,6 +116,7 @@ public class Chromatogram implements Feature {
 
   }
 
+  @Override
   public DataPoint getDataPoint(int scanNumber) {
     return dataPointsMap.get(scanNumber);
   }
@@ -129,6 +131,7 @@ public class Chromatogram implements Feature {
   /**
    * This method returns m/z value of the chromatogram
    */
+  @Override
   public double getMZ() {
     return mz;
   }
@@ -138,58 +141,77 @@ public class Chromatogram implements Feature {
    * 
    * @return String information
    */
+  @Override
   public String toString() {
     return "Chromatogram " + MZmineCore.getConfiguration().getMZFormat().format(mz) + " m/z";
   }
 
+  @Override
   public double getArea() {
     return area;
   }
 
+  @Override
   public double getHeight() {
     return height;
   }
 
+  @Override
   public int getMostIntenseFragmentScanNumber() {
     return fragmentScan;
   }
 
+  @Override
+  public int[] getAllMS2FragmentScanNumbers() {
+    return allMS2FragmentScanNumbers;
+  }
+
+  @Override
   public @Nonnull FeatureStatus getFeatureStatus() {
     return FeatureStatus.DETECTED;
   }
 
+  @Override
   public double getRT() {
     return rt;
   }
 
+  @Override
   public @Nonnull Range<Double> getRawDataPointsIntensityRange() {
     return rawDataPointsIntensityRange;
   }
 
+  @Override
   public @Nonnull Range<Double> getRawDataPointsMZRange() {
     return rawDataPointsMZRange;
   }
 
+  @Override
   public @Nonnull Range<Double> getRawDataPointsRTRange() {
     return rawDataPointsRTRange;
   }
 
+  @Override
   public int getRepresentativeScanNumber() {
     return representativeScan;
   }
 
+  @Override
   public @Nonnull int[] getScanNumbers() {
     return scanNumbers;
   }
 
+  @Override
   public @Nonnull RawDataFile getDataFile() {
     return dataFile;
   }
 
+  @Override
   public IsotopePattern getIsotopePattern() {
     return isotopePattern;
   }
 
+  @Override
   public void setIsotopePattern(@Nonnull IsotopePattern isotopePattern) {
     this.isotopePattern = isotopePattern;
   }
@@ -308,42 +330,52 @@ public class Chromatogram implements Feature {
     }
   }
 
+  @Override
   public int getCharge() {
     return charge;
   }
 
+  @Override
   public void setCharge(int charge) {
     this.charge = charge;
   }
 
+  @Override
   public Double getFWHM() {
     return fwhm;
   }
 
+  @Override
   public void setFWHM(Double fwhm) {
     this.fwhm = fwhm;
   }
 
+  @Override
   public Double getTailingFactor() {
     return tf;
   }
 
+  @Override
   public void setTailingFactor(Double tf) {
     this.tf = tf;
   }
 
+  @Override
   public Double getAsymmetryFactor() {
     return af;
   }
 
+  @Override
   public void setAsymmetryFactor(Double af) {
     this.af = af;
   }
 
+  @Override
   public void setPeakInformation(SimplePeakInformation peakInfoIn) {
     this.peakInfo = peakInfoIn;
   }
 
+  @Override
   public SimplePeakInformation getPeakInformation() {
     return peakInfo;
   }

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/gapfilling/peakfinder/Gap.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/gapfilling/peakfinder/Gap.java
@@ -183,9 +183,13 @@ public class Gap {
       // Find the best fragmentation scan, if available
       int fragmentScan = ScanUtils.findBestFragmentScan(rawDataFile, finalRTRange, finalMZRange);
 
+      // Find all MS2 level scans
+      int[] allMS2FragmentScanNumbers =
+          ScanUtils.findAllMS2FragmentScans(rawDataFile, finalRTRange, finalMZRange);
+
       SimpleFeature newPeak = new SimpleFeature(rawDataFile, mz, rt, height, area, scanNumbers,
-          finalDataPoint, FeatureStatus.ESTIMATED, representativeScan, fragmentScan, finalRTRange,
-          finalMZRange, finalIntensityRange);
+          finalDataPoint, FeatureStatus.ESTIMATED, representativeScan, fragmentScan,
+          allMS2FragmentScanNumbers, finalRTRange, finalMZRange, finalIntensityRange);
 
       // Fill the gap
       peakListRow.addPeak(rawDataFile, newPeak);

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/gapfilling/samerange/SameRangePeak.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/gapfilling/samerange/SameRangePeak.java
@@ -19,21 +19,18 @@
 package net.sf.mzmine.modules.peaklistmethods.gapfilling.samerange;
 
 import java.util.TreeMap;
-
 import javax.annotation.Nonnull;
-
+import com.google.common.collect.Range;
+import com.google.common.primitives.Ints;
 import net.sf.mzmine.datamodel.DataPoint;
 import net.sf.mzmine.datamodel.Feature;
 import net.sf.mzmine.datamodel.IsotopePattern;
 import net.sf.mzmine.datamodel.RawDataFile;
 import net.sf.mzmine.datamodel.Scan;
+import net.sf.mzmine.datamodel.impl.SimplePeakInformation;
 import net.sf.mzmine.util.MathUtils;
 import net.sf.mzmine.util.PeakUtils;
 import net.sf.mzmine.util.ScanUtils;
-
-import com.google.common.collect.Range;
-import com.google.common.primitives.Ints;
-import net.sf.mzmine.datamodel.impl.SimplePeakInformation;
 
 /**
  * This class represents a manually picked chromatographic peak.
@@ -56,6 +53,9 @@ class SameRangePeak implements Feature {
   // Number of most intense fragment scan
   private int fragmentScan, representativeScan;
 
+  // Numbers of all MS2 fragment scans
+  private int[] allMS2FragmentScanNumbers;
+
   // Isotope pattern. Null by default but can be set later by deisotoping
   // method.
   private IsotopePattern isotopePattern;
@@ -72,6 +72,7 @@ class SameRangePeak implements Feature {
   /**
    * This peak is always a result of manual peak detection, therefore MANUAL
    */
+  @Override
   public @Nonnull FeatureStatus getFeatureStatus() {
     return FeatureStatus.ESTIMATED;
   }
@@ -79,6 +80,7 @@ class SameRangePeak implements Feature {
   /**
    * This method returns M/Z value of the peak
    */
+  @Override
   public double getMZ() {
     return mz;
   }
@@ -86,6 +88,7 @@ class SameRangePeak implements Feature {
   /**
    * This method returns retention time of the peak
    */
+  @Override
   public double getRT() {
     return rt;
   }
@@ -93,6 +96,7 @@ class SameRangePeak implements Feature {
   /**
    * This method returns the raw height of the peak
    */
+  @Override
   public double getHeight() {
     return height;
   }
@@ -100,6 +104,7 @@ class SameRangePeak implements Feature {
   /**
    * This method returns the raw area of the peak
    */
+  @Override
   public double getArea() {
     return area;
   }
@@ -107,6 +112,7 @@ class SameRangePeak implements Feature {
   /**
    * This method returns numbers of scans that contain this peak
    */
+  @Override
   public @Nonnull int[] getScanNumbers() {
     return Ints.toArray(mzPeakMap.keySet());
   }
@@ -114,18 +120,22 @@ class SameRangePeak implements Feature {
   /**
    * This method returns a representative datapoint of this peak in a given scan
    */
+  @Override
   public DataPoint getDataPoint(int scanNumber) {
     return mzPeakMap.get(scanNumber);
   }
 
+  @Override
   public @Nonnull Range<Double> getRawDataPointsIntensityRange() {
     return intensityRange;
   }
 
+  @Override
   public @Nonnull Range<Double> getRawDataPointsMZRange() {
     return mzRange;
   }
 
+  @Override
   public @Nonnull Range<Double> getRawDataPointsRTRange() {
     return rtRange;
   }
@@ -133,6 +143,7 @@ class SameRangePeak implements Feature {
   /**
    * @see net.sf.mzmine.datamodel.Feature#getDataFile()
    */
+  @Override
   public @Nonnull RawDataFile getDataFile() {
     return dataFile;
   }
@@ -233,6 +244,7 @@ class SameRangePeak implements Feature {
     this.mz = MathUtils.calcQuantile(mzArray, 0.5f);
 
     fragmentScan = ScanUtils.findBestFragmentScan(dataFile, rtRange, mzRange);
+    allMS2FragmentScanNumbers = ScanUtils.findAllMS2FragmentScans(dataFile, rtRange, mzRange);
 
     if (fragmentScan > 0) {
       Scan fragmentScanObject = dataFile.getScan(fragmentScan);
@@ -247,67 +259,86 @@ class SameRangePeak implements Feature {
     this.mz = mz;
   }
 
+  @Override
   public int getRepresentativeScanNumber() {
     return representativeScan;
   }
 
+  @Override
   public int getMostIntenseFragmentScanNumber() {
     return fragmentScan;
   }
 
+  @Override
+  public int[] getAllMS2FragmentScanNumbers() {
+    return allMS2FragmentScanNumbers;
+  }
+
+  @Override
   public IsotopePattern getIsotopePattern() {
     return isotopePattern;
   }
 
+  @Override
   public void setIsotopePattern(@Nonnull IsotopePattern isotopePattern) {
     this.isotopePattern = isotopePattern;
   }
 
+  @Override
   public int getCharge() {
     return charge;
   }
 
+  @Override
   public void setCharge(int charge) {
     this.charge = charge;
   }
 
+  @Override
   public Double getFWHM() {
     return fwhm;
   }
 
+  @Override
   public void setFWHM(Double fwhm) {
     this.fwhm = fwhm;
   }
 
+  @Override
   public Double getTailingFactor() {
     return tf;
   }
 
+  @Override
   public void setTailingFactor(Double tf) {
     this.tf = tf;
   }
 
+  @Override
   public Double getAsymmetryFactor() {
     return af;
   }
 
+  @Override
   public void setAsymmetryFactor(Double af) {
     this.af = af;
   }
 
   // dulab Edit
+  @Override
   public void outputChromToFile() {
     int nothing = -1;
   }
 
+  @Override
   public void setPeakInformation(SimplePeakInformation peakInfoIn) {
     this.peakInfo = peakInfoIn;
   }
 
+  @Override
   public SimplePeakInformation getPeakInformation() {
     return peakInfo;
   }
   // End dulab Edit
-
 
 }

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/lipididentification/LipidSearchTask.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/lipididentification/LipidSearchTask.java
@@ -247,16 +247,16 @@ public class LipidSearchTask extends AbstractTask {
           massList = msmsScan.getMassLists()[0].getDataPoints();
         } else {
           // Create a new mass list for MS/MS scan. Check if sprectrum is profile or centroid mode
-          if (row.getBestFragmentation().getSpectrumType() == MassSpectrumType.CENTROIDED) {
+          if (msmsScan.getSpectrumType() == MassSpectrumType.CENTROIDED) {
             massDetector = new CentroidMassDetector();
             CentroidMassDetectorParameters parametersMSMS = new CentroidMassDetectorParameters();
             CentroidMassDetectorParameters.noiseLevel.setValue(noiseLevelMSMS);
-            massList = massDetector.getMassValues(row.getBestFragmentation(), parametersMSMS);
+            massList = massDetector.getMassValues(msmsScan, parametersMSMS);
           } else {
             massDetector = new ExactMassDetector();
             ExactMassDetectorParameters parametersMSMS = new ExactMassDetectorParameters();
             ExactMassDetectorParameters.noiseLevel.setValue(noiseLevelMSMS);
-            massList = massDetector.getMassValues(row.getBestFragmentation(), parametersMSMS);
+            massList = massDetector.getMassValues(msmsScan, parametersMSMS);
           }
         }
         MSMSLipidTools msmsLipidTools = new MSMSLipidTools();
@@ -273,8 +273,8 @@ public class LipidSearchTask extends AbstractTask {
               String annotatedNegativeFragment =
                   msmsLipidTools.checkForNegativeClassSpecificFragment(mzTolRangeMSMS,
                       row.getPreferredPeakIdentity(), lipidIonMass, fragments);
-              if (annotatedNegativeFragment.equals("") == false && listOfAnnotatedNegativeFragments
-                  .contains(annotatedNegativeFragment) == false) {
+              if (annotatedNegativeFragment.equals("") == false
+                  && row.getComment().contains(annotatedNegativeFragment) == false) {
                 listOfAnnotatedNegativeFragments.add(annotatedNegativeFragment);
               }
             }

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/lipididentification/LipidSearchTask.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/lipididentification/LipidSearchTask.java
@@ -29,6 +29,7 @@ import net.sf.mzmine.datamodel.MassSpectrumType;
 import net.sf.mzmine.datamodel.PeakList;
 import net.sf.mzmine.datamodel.PeakListRow;
 import net.sf.mzmine.datamodel.PolarityType;
+import net.sf.mzmine.datamodel.Scan;
 import net.sf.mzmine.datamodel.impl.SimplePeakIdentity;
 import net.sf.mzmine.datamodel.impl.SimplePeakList;
 import net.sf.mzmine.datamodel.impl.SimplePeakListAppliedMethod;
@@ -235,126 +236,147 @@ public class LipidSearchTask extends AbstractTask {
   private void searchMsmsFragments(PeakListRow row, double lipidIonMass, LipidIdentity lipid) {
 
     MassDetector massDetector = null;
-
     // Check if selected feature has MSMS spectra
-    if (row.getBestFragmentation() != null) {
+    if (row.getAllMS2Fragmentations() != null) {
+      Scan[] msmsScans = row.getAllMS2Fragmentations();
+      for (Scan msmsScan : msmsScans) {
 
-      DataPoint[] massList = null;
-      // check if MS/MS scan already has a mass list
-      if (row.getBestFragmentation().getMassLists().length != 0) {
-        massList = row.getBestFragmentation().getMassLists()[0].getDataPoints();
-      } else {
-        // Create a new mass list for MS/MS scan. Check if sprectrum is profile or centroid mode
-        if (row.getBestFragmentation().getSpectrumType() == MassSpectrumType.CENTROIDED) {
-          massDetector = new CentroidMassDetector();
-          CentroidMassDetectorParameters parametersMSMS = new CentroidMassDetectorParameters();
-          CentroidMassDetectorParameters.noiseLevel.setValue(noiseLevelMSMS);
-          massList = massDetector.getMassValues(row.getBestFragmentation(), parametersMSMS);
+        DataPoint[] massList = null;
+        // check if MS/MS scan already has a mass list
+        if (msmsScan.getMassLists().length != 0) {
+          massList = msmsScan.getMassLists()[0].getDataPoints();
         } else {
-          massDetector = new ExactMassDetector();
-          ExactMassDetectorParameters parametersMSMS = new ExactMassDetectorParameters();
-          ExactMassDetectorParameters.noiseLevel.setValue(noiseLevelMSMS);
-          massList = massDetector.getMassValues(row.getBestFragmentation(), parametersMSMS);
+          // Create a new mass list for MS/MS scan. Check if sprectrum is profile or centroid mode
+          if (row.getBestFragmentation().getSpectrumType() == MassSpectrumType.CENTROIDED) {
+            massDetector = new CentroidMassDetector();
+            CentroidMassDetectorParameters parametersMSMS = new CentroidMassDetectorParameters();
+            CentroidMassDetectorParameters.noiseLevel.setValue(noiseLevelMSMS);
+            massList = massDetector.getMassValues(row.getBestFragmentation(), parametersMSMS);
+          } else {
+            massDetector = new ExactMassDetector();
+            ExactMassDetectorParameters parametersMSMS = new ExactMassDetectorParameters();
+            ExactMassDetectorParameters.noiseLevel.setValue(noiseLevelMSMS);
+            massList = massDetector.getMassValues(row.getBestFragmentation(), parametersMSMS);
+          }
         }
-      }
-      MSMSLipidTools msmsLipidTools = new MSMSLipidTools();
+        MSMSLipidTools msmsLipidTools = new MSMSLipidTools();
 
-      // check for negative polarity
-      if (row.getBestFragmentation().getPolarity() == PolarityType.NEGATIVE) {
+        // check for negative polarity
+        if (msmsScan.getPolarity() == PolarityType.NEGATIVE) {
 
-        // check if lipid class has set negative fragments
-        String[] fragments = lipid.getLipidClass().getMsmsFragmentsNegativeIonization();
-        if (fragments.length > 0) {
-          ArrayList<String> listOfAnnotatedNegativeFragments = new ArrayList<String>();
-          for (int i = 0; i < massList.length; i++) {
-            Range<Double> mzTolRangeMSMS = mzToleranceMS2.getToleranceRange(massList[i].getMZ());
-            String annotatedNegativeFragment = msmsLipidTools.checkForNegativeClassSpecificFragment(
-                mzTolRangeMSMS, row.getPreferredPeakIdentity(), lipidIonMass, fragments);
-            if (annotatedNegativeFragment.equals("") == false) {
-              listOfAnnotatedNegativeFragments.add(annotatedNegativeFragment);
+          // check if lipid class has set negative fragments
+          String[] fragments = lipid.getLipidClass().getMsmsFragmentsNegativeIonization();
+          if (fragments.length > 0) {
+            ArrayList<String> listOfAnnotatedNegativeFragments = new ArrayList<String>();
+            for (int i = 0; i < massList.length; i++) {
+              Range<Double> mzTolRangeMSMS = mzToleranceMS2.getToleranceRange(massList[i].getMZ());
+              String annotatedNegativeFragment =
+                  msmsLipidTools.checkForNegativeClassSpecificFragment(mzTolRangeMSMS,
+                      row.getPreferredPeakIdentity(), lipidIonMass, fragments);
+              if (annotatedNegativeFragment.equals("") == false && listOfAnnotatedNegativeFragments
+                  .contains(annotatedNegativeFragment) == false) {
+                listOfAnnotatedNegativeFragments.add(annotatedNegativeFragment);
+              }
+            }
+
+            if (listOfAnnotatedNegativeFragments.isEmpty() == false) {
+
+              // predict lipid fatty acid composition if possible
+              ArrayList<String> listOfPossibleFattyAcidCompositions =
+                  msmsLipidTools.predictFattyAcidComposition(listOfAnnotatedNegativeFragments,
+                      row.getPreferredPeakIdentity());
+              for (int i = 0; i < listOfPossibleFattyAcidCompositions.size(); i++) {
+                // Add possible composition to comment
+                if (row.getComment().equals(null)) {
+                  row.setComment(" " + listOfPossibleFattyAcidCompositions.get(i) + " MS/MS scan "
+                      + msmsScan.getScanNumber() + ", RT " + MZmineCore.getConfiguration()
+                          .getRTFormat().format(msmsScan.getRetentionTime()));
+                } else {
+                  row.setComment(row.getComment() + ";" + " "
+                      + listOfPossibleFattyAcidCompositions.get(i) + " MS/MS scan "
+                      + msmsScan.getScanNumber() + ", RT " + MZmineCore.getConfiguration()
+                          .getRTFormat().format(msmsScan.getRetentionTime()));
+                }
+              }
+
+              // add class specific fragments
+              for (int i = 0; i < listOfAnnotatedNegativeFragments.size(); i++) {
+                if (listOfAnnotatedNegativeFragments.get(i).contains("C")
+                    || listOfAnnotatedNegativeFragments.get(i).contains("H")
+                    || listOfAnnotatedNegativeFragments.get(i).contains("O")) {
+                  // Add fragment to comment
+                  if (row.getComment().equals(null)) {
+                    row.setComment(" " + listOfAnnotatedNegativeFragments.get(i) + " MS/MS scan "
+                        + msmsScan.getScanNumber() + ", RT " + MZmineCore.getConfiguration()
+                            .getRTFormat().format(msmsScan.getRetentionTime()));
+                  } else {
+                    row.setComment(row.getComment() + ";" + " "
+                        + listOfAnnotatedNegativeFragments.get(i) + " MS/MS scan "
+                        + msmsScan.getScanNumber() + ", RT " + MZmineCore.getConfiguration()
+                            .getRTFormat().format(msmsScan.getRetentionTime()));
+                  }
+                }
+              }
             }
           }
+        }
 
-          if (listOfAnnotatedNegativeFragments.isEmpty() == false) {
+        // check if lipid class has positive fragments
+        if (msmsScan.getPolarity() == PolarityType.POSITIVE) {
+
+          // check if lipid class has set postiev fragments
+          String[] fragments = lipid.getLipidClass().getMsmsFragmentsPositiveIonization();
+          if (fragments.length > 0) {
+            ArrayList<String> listOfAnnotatedPositiveFragments = new ArrayList<String>();
+            for (int i = 0; i < massList.length; i++) {
+              Range<Double> mzTolRangeMSMS = mzToleranceMS2.getToleranceRange(massList[i].getMZ());
+              String annotatedPositiveFragment =
+                  msmsLipidTools.checkForPositiveClassSpecificFragment(mzTolRangeMSMS,
+                      row.getPreferredPeakIdentity(), lipidIonMass, fragments);
+              if (annotatedPositiveFragment.equals("") == false
+                  && row.getComment().contains(annotatedPositiveFragment) == false) {
+                listOfAnnotatedPositiveFragments.add(annotatedPositiveFragment);
+              }
+            }
 
             // predict lipid fatty acid composition if possible
             ArrayList<String> listOfPossibleFattyAcidCompositions =
-                msmsLipidTools.predictFattyAcidComposition(listOfAnnotatedNegativeFragments,
+                msmsLipidTools.predictFattyAcidComposition(listOfAnnotatedPositiveFragments,
                     row.getPreferredPeakIdentity());
             for (int i = 0; i < listOfPossibleFattyAcidCompositions.size(); i++) {
               // Add possible composition to comment
               if (row.getComment().equals(null)) {
-                row.setComment(" " + listOfPossibleFattyAcidCompositions.get(i));
+                row.setComment(" " + listOfPossibleFattyAcidCompositions.get(i) + " MS/MS scan "
+                    + msmsScan.getScanNumber() + ", RT " + MZmineCore.getConfiguration()
+                        .getRTFormat().format(msmsScan.getRetentionTime()));
               } else {
                 row.setComment(
-                    row.getComment() + ";" + " " + listOfPossibleFattyAcidCompositions.get(i));
+                    row.getComment() + ";" + " " + listOfPossibleFattyAcidCompositions.get(i)
+                        + " MS/MS scan " + msmsScan.getScanNumber() + ", RT " + MZmineCore
+                            .getConfiguration().getRTFormat().format(msmsScan.getRetentionTime()));
               }
             }
 
             // add class specific fragments
-            for (int i = 0; i < listOfAnnotatedNegativeFragments.size(); i++) {
-              if (listOfAnnotatedNegativeFragments.get(i).contains("C")
-                  || listOfAnnotatedNegativeFragments.get(i).contains("H")
-                  || listOfAnnotatedNegativeFragments.get(i).contains("O")) {
+            for (int i = 0; i < listOfAnnotatedPositiveFragments.size(); i++) {
+              if (listOfAnnotatedPositiveFragments.get(i).contains("C")) {
                 // Add fragment to comment
                 if (row.getComment().equals(null)) {
-                  row.setComment(" " + listOfAnnotatedNegativeFragments.get(i));
+                  row.setComment(" " + listOfAnnotatedPositiveFragments.get(i) + " MS/MS scan "
+                      + msmsScan.getScanNumber() + ", RT " + MZmineCore.getConfiguration()
+                          .getRTFormat().format(msmsScan.getRetentionTime()));
                 } else {
-                  row.setComment(
-                      row.getComment() + ";" + " " + listOfAnnotatedNegativeFragments.get(i));
+                  row.setComment(row.getComment() + ";" + " "
+                      + listOfAnnotatedPositiveFragments.get(i) + " MS/MS scan "
+                      + msmsScan.getScanNumber() + ", RT " + MZmineCore.getConfiguration()
+                          .getRTFormat().format(msmsScan.getRetentionTime()));
                 }
               }
             }
           }
         }
       }
-
-      // check if lipid class has positive fragments
-      if (row.getBestFragmentation().getPolarity() == PolarityType.POSITIVE) {
-
-        // check if lipid class has set postiev fragments
-        String[] fragments = lipid.getLipidClass().getMsmsFragmentsPositiveIonization();
-        if (fragments.length > 0) {
-          ArrayList<String> listOfAnnotatedPositiveFragments = new ArrayList<String>();
-          for (int i = 0; i < massList.length; i++) {
-            Range<Double> mzTolRangeMSMS = mzToleranceMS2.getToleranceRange(massList[i].getMZ());
-            String annotatedPositiveFragment = msmsLipidTools.checkForPositiveClassSpecificFragment(
-                mzTolRangeMSMS, row.getPreferredPeakIdentity(), lipidIonMass, fragments);
-            if (annotatedPositiveFragment.equals("") == false) {
-              listOfAnnotatedPositiveFragments.add(annotatedPositiveFragment);
-            }
-          }
-
-          // predict lipid fatty acid composition if possible
-          ArrayList<String> listOfPossibleFattyAcidCompositions =
-              msmsLipidTools.predictFattyAcidComposition(listOfAnnotatedPositiveFragments,
-                  row.getPreferredPeakIdentity());
-          for (int i = 0; i < listOfPossibleFattyAcidCompositions.size(); i++) {
-            // Add possible composition to comment
-            if (row.getComment().equals(null)) {
-              row.setComment(" " + listOfPossibleFattyAcidCompositions.get(i));
-            } else {
-              row.setComment(
-                  row.getComment() + ";" + " " + listOfPossibleFattyAcidCompositions.get(i));
-            }
-          }
-
-          // add class specific fragments
-          for (int i = 0; i < listOfAnnotatedPositiveFragments.size(); i++) {
-            if (listOfAnnotatedPositiveFragments.get(i).contains("C")) {
-              // Add fragment to comment
-              if (row.getComment().equals(null)) {
-                row.setComment(" " + listOfAnnotatedPositiveFragments.get(i));
-              } else {
-                row.setComment(
-                    row.getComment() + ";" + " " + listOfAnnotatedPositiveFragments.get(i));
-              }
-            }
-          }
-        }
-      }
     }
-
   }
 
   private void searchModifications(PeakListRow rows, double lipidIonMass, LipidIdentity lipid,

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/lipididentification/lipids/LipidDatabaseTableDialog.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/lipididentification/lipids/LipidDatabaseTableDialog.java
@@ -134,7 +134,7 @@ public class LipidDatabaseTableDialog extends JFrame {
     yellowPanel.add(yellowColorLabel);
     legendPanel.add(yellowPanel);
 
-    JLabel redColorLabel = new JLabel("Isobaric interference");
+    JLabel redColorLabel = new JLabel("Isomeric interference");
     JPanel redPanel = new JPanel();
     redPanel.setBackground(Color.red);
     redPanel.add(redColorLabel);
@@ -348,7 +348,7 @@ public class LipidDatabaseTableDialog extends JFrame {
     XYSeriesCollection datasetCollection = new XYSeriesCollection();
     XYSeries noInterferenceSeries = new XYSeries("No interference");
     XYSeries possibleInterferenceSeries = new XYSeries("Possible interference");
-    XYSeries interferenceSeries = new XYSeries("Isobaric interference");
+    XYSeries interferenceSeries = new XYSeries("Isomeric interference");
 
     // add data to all series
     double yValue = 0;

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/casmiimport/CasmiImportTask.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/casmiimport/CasmiImportTask.java
@@ -22,7 +22,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Scanner;
 import java.util.logging.Logger;
-
+import com.google.common.collect.Range;
 import net.sf.mzmine.datamodel.DataPoint;
 import net.sf.mzmine.datamodel.Feature;
 import net.sf.mzmine.datamodel.Feature.FeatureStatus;
@@ -50,8 +50,6 @@ import net.sf.mzmine.taskcontrol.AbstractTask;
 import net.sf.mzmine.taskcontrol.TaskStatus;
 import net.sf.mzmine.util.ScanUtils;
 
-import com.google.common.collect.Range;
-
 class CasmiImportTask extends AbstractTask {
 
   private Logger logger = Logger.getLogger(this.getClass().getName());
@@ -72,6 +70,7 @@ class CasmiImportTask extends AbstractTask {
 
   }
 
+  @Override
   public double getFinishedPercentage() {
     if (newPeakList != null)
       return 1d;
@@ -81,10 +80,12 @@ class CasmiImportTask extends AbstractTask {
 
   }
 
+  @Override
   public String getTaskDescription() {
     return "Generating CASMI task " + casmiProblemName;
   }
 
+  @Override
   public void run() {
 
     setStatus(TaskStatus.PROCESSING);
@@ -102,6 +103,7 @@ class CasmiImportTask extends AbstractTask {
       final DataPoint firstDataPoint = msSpectrumDataPoints[0];
       final int msScanNumber = 1;
       final int msMsScanNumber = 2;
+      final int[] allMsMsScanNumbers = new int[] {2};
 
       // Generate the raw data file
       RawDataFileWriter dataFileWriter;
@@ -136,9 +138,9 @@ class CasmiImportTask extends AbstractTask {
       Range<Double> mzRange = ScanUtils.findMzRange(msSpectrumDataPoints);
       Range<Double> rtRange = Range.singleton(msScan.getRetentionTime());
       Range<Double> intensityRange = Range.closed(0.0, firstDataPoint.getIntensity());
-      Feature newPeak =
-          new SimpleFeature(newDataFile, mz, rt, height, area, scanNumbers, dataPointsPerScan,
-              FeatureStatus.MANUAL, msScanNumber, msMsScanNumber, rtRange, mzRange, intensityRange);
+      Feature newPeak = new SimpleFeature(newDataFile, mz, rt, height, area, scanNumbers,
+          dataPointsPerScan, FeatureStatus.MANUAL, msScanNumber, msMsScanNumber, allMsMsScanNumbers,
+          rtRange, mzRange, intensityRange);
 
       // Generate the isotope pattern
       IsotopePattern isotopePat = new SimpleIsotopePattern(msSpectrumDataPoints,

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/mztabimport/MzTabImportTask.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/mztabimport/MzTabImportTask.java
@@ -27,7 +27,9 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.SortedMap;
 import java.util.TreeMap;
-
+import com.google.common.collect.Range;
+import com.google.common.io.ByteStreams;
+import com.google.common.math.DoubleMath;
 import net.sf.mzmine.datamodel.DataPoint;
 import net.sf.mzmine.datamodel.Feature;
 import net.sf.mzmine.datamodel.Feature.FeatureStatus;
@@ -56,10 +58,6 @@ import uk.ac.ebi.pride.jmztab.model.SmallMolecule;
 import uk.ac.ebi.pride.jmztab.model.SplitList;
 import uk.ac.ebi.pride.jmztab.model.StudyVariable;
 import uk.ac.ebi.pride.jmztab.utils.MZTabFileParser;
-
-import com.google.common.collect.Range;
-import com.google.common.io.ByteStreams;
-import com.google.common.math.DoubleMath;
 
 class MzTabImportTask extends AbstractTask {
 
@@ -436,14 +434,15 @@ class MzTabImportTask extends AbstractTask {
         finalDataPoint[0] = new SimpleDataPoint(peak_mz, peak_height);
         int representativeScan = 0;
         int fragmentScan = 0;
+        int[] allFragmentScans = new int[] {0};
         Range<Double> finalRTRange = Range.singleton(peak_rt);
         Range<Double> finalMZRange = Range.singleton(peak_mz);
         Range<Double> finalIntensityRange = Range.singleton(peak_height);
         FeatureStatus status = FeatureStatus.DETECTED;
 
         Feature peak = new SimpleFeature(rawData, peak_mz, peak_rt, peak_height, abundance,
-            scanNumbers, finalDataPoint, status, representativeScan, fragmentScan, finalRTRange,
-            finalMZRange, finalIntensityRange);
+            scanNumbers, finalDataPoint, status, representativeScan, fragmentScan, allFragmentScans,
+            finalRTRange, finalMZRange, finalIntensityRange);
 
         if (abundance > 0) {
           newRow.addPeak(rawData, peak);

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/adap3decompositionV2/ADAP3DecompositionV2Task.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/adap3decompositionV2/ADAP3DecompositionV2Task.java
@@ -15,23 +15,36 @@
  */
 package net.sf.mzmine.modules.peaklistmethods.peakpicking.adap3decompositionV2;
 
-import com.google.common.collect.Range;
-import dulab.adap.datamodel.*;
-
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
+import javax.annotation.Nonnull;
+import com.google.common.collect.Range;
+import dulab.adap.datamodel.BetterComponent;
+import dulab.adap.datamodel.BetterPeak;
+import dulab.adap.datamodel.Chromatogram;
 import dulab.adap.workflow.decomposition.Decomposition;
 import dulab.adap.workflow.decomposition.RetTimeClusterer;
-import net.sf.mzmine.datamodel.*;
-import net.sf.mzmine.datamodel.impl.*;
+import net.sf.mzmine.datamodel.DataPoint;
+import net.sf.mzmine.datamodel.Feature;
+import net.sf.mzmine.datamodel.IsotopePattern;
+import net.sf.mzmine.datamodel.MZmineProject;
+import net.sf.mzmine.datamodel.PeakList;
+import net.sf.mzmine.datamodel.PeakListRow;
+import net.sf.mzmine.datamodel.RawDataFile;
+import net.sf.mzmine.datamodel.impl.SimpleDataPoint;
+import net.sf.mzmine.datamodel.impl.SimpleFeature;
+import net.sf.mzmine.datamodel.impl.SimpleIsotopePattern;
+import net.sf.mzmine.datamodel.impl.SimplePeakList;
+import net.sf.mzmine.datamodel.impl.SimplePeakListAppliedMethod;
+import net.sf.mzmine.datamodel.impl.SimplePeakListRow;
 import net.sf.mzmine.modules.peaklistmethods.qualityparameters.QualityParameters;
 import net.sf.mzmine.parameters.ParameterSet;
 import net.sf.mzmine.taskcontrol.AbstractTask;
 import net.sf.mzmine.taskcontrol.TaskStatus;
-
-import javax.annotation.Nonnull;
 
 /**
  *
@@ -272,7 +285,7 @@ public class ADAP3DecompositionV2Task extends AbstractTask {
 
     return new SimpleFeature(file, peak.getMZ(), peak.getRetTime(), peak.getIntensity(), area,
         scanNumbers, dataPoints, Feature.FeatureStatus.MANUAL, representativeScan,
-        representativeScan, Range.closed(peak.getFirstRetTime(), peak.getLastRetTime()),
+        representativeScan, null, Range.closed(peak.getFirstRetTime(), peak.getLastRetTime()),
         Range.closed(peak.getMZ() - 0.01, peak.getMZ() + 0.01),
         Range.closed(0.0, peak.getIntensity()));
   }

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/adap3decompositionV2/ADAP3DecompositionV2Task.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/adap3decompositionV2/ADAP3DecompositionV2Task.java
@@ -285,7 +285,8 @@ public class ADAP3DecompositionV2Task extends AbstractTask {
 
     return new SimpleFeature(file, peak.getMZ(), peak.getRetTime(), peak.getIntensity(), area,
         scanNumbers, dataPoints, Feature.FeatureStatus.MANUAL, representativeScan,
-        representativeScan, null, Range.closed(peak.getFirstRetTime(), peak.getLastRetTime()),
+        representativeScan, new int[] {-1},
+        Range.closed(peak.getFirstRetTime(), peak.getLastRetTime()),
         Range.closed(peak.getMZ() - 0.01, peak.getMZ() + 0.01),
         Range.closed(0.0, peak.getIntensity()));
   }

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/ResolvedPeak.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/ResolvedPeak.java
@@ -58,6 +58,9 @@ public class ResolvedPeak implements Feature {
   // Top intensity scan, fragment scan
   private int representativeScan, fragmentScan;
 
+  // All MS2 fragment scan numbers
+  private int[] allMS2FragmentScanNumbers;
+
   // Ranges of raw data points
   private Range<Double> rawDataPointsIntensityRange, rawDataPointsMZRange, rawDataPointsRTRange;
 
@@ -176,6 +179,8 @@ public class ResolvedPeak implements Feature {
       searchingRangeRT = rawDataPointsRTRange;
 
     fragmentScan = ScanUtils.findBestFragmentScan(dataFile, searchingRangeRT, searchingRange);
+    allMS2FragmentScanNumbers =
+        ScanUtils.findAllMS2FragmentScans(dataFile, searchingRangeRT, searchingRange);
 
     if (fragmentScan > 0) {
       Scan fragmentScanObject = dataFile.getScan(fragmentScan);
@@ -230,6 +235,11 @@ public class ResolvedPeak implements Feature {
   @Override
   public int getMostIntenseFragmentScanNumber() {
     return fragmentScan;
+  }
+
+  @Override
+  public int[] getAllMS2FragmentScanNumbers() {
+    return allMS2FragmentScanNumbers;
   }
 
   @Override
@@ -338,4 +348,5 @@ public class ResolvedPeak implements Feature {
     return peakInfo;
   }
   // End dulab Edit
+
 }

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/peakextender/ExtendedPeak.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/peakextender/ExtendedPeak.java
@@ -2,23 +2,20 @@ package net.sf.mzmine.modules.peaklistmethods.peakpicking.peakextender;
 
 import java.util.Arrays;
 import java.util.Hashtable;
-
 import javax.annotation.Nonnull;
-
+import com.google.common.collect.Range;
+import com.google.common.primitives.Ints;
 import net.sf.mzmine.datamodel.DataPoint;
 import net.sf.mzmine.datamodel.Feature;
 import net.sf.mzmine.datamodel.IsotopePattern;
 import net.sf.mzmine.datamodel.RawDataFile;
 import net.sf.mzmine.datamodel.Scan;
 import net.sf.mzmine.datamodel.impl.SimpleDataPoint;
+import net.sf.mzmine.datamodel.impl.SimplePeakInformation;
 import net.sf.mzmine.main.MZmineCore;
 import net.sf.mzmine.util.MathUtils;
 import net.sf.mzmine.util.PeakUtils;
 import net.sf.mzmine.util.ScanUtils;
-
-import com.google.common.collect.Range;
-import com.google.common.primitives.Ints;
-import net.sf.mzmine.datamodel.impl.SimplePeakInformation;
 
 public class ExtendedPeak implements Feature {
   private SimplePeakInformation peakInfo;
@@ -35,6 +32,9 @@ public class ExtendedPeak implements Feature {
 
   // Top intensity scan, fragment scan
   private int representativeScan = -1, fragmentScan = -1;
+
+  // All MS2 fragment scans
+  private int[] allMS2FragmentScanNumbers;
 
   // Ranges of raw data points
   private Range<Double> rawDataPointsIntensityRange, rawDataPointsMZRange, rawDataPointsRTRange;
@@ -70,6 +70,7 @@ public class ExtendedPeak implements Feature {
     dataPointsMap.put(scanNumber, mzValue);
   }
 
+  @Override
   public DataPoint getDataPoint(int scanNumber) {
     return dataPointsMap.get(scanNumber);
   }
@@ -84,6 +85,7 @@ public class ExtendedPeak implements Feature {
   /**
    * This method returns m/z value of the extended peak
    */
+  @Override
   public double getMZ() {
     return mz;
   }
@@ -97,14 +99,17 @@ public class ExtendedPeak implements Feature {
     return "Extended peak " + MZmineCore.getConfiguration().getMZFormat().format(mz) + " m/z";
   }
 
+  @Override
   public double getArea() {
     return area;
   }
 
+  @Override
   public double getHeight() {
     return height;
   }
 
+  @Override
   public int getMostIntenseFragmentScanNumber() {
     return fragmentScan;
   }
@@ -118,42 +123,57 @@ public class ExtendedPeak implements Feature {
     this.fragmentScan = scanNumber;
   }
 
+  @Override
+  public int[] getAllMS2FragmentScanNumbers() {
+    return allMS2FragmentScanNumbers;
+  }
+
+  @Override
   public @Nonnull FeatureStatus getFeatureStatus() {
     return FeatureStatus.DETECTED;
   }
 
+  @Override
   public double getRT() {
     return rt;
   }
 
+  @Override
   public @Nonnull Range<Double> getRawDataPointsIntensityRange() {
     return rawDataPointsIntensityRange;
   }
 
+  @Override
   public @Nonnull Range<Double> getRawDataPointsMZRange() {
     return rawDataPointsMZRange;
   }
 
+  @Override
   public @Nonnull Range<Double> getRawDataPointsRTRange() {
     return rawDataPointsRTRange;
   }
 
+  @Override
   public int getRepresentativeScanNumber() {
     return representativeScan;
   }
 
+  @Override
   public @Nonnull int[] getScanNumbers() {
     return scanNumbers;
   }
 
+  @Override
   public @Nonnull RawDataFile getDataFile() {
     return dataFile;
   }
 
+  @Override
   public IsotopePattern getIsotopePattern() {
     return isotopePattern;
   }
 
+  @Override
   public void setIsotopePattern(@Nonnull IsotopePattern isotopePattern) {
     this.isotopePattern = isotopePattern;
   }
@@ -220,6 +240,9 @@ public class ExtendedPeak implements Feature {
     fragmentScan =
         ScanUtils.findBestFragmentScan(dataFile, dataFile.getDataRTRange(1), rawDataPointsMZRange);
 
+    allMS2FragmentScanNumbers = ScanUtils.findAllMS2FragmentScans(dataFile,
+        dataFile.getDataRTRange(1), rawDataPointsMZRange);
+
     if (fragmentScan > 0) {
       Scan fragmentScanObject = dataFile.getScan(fragmentScan);
       int precursorCharge = fragmentScanObject.getPrecursorCharge();
@@ -229,10 +252,12 @@ public class ExtendedPeak implements Feature {
 
   }
 
+  @Override
   public int getCharge() {
     return charge;
   }
 
+  @Override
   public void setCharge(int charge) {
     this.charge = charge;
   }
@@ -245,39 +270,48 @@ public class ExtendedPeak implements Feature {
     return PeakUtils.peakToString(this);
   }
 
+  @Override
   public Double getFWHM() {
     return fwhm;
   }
 
+  @Override
   public void setFWHM(Double fwhm) {
     this.fwhm = fwhm;
   }
 
+  @Override
   public Double getTailingFactor() {
     return tf;
   }
 
+  @Override
   public void setTailingFactor(Double tf) {
     this.tf = tf;
   }
 
+  @Override
   public Double getAsymmetryFactor() {
     return af;
   }
 
+  @Override
   public void setAsymmetryFactor(Double af) {
     this.af = af;
   }
 
   // dulab Edit
+  @Override
   public void outputChromToFile() {
     int nothing = -1;
   }
 
+  @Override
   public void setPeakInformation(SimplePeakInformation peakInfoIn) {
     this.peakInfo = peakInfoIn;
   }
 
+  @Override
   public SimplePeakInformation getPeakInformation() {
     return peakInfo;
   }

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/shapemodeler/peakmodels/EMGPeakModel.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/shapemodeler/peakmodels/EMGPeakModel.java
@@ -51,6 +51,7 @@ public class EMGPeakModel implements Feature {
   private RawDataFile rawDataFile;
   private FeatureStatus status;
   private int representativeScan = -1, fragmentScan = -1;
+  private int[] allMS2FragmentScanNumbers = new int[] {-1};
   private Range<Double> rawDataPointsIntensityRange, rawDataPointsMZRange, rawDataPointsRTRange;
   private TreeMap<Integer, DataPoint> dataPointsMap;
 
@@ -157,6 +158,11 @@ public class EMGPeakModel implements Feature {
   @Override
   public int getMostIntenseFragmentScanNumber() {
     return fragmentScan;
+  }
+
+  @Override
+  public int[] getAllMS2FragmentScanNumbers() {
+    return allMS2FragmentScanNumbers;
   }
 
   @Override
@@ -475,12 +481,6 @@ public class EMGPeakModel implements Feature {
   @Override
   public void setAsymmetryFactor(Double af) {
     this.af = af;
-  }
-
-  @Override
-  public int[] getAllMS2FragmentScanNumbers() {
-    // TODO
-    return null;
   }
 
 }

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/shapemodeler/peakmodels/EMGPeakModel.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/shapemodeler/peakmodels/EMGPeakModel.java
@@ -21,20 +21,17 @@ package net.sf.mzmine.modules.peaklistmethods.peakpicking.shapemodeler.peakmodel
 import java.util.Iterator;
 import java.util.TreeMap;
 import java.util.logging.Logger;
-
 import javax.annotation.Nonnull;
-
+import com.google.common.collect.Range;
 import net.sf.mzmine.datamodel.DataPoint;
 import net.sf.mzmine.datamodel.Feature;
 import net.sf.mzmine.datamodel.IsotopePattern;
 import net.sf.mzmine.datamodel.RawDataFile;
 import net.sf.mzmine.datamodel.impl.SimpleDataPoint;
+import net.sf.mzmine.datamodel.impl.SimplePeakInformation;
 import net.sf.mzmine.modules.peaklistmethods.peakpicking.deconvolution.savitzkygolay.SGDerivative;
 import net.sf.mzmine.util.PeakUtils;
 import net.sf.mzmine.util.RangeUtils;
-
-import com.google.common.collect.Range;
-import net.sf.mzmine.datamodel.impl.SimplePeakInformation;
 
 public class EMGPeakModel implements Feature {
   private SimplePeakInformation peakInfo;
@@ -121,67 +118,83 @@ public class EMGPeakModel implements Feature {
   }
 
   // dulab Edit
+  @Override
   public void outputChromToFile() {
     int nothing = -1;
   }
 
+  @Override
   public void setPeakInformation(SimplePeakInformation peakInfoIn) {
     this.peakInfo = peakInfoIn;
   }
 
+  @Override
   public SimplePeakInformation getPeakInformation() {
     return peakInfo;
   }
   // End dulab Edit
 
+  @Override
   public double getArea() {
     return area;
   }
 
+  @Override
   public @Nonnull RawDataFile getDataFile() {
     return rawDataFile;
   }
 
+  @Override
   public double getHeight() {
     return height;
   }
 
+  @Override
   public double getMZ() {
     return mz;
   }
 
+  @Override
   public int getMostIntenseFragmentScanNumber() {
     return fragmentScan;
   }
 
+  @Override
   public DataPoint getDataPoint(int scanNumber) {
     return dataPointsMap.get(scanNumber);
   }
 
+  @Override
   public @Nonnull FeatureStatus getFeatureStatus() {
     return status;
   }
 
+  @Override
   public double getRT() {
     return rt;
   }
 
+  @Override
   public @Nonnull Range<Double> getRawDataPointsIntensityRange() {
     return rawDataPointsIntensityRange;
   }
 
+  @Override
   public @Nonnull Range<Double> getRawDataPointsMZRange() {
     return rawDataPointsMZRange;
   }
 
+  @Override
   public @Nonnull Range<Double> getRawDataPointsRTRange() {
     return rawDataPointsRTRange;
   }
 
+  @Override
   public int getRepresentativeScanNumber() {
     return representativeScan;
   }
 
+  @Override
   public @Nonnull int[] getScanNumbers() {
     return scanNumbers;
   }
@@ -190,10 +203,12 @@ public class EMGPeakModel implements Feature {
     return "EMG peak " + PeakUtils.peakToString(this);
   }
 
+  @Override
   public IsotopePattern getIsotopePattern() {
     return isotopePattern;
   }
 
+  @Override
   public void setIsotopePattern(@Nonnull IsotopePattern isotopePattern) {
     this.isotopePattern = isotopePattern;
   }
@@ -413,7 +428,7 @@ public class EMGPeakModel implements Feature {
     double partB3 = (C / 24) * (Math.pow(partB1, 4) - (6 * Math.pow(partB1, 2)) + 3);
     double partB = 1 + partB2 + partB3;
 
-    shapeHeight = (double) (partA * partB);
+    shapeHeight = partA * partB;
 
     if (shapeHeight < 0)
       shapeHeight = 0;
@@ -421,37 +436,51 @@ public class EMGPeakModel implements Feature {
     return shapeHeight;
   }
 
+  @Override
   public int getCharge() {
     return charge;
   }
 
+  @Override
   public void setCharge(int charge) {
     this.charge = charge;
   }
 
 
+  @Override
   public Double getFWHM() {
     return fwhm;
   }
 
+  @Override
   public void setFWHM(Double fwhm) {
     this.fwhm = fwhm;
   }
 
+  @Override
   public Double getTailingFactor() {
     return tf;
   }
 
+  @Override
   public void setTailingFactor(Double tf) {
     this.tf = tf;
   }
 
+  @Override
   public Double getAsymmetryFactor() {
     return af;
   }
 
+  @Override
   public void setAsymmetryFactor(Double af) {
     this.af = af;
+  }
+
+  @Override
+  public int[] getAllMS2FragmentScanNumbers() {
+    // TODO
+    return null;
   }
 
 }

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/shapemodeler/peakmodels/GaussianPeakModel.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/shapemodeler/peakmodels/GaussianPeakModel.java
@@ -42,6 +42,7 @@ public class GaussianPeakModel implements Feature {
   private RawDataFile rawDataFile;
   private FeatureStatus status;
   private int representativeScan = -1, fragmentScan = -1;
+  private int[] allMS2FragmentScanNumbers = new int[] {-1};
   private Range<Double> rawDataPointsIntensityRange, rawDataPointsMZRange, rawDataPointsRTRange;
   private TreeMap<Integer, DataPoint> dataPointsMap;
 
@@ -362,8 +363,7 @@ public class GaussianPeakModel implements Feature {
 
   @Override
   public int[] getAllMS2FragmentScanNumbers() {
-    // TODO
-    return null;
+    return allMS2FragmentScanNumbers;
   }
 
 }

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/shapemodeler/peakmodels/GaussianPeakModel.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/shapemodeler/peakmodels/GaussianPeakModel.java
@@ -20,19 +20,16 @@ package net.sf.mzmine.modules.peaklistmethods.peakpicking.shapemodeler.peakmodel
 
 import java.util.Iterator;
 import java.util.TreeMap;
-
 import javax.annotation.Nonnull;
-
+import com.google.common.collect.Range;
 import net.sf.mzmine.datamodel.DataPoint;
 import net.sf.mzmine.datamodel.Feature;
 import net.sf.mzmine.datamodel.IsotopePattern;
 import net.sf.mzmine.datamodel.RawDataFile;
 import net.sf.mzmine.datamodel.impl.SimpleDataPoint;
+import net.sf.mzmine.datamodel.impl.SimplePeakInformation;
 import net.sf.mzmine.util.PeakUtils;
 import net.sf.mzmine.util.RangeUtils;
-
-import com.google.common.collect.Range;
-import net.sf.mzmine.datamodel.impl.SimplePeakInformation;
 
 public class GaussianPeakModel implements Feature {
   private SimplePeakInformation peakInfo;
@@ -74,7 +71,7 @@ public class GaussianPeakModel implements Feature {
     // FWHM = MathUtils.calcStd(intensities) * 2.355;
 
     partC = FWHM / CONST;
-    part2C2 = 2f * (double) Math.pow(partC, 2);
+    part2C2 = 2f * Math.pow(partC, 2);
 
     // Calculate intensity of each point in the shape.
     double shapeHeight, currentRT, previousRT, previousHeight;
@@ -116,67 +113,83 @@ public class GaussianPeakModel implements Feature {
   }
 
   // dulab Edit
+  @Override
   public void outputChromToFile() {
     int nothing = -1;
   }
 
+  @Override
   public void setPeakInformation(SimplePeakInformation peakInfoIn) {
     this.peakInfo = peakInfoIn;
   }
 
+  @Override
   public SimplePeakInformation getPeakInformation() {
     return peakInfo;
   }
   // End dulab Edit
 
+  @Override
   public double getArea() {
     return area;
   }
 
+  @Override
   public @Nonnull RawDataFile getDataFile() {
     return rawDataFile;
   }
 
+  @Override
   public double getHeight() {
     return height;
   }
 
+  @Override
   public double getMZ() {
     return mz;
   }
 
+  @Override
   public int getMostIntenseFragmentScanNumber() {
     return fragmentScan;
   }
 
+  @Override
   public DataPoint getDataPoint(int scanNumber) {
     return dataPointsMap.get(scanNumber);
   }
 
+  @Override
   public @Nonnull FeatureStatus getFeatureStatus() {
     return status;
   }
 
+  @Override
   public double getRT() {
     return rt;
   }
 
+  @Override
   public @Nonnull Range<Double> getRawDataPointsIntensityRange() {
     return rawDataPointsIntensityRange;
   }
 
+  @Override
   public @Nonnull Range<Double> getRawDataPointsMZRange() {
     return rawDataPointsMZRange;
   }
 
+  @Override
   public @Nonnull Range<Double> getRawDataPointsRTRange() {
     return rawDataPointsRTRange;
   }
 
+  @Override
   public int getRepresentativeScanNumber() {
     return representativeScan;
   }
 
+  @Override
   public @Nonnull int[] getScanNumbers() {
     return scanNumbers;
   }
@@ -185,10 +198,12 @@ public class GaussianPeakModel implements Feature {
     return "Gaussian peak " + PeakUtils.peakToString(this);
   }
 
+  @Override
   public IsotopePattern getIsotopePattern() {
     return isotopePattern;
   }
 
+  @Override
   public void setIsotopePattern(@Nonnull IsotopePattern isotopePattern) {
     this.isotopePattern = isotopePattern;
   }
@@ -196,9 +211,9 @@ public class GaussianPeakModel implements Feature {
   public double calculateIntensity(double retentionTime) {
 
     // Using the Gaussian function we calculate the intensity at given m/z
-    double diff2 = (double) Math.pow(retentionTime - rt, 2);
+    double diff2 = Math.pow(retentionTime - rt, 2);
     double exponent = -1 * (diff2 / part2C2);
-    double eX = (double) Math.exp(exponent);
+    double eX = Math.exp(exponent);
     double intensity = height * eX;
     return intensity;
   }
@@ -304,37 +319,51 @@ public class GaussianPeakModel implements Feature {
     return aproximatedFWHM;
   }
 
+  @Override
   public int getCharge() {
     return charge;
   }
 
+  @Override
   public void setCharge(int charge) {
     this.charge = charge;
   }
 
 
+  @Override
   public Double getFWHM() {
     return fwhm;
   }
 
+  @Override
   public void setFWHM(Double fwhm) {
     this.fwhm = fwhm;
   }
 
+  @Override
   public Double getTailingFactor() {
     return tf;
   }
 
+  @Override
   public void setTailingFactor(Double tf) {
     this.tf = tf;
   }
 
+  @Override
   public Double getAsymmetryFactor() {
     return af;
   }
 
+  @Override
   public void setAsymmetryFactor(Double af) {
     this.af = af;
+  }
+
+  @Override
+  public int[] getAllMS2FragmentScanNumbers() {
+    // TODO
+    return null;
   }
 
 }

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/shapemodeler/peakmodels/TrianglePeakModel.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/shapemodeler/peakmodels/TrianglePeakModel.java
@@ -19,18 +19,15 @@
 package net.sf.mzmine.modules.peaklistmethods.peakpicking.shapemodeler.peakmodels;
 
 import java.util.TreeMap;
-
 import javax.annotation.Nonnull;
-
+import com.google.common.collect.Range;
 import net.sf.mzmine.datamodel.DataPoint;
 import net.sf.mzmine.datamodel.Feature;
 import net.sf.mzmine.datamodel.IsotopePattern;
 import net.sf.mzmine.datamodel.RawDataFile;
 import net.sf.mzmine.datamodel.impl.SimpleDataPoint;
-import net.sf.mzmine.util.PeakUtils;
-
-import com.google.common.collect.Range;
 import net.sf.mzmine.datamodel.impl.SimplePeakInformation;
+import net.sf.mzmine.util.PeakUtils;
 
 public class TrianglePeakModel implements Feature {
   private SimplePeakInformation peakInfo;
@@ -54,54 +51,67 @@ public class TrianglePeakModel implements Feature {
   private IsotopePattern isotopePattern;
   private int charge = 0;
 
+  @Override
   public double getArea() {
     return area;
   }
 
+  @Override
   public @Nonnull RawDataFile getDataFile() {
     return rawDataFile;
   }
 
+  @Override
   public double getHeight() {
     return height;
   }
 
+  @Override
   public double getMZ() {
     return mz;
   }
 
+  @Override
   public int getMostIntenseFragmentScanNumber() {
     return fragmentScan;
   }
 
+  @Override
   public DataPoint getDataPoint(int scanNumber) {
     return dataPointsMap.get(scanNumber);
   }
 
+  @Override
   public @Nonnull FeatureStatus getFeatureStatus() {
     return status;
   }
 
+  @Override
   public double getRT() {
     return rt;
   }
 
+  @Override
   public @Nonnull Range<Double> getRawDataPointsIntensityRange() {
     return rawDataPointsIntensityRange;
   }
 
+  @Override
   public @Nonnull Range<Double> getRawDataPointsMZRange() {
     return rawDataPointsMZRange;
   }
 
+  @Override
   public @Nonnull Range<Double> getRawDataPointsRTRange() {
     return rawDataPointsRTRange;
   }
 
+  @Override
   public int getRepresentativeScanNumber() {
     return representativeScan;
   }
 
+  @Override
   public @Nonnull int[] getScanNumbers() {
     return scanNumbers;
   }
@@ -110,10 +120,12 @@ public class TrianglePeakModel implements Feature {
     return "Triangle peak " + PeakUtils.peakToString(this);
   }
 
+  @Override
   public IsotopePattern getIsotopePattern() {
     return isotopePattern;
   }
 
+  @Override
   public void setIsotopePattern(@Nonnull IsotopePattern isotopePattern) {
     this.isotopePattern = isotopePattern;
   }
@@ -137,8 +149,8 @@ public class TrianglePeakModel implements Feature {
     rtRight = retentionTimes[retentionTimes.length - 1];
     rtLeft = retentionTimes[0];
 
-    alpha = (double) Math.atan(height / (rt - rtLeft));
-    beta = (double) Math.atan(height / (rtRight - rt));
+    alpha = Math.atan(height / (rt - rtLeft));
+    beta = Math.atan(height / (rtRight - rt));
 
     // Calculate intensity of each point in the shape.
     double shapeHeight, currentRT, previousRT, previousHeight;
@@ -166,61 +178,78 @@ public class TrianglePeakModel implements Feature {
     double intensity = 0;
     if ((retentionTime > rtLeft) && (retentionTime < rtRight)) {
       if (retentionTime <= rt) {
-        intensity = (double) Math.tan(alpha) * (retentionTime - rtLeft);
+        intensity = Math.tan(alpha) * (retentionTime - rtLeft);
       }
       if (retentionTime > rt) {
-        intensity = (double) Math.tan(beta) * (rtRight - retentionTime);
+        intensity = Math.tan(beta) * (rtRight - retentionTime);
       }
     }
 
     return intensity;
   }
 
+  @Override
   public int getCharge() {
     return charge;
   }
 
+  @Override
   public void setCharge(int charge) {
     this.charge = charge;
   }
 
 
+  @Override
   public Double getFWHM() {
     return fwhm;
   }
 
+  @Override
   public void setFWHM(Double fwhm) {
     this.fwhm = fwhm;
   }
 
+  @Override
   public Double getTailingFactor() {
     return tf;
   }
 
+  @Override
   public void setTailingFactor(Double tf) {
     this.tf = tf;
   }
 
+  @Override
   public Double getAsymmetryFactor() {
     return af;
   }
 
+  @Override
   public void setAsymmetryFactor(Double af) {
     this.af = af;
   }
 
   // dulab Edit
+  @Override
   public void outputChromToFile() {
     int nothing = -1;
   }
 
+  @Override
   public void setPeakInformation(SimplePeakInformation peakInfoIn) {
     this.peakInfo = peakInfoIn;
   }
 
+  @Override
   public SimplePeakInformation getPeakInformation() {
     return peakInfo;
   }
   // End dulab Edit
+
+  @Override
+  public int[] getAllMS2FragmentScanNumbers() {
+    // TODO
+    return null;
+  }
 
 }

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/smoothing/SmoothingTask.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/smoothing/SmoothingTask.java
@@ -26,7 +26,6 @@ package net.sf.mzmine.modules.peaklistmethods.peakpicking.smoothing;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
 import net.sf.mzmine.datamodel.DataPoint;
 import net.sf.mzmine.datamodel.Feature;
 import net.sf.mzmine.datamodel.MZmineProject;
@@ -43,7 +42,6 @@ import net.sf.mzmine.modules.peaklistmethods.qualityparameters.QualityParameters
 import net.sf.mzmine.parameters.ParameterSet;
 import net.sf.mzmine.taskcontrol.AbstractTask;
 import net.sf.mzmine.taskcontrol.TaskStatus;
-
 import com.google.common.collect.Range;
 
 /**
@@ -195,7 +193,8 @@ public class SmoothingTask extends AbstractTask {
                 newRow.addPeak(dataFile,
                     new SimpleFeature(dataFile, maxDataPoint.getMZ(), peak.getRT(), maxIntensity,
                         area, scanNumbers, newDataPoints, peak.getFeatureStatus(), maxScanNumber,
-                        peak.getMostIntenseFragmentScanNumber(), peak.getRawDataPointsRTRange(),
+                        peak.getMostIntenseFragmentScanNumber(),
+                        peak.getAllMS2FragmentScanNumbers(), peak.getRawDataPointsRTRange(),
                         peak.getRawDataPointsMZRange(), intensityRange));
               }
             }

--- a/src/main/java/net/sf/mzmine/modules/projectmethods/projectload/version_2_0/PeakListElementName_2_0.java
+++ b/src/main/java/net/sf/mzmine/modules/projectmethods/projectload/version_2_0/PeakListElementName_2_0.java
@@ -30,7 +30,9 @@ public enum PeakListElementName_2_0 {
                               "isotope"), MZPEAKS("mzpeaks"), METHOD("applied_method"), METHOD_NAME(
                                   "method_name"), METHOD_PARAMETERS(
                                       "method_parameters"), REPRESENTATIVE_SCAN(
-                                          "best_scan"), FRAGMENT_SCAN("fragment_scan");
+                                          "best_scan"), FRAGMENT_SCAN(
+                                              "fragment_scan"), ALL_MS2_FRAGMENT_SCANS(
+                                                  "all_MS2_fragment_scans");
 
   private String elementName;
 

--- a/src/main/java/net/sf/mzmine/modules/projectmethods/projectload/version_2_0/PeakListOpenHandler_2_0.java
+++ b/src/main/java/net/sf/mzmine/modules/projectmethods/projectload/version_2_0/PeakListOpenHandler_2_0.java
@@ -274,6 +274,7 @@ public class PeakListOpenHandler_2_0 extends DefaultHandler implements PeakListO
 
     // <All_MS2_FRAGMENT_SCANS>
     if (qName.equals(PeakListElementName_2_5.ALL_MS2_FRAGMENT_SCANS.getElementName())) {
+      currentAllMS2FragmentScans.clear();
       Integer fragmentNumber = Integer.valueOf(getTextOfElement());
       currentAllMS2FragmentScans.add(fragmentNumber);
     }

--- a/src/main/java/net/sf/mzmine/modules/projectmethods/projectload/version_2_3/PeakListElementName_2_3.java
+++ b/src/main/java/net/sf/mzmine/modules/projectmethods/projectload/version_2_3/PeakListElementName_2_3.java
@@ -30,7 +30,9 @@ public enum PeakListElementName_2_3 {
                               "isotope"), MZPEAKS("mzpeaks"), METHOD("applied_method"), METHOD_NAME(
                                   "method_name"), METHOD_PARAMETERS(
                                       "method_parameters"), REPRESENTATIVE_SCAN(
-                                          "best_scan"), FRAGMENT_SCAN("fragment_scan");
+                                          "best_scan"), FRAGMENT_SCAN(
+                                              "fragment_scan"), ALL_MS2_FRAGMENT_SCANS(
+                                                  "all_MS2_fragment_scans");
 
   private String elementName;
 

--- a/src/main/java/net/sf/mzmine/modules/projectmethods/projectload/version_2_3/PeakListOpenHandler_2_3.java
+++ b/src/main/java/net/sf/mzmine/modules/projectmethods/projectload/version_2_3/PeakListOpenHandler_2_3.java
@@ -273,6 +273,7 @@ public class PeakListOpenHandler_2_3 extends DefaultHandler implements PeakListO
 
     // <All_MS2_FRAGMENT_SCANS>
     if (qName.equals(PeakListElementName_2_5.ALL_MS2_FRAGMENT_SCANS.getElementName())) {
+      currentAllMS2FragmentScans.clear();
       Integer fragmentNumber = Integer.valueOf(getTextOfElement());
       currentAllMS2FragmentScans.add(fragmentNumber);
     }

--- a/src/main/java/net/sf/mzmine/modules/projectmethods/projectload/version_2_5/PeakListElementName_2_5.java
+++ b/src/main/java/net/sf/mzmine/modules/projectmethods/projectload/version_2_5/PeakListElementName_2_5.java
@@ -21,8 +21,8 @@ package net.sf.mzmine.modules.projectmethods.projectload.version_2_5;
 public enum PeakListElementName_2_5 {
 
   PEAKLIST("peaklist"), PEAKLIST_DATE("created"), QUANTITY("quantity"), RAWFILE(
-      "raw_file"), PEAKLIST_NAME("pl_name"), ID("id"), RT("rt"), MZ(
-          "mz"), HEIGHT("height"), RTRANGE("rt_range"), MZRANGE("mz_range"), AREA("area"), STATUS(
+      "raw_file"), PEAKLIST_NAME("pl_name"), ID("id"), RT("rt"), MZ("mz"), HEIGHT(
+          "height"), RTRANGE("rt_range"), MZRANGE("mz_range"), AREA("area"), STATUS(
               "status"), COLUMN("column_id"), SCAN_ID("scan_id"), ROW("row"), PEAK_INFORMATION(
                   "information"), INFO_PROPERTY("information_property"), PEAK_IDENTITY(
                       "identity"), PREFERRED("preferred"), IDPROPERTY("identity_property"), NAME(
@@ -32,7 +32,9 @@ public enum PeakListElementName_2_5 {
                                       "mzpeaks"), METHOD("applied_method"), METHOD_NAME(
                                           "method_name"), METHOD_PARAMETERS(
                                               "method_parameters"), REPRESENTATIVE_SCAN(
-                                                  "best_scan"), FRAGMENT_SCAN("fragment_scan");
+                                                  "best_scan"), FRAGMENT_SCAN(
+                                                      "fragment_scan"), ALL_MS2_FRAGMENT_SCANS(
+                                                          "all_MS2_fragment_scans");
 
   private String elementName;
 

--- a/src/main/java/net/sf/mzmine/modules/projectmethods/projectload/version_2_5/PeakListOpenHandler_2_5.java
+++ b/src/main/java/net/sf/mzmine/modules/projectmethods/projectload/version_2_5/PeakListOpenHandler_2_5.java
@@ -294,6 +294,7 @@ public class PeakListOpenHandler_2_5 extends DefaultHandler implements PeakListO
 
     // <All_MS2_FRAGMENT_SCANS>
     if (qName.equals(PeakListElementName_2_5.ALL_MS2_FRAGMENT_SCANS.getElementName())) {
+      currentAllMS2FragmentScans.clear();
       Integer fragmentNumber = Integer.valueOf(getTextOfElement());
       currentAllMS2FragmentScans.add(fragmentNumber);
     }

--- a/src/main/java/net/sf/mzmine/modules/projectmethods/projectload/version_2_5/PeakListOpenHandler_2_5.java
+++ b/src/main/java/net/sf/mzmine/modules/projectmethods/projectload/version_2_5/PeakListOpenHandler_2_5.java
@@ -22,17 +22,23 @@ import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.HashMap;
 import java.util.Hashtable;
+import java.util.Map;
 import java.util.Vector;
 import java.util.logging.Logger;
-
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
-
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.DefaultHandler;
+import com.Ostermiller.util.Base64;
+import com.google.common.collect.Range;
 import net.sf.mzmine.datamodel.DataPoint;
 import net.sf.mzmine.datamodel.Feature.FeatureStatus;
 import net.sf.mzmine.datamodel.IsotopePattern.IsotopePatternStatus;
+import net.sf.mzmine.datamodel.PeakInformation;
 import net.sf.mzmine.datamodel.PeakList;
 import net.sf.mzmine.datamodel.PeakList.PeakListAppliedMethod;
 import net.sf.mzmine.datamodel.RawDataFile;
@@ -41,21 +47,11 @@ import net.sf.mzmine.datamodel.impl.SimpleDataPoint;
 import net.sf.mzmine.datamodel.impl.SimpleFeature;
 import net.sf.mzmine.datamodel.impl.SimpleIsotopePattern;
 import net.sf.mzmine.datamodel.impl.SimplePeakIdentity;
+import net.sf.mzmine.datamodel.impl.SimplePeakInformation;
 import net.sf.mzmine.datamodel.impl.SimplePeakList;
 import net.sf.mzmine.datamodel.impl.SimplePeakListAppliedMethod;
 import net.sf.mzmine.datamodel.impl.SimplePeakListRow;
 import net.sf.mzmine.modules.projectmethods.projectload.PeakListOpenHandler;
-
-import org.xml.sax.Attributes;
-import org.xml.sax.SAXException;
-import org.xml.sax.helpers.DefaultHandler;
-
-import com.Ostermiller.util.Base64;
-import com.google.common.collect.Range;
-import java.util.HashMap;
-import java.util.Map;
-import net.sf.mzmine.datamodel.PeakInformation;
-import net.sf.mzmine.datamodel.impl.SimplePeakInformation;
 
 public class PeakListOpenHandler_2_5 extends DefaultHandler implements PeakListOpenHandler {
 
@@ -68,6 +64,8 @@ public class PeakListOpenHandler_2_5 extends DefaultHandler implements PeakListO
   private String peakColumnID;
   private double mass, rt, area;
   private int[] scanNumbers;
+  private int[] allMS2FragmentScanNumbers;
+  private Vector<Integer> currentAllMS2FragmentScans;
   private double height;
   private double[] masses, intensities;
   private String peakStatus, peakListName, name, identityPropertyName, rawDataFileID;
@@ -101,6 +99,7 @@ public class PeakListOpenHandler_2_5 extends DefaultHandler implements PeakListO
   /**
    * Load the peak list from the zip file reading the XML peak list file
    */
+  @Override
   public PeakList readPeakList(InputStream peakListStream)
       throws IOException, ParserConfigurationException, SAXException {
 
@@ -112,6 +111,7 @@ public class PeakListOpenHandler_2_5 extends DefaultHandler implements PeakListO
     appliedMethodParameters = new Vector<String>();
     currentPeakListDataFiles = new Vector<RawDataFile>();
     currentIsotopes = new Vector<DataPoint>();
+    currentAllMS2FragmentScans = new Vector<Integer>();
 
     buildingPeakList = null;
 
@@ -138,6 +138,7 @@ public class PeakListOpenHandler_2_5 extends DefaultHandler implements PeakListO
     return (double) parsedRows / totalRows;
   }
 
+  @Override
   public void cancel() {
     canceled = true;
   }
@@ -146,6 +147,7 @@ public class PeakListOpenHandler_2_5 extends DefaultHandler implements PeakListO
    * @see org.xml.sax.helpers.DefaultHandler#startElement(java.lang.String, java.lang.String,
    *      java.lang.String, org.xml.sax.Attributes)
    */
+  @Override
   public void startElement(String namespaceURI, String lName, String qName, Attributes attrs)
       throws SAXException {
 
@@ -229,6 +231,7 @@ public class PeakListOpenHandler_2_5 extends DefaultHandler implements PeakListO
    * @see org.xml.sax.helpers.DefaultHandler#endElement(java.lang.String, java.lang.String,
    *      java.lang.String)
    */
+  @Override
   public void endElement(String namespaceURI, String sName, String qName) throws SAXException {
 
     if (canceled)
@@ -285,9 +288,14 @@ public class PeakListOpenHandler_2_5 extends DefaultHandler implements PeakListO
     }
 
     // <FRAGMENT_SCAN>
-
     if (qName.equals(PeakListElementName_2_5.FRAGMENT_SCAN.getElementName())) {
       fragmentScan = Integer.valueOf(getTextOfElement());
+    }
+
+    // <All_MS2_FRAGMENT_SCANS>
+    if (qName.equals(PeakListElementName_2_5.ALL_MS2_FRAGMENT_SCANS.getElementName())) {
+      Integer fragmentNumber = Integer.valueOf(getTextOfElement());
+      currentAllMS2FragmentScans.add(fragmentNumber);
     }
 
     // <MASS>
@@ -299,7 +307,7 @@ public class PeakListOpenHandler_2_5 extends DefaultHandler implements PeakListO
       masses = new double[numOfMZpeaks];
       for (int i = 0; i < numOfMZpeaks; i++) {
         try {
-          masses[i] = (double) dataInputStream.readFloat();
+          masses[i] = dataInputStream.readFloat();
         } catch (IOException ex) {
           throw new SAXException(ex);
         }
@@ -315,7 +323,7 @@ public class PeakListOpenHandler_2_5 extends DefaultHandler implements PeakListO
       intensities = new double[numOfMZpeaks];
       for (int i = 0; i < numOfMZpeaks; i++) {
         try {
-          intensities[i] = (double) dataInputStream.readFloat();
+          intensities[i] = dataInputStream.readFloat();
         } catch (IOException ex) {
           throw new SAXException(ex);
         }
@@ -364,8 +372,15 @@ public class PeakListOpenHandler_2_5 extends DefaultHandler implements PeakListO
 
       FeatureStatus status = FeatureStatus.valueOf(peakStatus);
 
+      // convert vector of allMS2FragmentScans to array
+      allMS2FragmentScanNumbers = new int[currentAllMS2FragmentScans.size()];
+      for (int i = 0; i < allMS2FragmentScanNumbers.length; i++) {
+        allMS2FragmentScanNumbers[i] = currentAllMS2FragmentScans.get(i);
+      }
+
       SimpleFeature peak = new SimpleFeature(dataFile, mass, rt, height, area, scanNumbers, mzPeaks,
-          status, representativeScan, fragmentScan, peakRTRange, peakMZRange, peakIntensityRange);
+          status, representativeScan, fragmentScan, allMS2FragmentScanNumbers, peakRTRange,
+          peakMZRange, peakIntensityRange);
 
       peak.setCharge(currentPeakCharge);
 
@@ -450,6 +465,7 @@ public class PeakListOpenHandler_2_5 extends DefaultHandler implements PeakListO
    * 
    * @see org.xml.sax.ContentHandler#characters(char[], int, int)
    */
+  @Override
   public void characters(char buf[], int offset, int len) throws SAXException {
     charBuffer = charBuffer.append(buf, offset, len);
   }

--- a/src/main/java/net/sf/mzmine/modules/projectmethods/projectsave/PeakListElementName.java
+++ b/src/main/java/net/sf/mzmine/modules/projectmethods/projectsave/PeakListElementName.java
@@ -27,14 +27,15 @@ enum PeakListElementName {
                   "information"), INFO_PROPERTY("information_property"), PEAK_IDENTITY(
                       "identity"), PREFERRED("preferred"), IDPROPERTY("identity_property"), NAME(
                           "name"), COMMENT("comment"), PEAK("peak"), ISOTOPE_PATTERN(
-                              "isotope_pattern"), DESCRIPTION(
-                                  "description"), CHARGE("charge"), ISOTOPE("isotope"), MZPEAKS(
-                                      "mzpeaks"), METHOD("applied_method"), METHOD_NAME(
+                              "isotope_pattern"), DESCRIPTION("description"), CHARGE(
+                                  "charge"), ISOTOPE("isotope"), MZPEAKS("mzpeaks"), METHOD(
+                                      "applied_method"), METHOD_NAME(
                                           "method_name"), METHOD_PARAMETERS(
                                               "method_parameters"), REPRESENTATIVE_SCAN(
                                                   "best_scan"), FRAGMENT_SCAN(
-                                                      "fragment_scan"), INDEX(
-                                                          "index"), SHARPNESS("sharpness");
+                                                      "fragment_scan"), ALL_MS2_FRAGMENT_SCANS(
+                                                          "all_MS2_fragment_scans"), INDEX(
+                                                              "index"), SHARPNESS("sharpness");
   private String elementName;
 
   private PeakListElementName(String itemName) {

--- a/src/main/java/net/sf/mzmine/modules/projectmethods/projectsave/PeakListSaveHandler.java
+++ b/src/main/java/net/sf/mzmine/modules/projectmethods/projectsave/PeakListSaveHandler.java
@@ -324,9 +324,7 @@ public class PeakListSaveHandler {
     hd.endElement("", "", PeakListElementName.FRAGMENT_SCAN.getElementName());
 
     // <ALL_MS2_FRAGMENT_SCANS>
-    // hd.startElement("", "", PeakListElementName.ALL_MS2_FRAGMENT_SCANS.getElementName(), atts);
     fillAllMS2FragmentScanNumbers(peak.getAllMS2FragmentScanNumbers(), hd);
-    // hd.endElement("", "", PeakListElementName.ALL_MS2_FRAGMENT_SCANS.getElementName());
 
     int scanNumbers[] = peak.getScanNumbers();
 

--- a/src/main/java/net/sf/mzmine/modules/projectmethods/projectsave/PeakListSaveHandler.java
+++ b/src/main/java/net/sf/mzmine/modules/projectmethods/projectsave/PeakListSaveHandler.java
@@ -28,29 +28,25 @@ import java.util.Date;
 import java.util.Hashtable;
 import java.util.Map;
 import java.util.Map.Entry;
-
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.sax.SAXTransformerFactory;
 import javax.xml.transform.sax.TransformerHandler;
 import javax.xml.transform.stream.StreamResult;
-
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.AttributesImpl;
+import com.Ostermiller.util.Base64;
 import net.sf.mzmine.datamodel.DataPoint;
 import net.sf.mzmine.datamodel.Feature;
 import net.sf.mzmine.datamodel.IsotopePattern;
 import net.sf.mzmine.datamodel.PeakIdentity;
+import net.sf.mzmine.datamodel.PeakInformation;
 import net.sf.mzmine.datamodel.PeakList;
 import net.sf.mzmine.datamodel.PeakList.PeakListAppliedMethod;
 import net.sf.mzmine.datamodel.PeakListRow;
 import net.sf.mzmine.datamodel.RawDataFile;
 import net.sf.mzmine.datamodel.impl.SimplePeakList;
-
-import org.xml.sax.SAXException;
-import org.xml.sax.helpers.AttributesImpl;
-
-import com.Ostermiller.util.Base64;
-import net.sf.mzmine.datamodel.PeakInformation;
 
 public class PeakListSaveHandler {
 
@@ -327,6 +323,11 @@ public class PeakListSaveHandler {
         String.valueOf(peak.getMostIntenseFragmentScanNumber()).length());
     hd.endElement("", "", PeakListElementName.FRAGMENT_SCAN.getElementName());
 
+    // <ALL_MS2_FRAGMENT_SCANS>
+    // hd.startElement("", "", PeakListElementName.ALL_MS2_FRAGMENT_SCANS.getElementName(), atts);
+    fillAllMS2FragmentScanNumbers(peak.getAllMS2FragmentScanNumbers(), hd);
+    // hd.endElement("", "", PeakListElementName.ALL_MS2_FRAGMENT_SCANS.getElementName());
+
     int scanNumbers[] = peak.getScanNumbers();
 
     // <ISOTOPE_PATTERN>
@@ -412,6 +413,16 @@ public class PeakListSaveHandler {
       String isotopeString = isotope.getMZ() + ":" + isotope.getIntensity();
       hd.characters(isotopeString.toCharArray(), 0, isotopeString.length());
       hd.endElement("", "", PeakListElementName.ISOTOPE.getElementName());
+    }
+  }
+
+  private void fillAllMS2FragmentScanNumbers(int[] scanNumbers, TransformerHandler hd)
+      throws SAXException, IOException {
+    AttributesImpl atts = new AttributesImpl();
+    for (int scan : scanNumbers) {
+      hd.startElement("", "", PeakListElementName.ALL_MS2_FRAGMENT_SCANS.getElementName(), atts);
+      hd.characters(String.valueOf(scan).toCharArray(), 0, String.valueOf(scan).length());
+      hd.endElement("", "", PeakListElementName.ALL_MS2_FRAGMENT_SCANS.getElementName());
     }
   }
 

--- a/src/main/java/net/sf/mzmine/modules/rawdatamethods/peakpicking/manual/ManualPeak.java
+++ b/src/main/java/net/sf/mzmine/modules/rawdatamethods/peakpicking/manual/ManualPeak.java
@@ -19,21 +19,18 @@
 package net.sf.mzmine.modules.rawdatamethods.peakpicking.manual;
 
 import java.util.TreeMap;
-
 import javax.annotation.Nonnull;
-
+import com.google.common.collect.Range;
+import com.google.common.primitives.Ints;
 import net.sf.mzmine.datamodel.DataPoint;
 import net.sf.mzmine.datamodel.Feature;
 import net.sf.mzmine.datamodel.IsotopePattern;
 import net.sf.mzmine.datamodel.RawDataFile;
 import net.sf.mzmine.datamodel.Scan;
+import net.sf.mzmine.datamodel.impl.SimplePeakInformation;
 import net.sf.mzmine.util.MathUtils;
 import net.sf.mzmine.util.PeakUtils;
 import net.sf.mzmine.util.ScanUtils;
-
-import com.google.common.collect.Range;
-import com.google.common.primitives.Ints;
-import net.sf.mzmine.datamodel.impl.SimplePeakInformation;
 
 /**
  * This class represents a manually picked chromatographic peak.
@@ -57,6 +54,9 @@ class ManualPeak implements Feature {
   // Number of most intense fragment scan
   private int fragmentScan, representativeScan;
 
+  // Number of all MS2 fragment scans
+  private int[] allMS2FragmentScanNumbers;
+
   // Isotope pattern. Null by default but can be set later by deisotoping
   // method.
   private IsotopePattern isotopePattern;
@@ -73,6 +73,7 @@ class ManualPeak implements Feature {
   /**
    * This peak is always a result of manual peak detection, therefore MANUAL
    */
+  @Override
   public @Nonnull FeatureStatus getFeatureStatus() {
     return FeatureStatus.MANUAL;
   }
@@ -80,6 +81,7 @@ class ManualPeak implements Feature {
   /**
    * This method returns M/Z value of the peak
    */
+  @Override
   public double getMZ() {
     return mz;
   }
@@ -87,6 +89,7 @@ class ManualPeak implements Feature {
   /**
    * This method returns retention time of the peak
    */
+  @Override
   public double getRT() {
     return rt;
   }
@@ -94,6 +97,7 @@ class ManualPeak implements Feature {
   /**
    * This method returns the raw height of the peak
    */
+  @Override
   public double getHeight() {
     return height;
   }
@@ -101,6 +105,7 @@ class ManualPeak implements Feature {
   /**
    * This method returns the raw area of the peak
    */
+  @Override
   public double getArea() {
     return area;
   }
@@ -108,6 +113,7 @@ class ManualPeak implements Feature {
   /**
    * This method returns numbers of scans that contain this peak
    */
+  @Override
   public @Nonnull int[] getScanNumbers() {
     return Ints.toArray(dataPointMap.keySet());
   }
@@ -115,18 +121,22 @@ class ManualPeak implements Feature {
   /**
    * This method returns a representative datapoint of this peak in a given scan
    */
+  @Override
   public DataPoint getDataPoint(int scanNumber) {
     return dataPointMap.get(scanNumber);
   }
 
+  @Override
   public @Nonnull Range<Double> getRawDataPointsIntensityRange() {
     return intensityRange;
   }
 
+  @Override
   public @Nonnull Range<Double> getRawDataPointsMZRange() {
     return mzRange;
   }
 
+  @Override
   public @Nonnull Range<Double> getRawDataPointsRTRange() {
     return rtRange;
   }
@@ -134,6 +144,7 @@ class ManualPeak implements Feature {
   /**
    * @see net.sf.mzmine.datamodel.Feature#getDataFile()
    */
+  @Override
   public @Nonnull RawDataFile getDataFile() {
     return dataFile;
   }
@@ -142,10 +153,12 @@ class ManualPeak implements Feature {
     return PeakUtils.peakToString(this);
   }
 
+  @Override
   public IsotopePattern getIsotopePattern() {
     return isotopePattern;
   }
 
+  @Override
   public void setIsotopePattern(@Nonnull IsotopePattern isotopePattern) {
     this.isotopePattern = isotopePattern;
   }
@@ -239,6 +252,8 @@ class ManualPeak implements Feature {
 
     fragmentScan = ScanUtils.findBestFragmentScan(dataFile, rtRange, mzRange);
 
+    allMS2FragmentScanNumbers = ScanUtils.findAllMS2FragmentScans(dataFile, rtRange, mzRange);
+
     if (fragmentScan > 0) {
       Scan fragmentScanObject = dataFile.getScan(fragmentScan);
       int precursorCharge = fragmentScanObject.getPrecursorCharge();
@@ -248,55 +263,73 @@ class ManualPeak implements Feature {
 
   }
 
+  @Override
   public int getRepresentativeScanNumber() {
     return representativeScan;
   }
 
+  @Override
   public int getMostIntenseFragmentScanNumber() {
     return fragmentScan;
   }
 
+  @Override
+  public int[] getAllMS2FragmentScanNumbers() {
+    return allMS2FragmentScanNumbers;
+  }
+
+  @Override
   public int getCharge() {
     return charge;
   }
 
+  @Override
   public void setCharge(int charge) {
     this.charge = charge;
   }
 
+  @Override
   public Double getFWHM() {
     return fwhm;
   }
 
+  @Override
   public void setFWHM(Double fwhm) {
     this.fwhm = fwhm;
   }
 
+  @Override
   public Double getTailingFactor() {
     return tf;
   }
 
+  @Override
   public void setTailingFactor(Double tf) {
     this.tf = tf;
   }
 
+  @Override
   public Double getAsymmetryFactor() {
     return af;
   }
 
+  @Override
   public void setAsymmetryFactor(Double af) {
     this.af = af;
   }
 
   // dulab Edit
+  @Override
   public void outputChromToFile() {
     int nothing = -1;
   }
 
+  @Override
   public void setPeakInformation(SimplePeakInformation peakInfoIn) {
     this.peakInfo = peakInfoIn;
   }
 
+  @Override
   public SimplePeakInformation getPeakInformation() {
     return peakInfo;
   }

--- a/src/main/java/net/sf/mzmine/modules/rawdatamethods/peakpicking/msms/MsMsPeakPickingTask.java
+++ b/src/main/java/net/sf/mzmine/modules/rawdatamethods/peakpicking/msms/MsMsPeakPickingTask.java
@@ -19,7 +19,7 @@
 package net.sf.mzmine.modules.rawdatamethods.peakpicking.msms;
 
 import java.util.logging.Logger;
-
+import com.google.common.collect.Range;
 import net.sf.mzmine.datamodel.DataPoint;
 import net.sf.mzmine.datamodel.Feature.FeatureStatus;
 import net.sf.mzmine.datamodel.MZmineProject;
@@ -35,8 +35,6 @@ import net.sf.mzmine.parameters.parametertypes.selectors.ScanSelection;
 import net.sf.mzmine.taskcontrol.AbstractTask;
 import net.sf.mzmine.taskcontrol.TaskStatus;
 import net.sf.mzmine.util.ScanUtils;
-
-import com.google.common.collect.Range;
 
 public class MsMsPeakPickingTask extends AbstractTask {
   private Logger logger = Logger.getLogger(this.getClass().getName());
@@ -64,16 +62,19 @@ public class MsMsPeakPickingTask extends AbstractTask {
     return dataFile;
   }
 
+  @Override
   public double getFinishedPercentage() {
     if (totalScans == 0)
       return 0f;
     return (double) processedScans / totalScans;
   }
 
+  @Override
   public String getTaskDescription() {
     return "Building MS/MS Peaklist based on MS/MS from " + dataFile;
   }
 
+  @Override
   public void run() {
 
     setStatus(TaskStatus.PROCESSING);
@@ -122,7 +123,7 @@ public class MsMsPeakPickingTask extends AbstractTask {
       SimpleFeature c = new SimpleFeature(dataFile, scan.getPrecursorMZ(),
           bestScan.getRetentionTime(), maxPoint.getIntensity(), maxPoint.getIntensity(),
           new int[] {bestScan.getScanNumber()}, new DataPoint[] {maxPoint}, FeatureStatus.DETECTED,
-          bestScan.getScanNumber(), scan.getScanNumber(),
+          bestScan.getScanNumber(), scan.getScanNumber(), new int[] {-1},
           Range.singleton(bestScan.getRetentionTime()), Range.singleton(scan.getPrecursorMZ()),
           Range.singleton(maxPoint.getIntensity()));
 

--- a/src/main/java/net/sf/mzmine/modules/rawdatamethods/peakpicking/targetedpeakdetection/Gap.java
+++ b/src/main/java/net/sf/mzmine/modules/rawdatamethods/peakpicking/targetedpeakdetection/Gap.java
@@ -20,7 +20,7 @@ package net.sf.mzmine.modules.rawdatamethods.peakpicking.targetedpeakdetection;
 
 import java.util.List;
 import java.util.Vector;
-
+import com.google.common.collect.Range;
 import net.sf.mzmine.datamodel.DataPoint;
 import net.sf.mzmine.datamodel.Feature.FeatureStatus;
 import net.sf.mzmine.datamodel.PeakListRow;
@@ -29,8 +29,6 @@ import net.sf.mzmine.datamodel.Scan;
 import net.sf.mzmine.datamodel.impl.SimpleDataPoint;
 import net.sf.mzmine.datamodel.impl.SimpleFeature;
 import net.sf.mzmine.util.ScanUtils;
-
-import com.google.common.collect.Range;
 
 class Gap {
 
@@ -183,11 +181,15 @@ class Gap {
       // Find the best fragmentation scan, if available
       int fragmentScan = ScanUtils.findBestFragmentScan(rawDataFile, finalRTRange, finalMZRange);
 
+      // Find all MS2 fragment scans, if available
+      int[] allMS2fragmentScanNumbers =
+          ScanUtils.findAllMS2FragmentScans(rawDataFile, finalRTRange, finalMZRange);
+
       // Is intensity above the noise level?
       if (height >= noiseLevel) {
         SimpleFeature newPeak = new SimpleFeature(rawDataFile, mz, rt, height, area, scanNumbers,
-            finalDataPoint, FeatureStatus.ESTIMATED, representativeScan, fragmentScan, finalRTRange,
-            finalMZRange, finalIntensityRange);
+            finalDataPoint, FeatureStatus.ESTIMATED, representativeScan, fragmentScan,
+            allMS2fragmentScanNumbers, finalRTRange, finalMZRange, finalIntensityRange);
 
         // Fill the gap
         peakListRow.addPeak(rawDataFile, newPeak);

--- a/src/main/java/net/sf/mzmine/util/ScanUtils.java
+++ b/src/main/java/net/sf/mzmine/util/ScanUtils.java
@@ -27,11 +27,8 @@ import java.text.Format;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
-
 import javax.annotation.Nonnull;
-
 import com.google.common.collect.Range;
-
 import net.sf.mzmine.datamodel.DataPoint;
 import net.sf.mzmine.datamodel.MassSpectrumType;
 import net.sf.mzmine.datamodel.RawDataFile;
@@ -462,6 +459,38 @@ public class ScanUtils {
 
   }
 
+
+  /**
+   * Finds all MS/MS scans on MS2 level within given retention time range and with precursor m/z
+   * within given m/z range
+   */
+  public static int[] findAllMS2FragmentScans(RawDataFile dataFile, Range<Double> rtRange,
+      Range<Double> mzRange) {
+
+    assert dataFile != null;
+    assert rtRange != null;
+    assert mzRange != null;
+
+    int[] fragmentScanNumbers = dataFile.getScanNumbers(2, rtRange);
+    ArrayList<Integer> fragmentScanNumbersInMZRange = new ArrayList<Integer>();
+
+    for (int number : fragmentScanNumbers) {
+
+      Scan scan = dataFile.getScan(number);
+
+      if (mzRange.contains(scan.getPrecursorMZ())) {
+        fragmentScanNumbersInMZRange.add(number);
+      }
+    }
+    int[] resultScans = new int[fragmentScanNumbersInMZRange.size()];
+    if (resultScans.length > 0) {
+      resultScans = fragmentScanNumbersInMZRange.stream().mapToInt(i -> i).toArray();
+    } else {
+      resultScans = new int[] {-1};
+    }
+    return resultScans;
+  }
+
   /**
    * Find the highest data point in array
    * 
@@ -523,7 +552,7 @@ public class ScanUtils {
     return Range.closed(lowRt, highRt);
   }
 
-   public static byte[] encodeDataPointsToBytes(DataPoint dataPoints[]) {
+  public static byte[] encodeDataPointsToBytes(DataPoint dataPoints[]) {
     ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
     DataOutputStream peakStream = new DataOutputStream(byteStream);
     for (int i = 0; i < dataPoints.length; i++) {


### PR DESCRIPTION
Dear Tomas,
I have added a new method to the data model that allows access to all MS/MS scans of the same precursor mass of a feature. Every feature now holds an int[] containing all MS/MS scan numbers. MS/MS scan numbers are assigned at peak deconvolution similar to the "getBestFragmentation()" method. I have noticed that the previously stored "best fragmentation" scan number is set to -1 if no scan was found or no scan was assigned. I followed that logic. I have also implemented that method into the lipid search module. I get much better results now. I have also modified the project saving and loading methods. All MS/MS scan numbers on MS2 level are now also stored in the xml file. So far I didn't have any backwards compatibility issues with old or new project files I have saved with this version at reopening them in an older MZmine version. 
I have added the method to all modules that are using the feature class. I hope i didn't break anything. All methods that use the "getBestFragmentation()" method are still working fine since I did not modify it.
Best wishes,
Ansgar 