### PR TITLE
Parent row ID that we discussed in #553

### DIFF
--- a/src/main/java/net/sf/mzmine/datamodel/Feature.java
+++ b/src/main/java/net/sf/mzmine/datamodel/Feature.java
@@ -182,4 +182,8 @@ public interface Feature {
   public SimplePeakInformation getPeakInformation();
   // End dulab Edit
 
+  @Nullable
+  default public Integer getParentChromatogramRowID() {
+    return null;
+  }
 }

--- a/src/main/java/net/sf/mzmine/datamodel/PeakListRow.java
+++ b/src/main/java/net/sf/mzmine/datamodel/PeakListRow.java
@@ -202,10 +202,4 @@ public interface PeakListRow {
   public void setID(int id);
 
   // End DorresteinLab edit
-
-  // DuLab edit
-  public void setParentRowID(Integer id);
-
-  public Integer getParentRowID();
-  // End of DuLab edit
 }

--- a/src/main/java/net/sf/mzmine/datamodel/PeakListRow.java
+++ b/src/main/java/net/sf/mzmine/datamodel/PeakListRow.java
@@ -203,4 +203,9 @@ public interface PeakListRow {
 
   // End DorresteinLab edit
 
+  // DuLab edit
+  public void setParentRowID(Integer id);
+
+  public Integer getParentRowID();
+  // End of DuLab edit
 }

--- a/src/main/java/net/sf/mzmine/datamodel/impl/SimpleFeature.java
+++ b/src/main/java/net/sf/mzmine/datamodel/impl/SimpleFeature.java
@@ -20,6 +20,8 @@ package net.sf.mzmine.datamodel.impl;
 
 import java.util.Arrays;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import com.google.common.collect.Range;
 import com.google.common.primitives.Doubles;
 import io.github.msdk.datamodel.Chromatogram;
@@ -66,6 +68,10 @@ public class SimpleFeature implements Feature {
   private IsotopePattern isotopePattern;
   private int charge = 0;
 
+  // PeakListRow.ID of the chromatogram where this feature is detected. Null by default but can be set by
+  // chromatogram deconvolution method.
+  private Integer parentChromatogramRowID;
+
   /**
    * Initializes a new peak using given values
    * 
@@ -96,6 +102,7 @@ public class SimpleFeature implements Feature {
     this.fwhm = null;
     this.tf = null;
     this.af = null;
+    this.parentChromatogramRowID = null;
   }
 
   /**
@@ -133,6 +140,7 @@ public class SimpleFeature implements Feature {
     this.fragmentScanNumber = p.getMostIntenseFragmentScanNumber();
     this.allMS2FragmentScanNumbers = p.getAllMS2FragmentScanNumbers();
 
+    this.parentChromatogramRowID = p.getParentChromatogramRowID();
   }
 
   /**
@@ -179,6 +187,7 @@ public class SimpleFeature implements Feature {
       }
     }
 
+    this.parentChromatogramRowID = null; //TODO: ask Tomas and update
   }
 
   /**
@@ -414,4 +423,13 @@ public class SimpleFeature implements Feature {
   }
   // End dulab Edit
 
+  public void setParentChromatogramRowID(@Nullable Integer id) {
+    this.parentChromatogramRowID = id;
+  }
+
+  @Override
+  @Nullable
+  public Integer getParentChromatogramRowID() {
+    return this.parentChromatogramRowID;
+  }
 }

--- a/src/main/java/net/sf/mzmine/datamodel/impl/SimplePeakListRow.java
+++ b/src/main/java/net/sf/mzmine/datamodel/impl/SimplePeakListRow.java
@@ -38,8 +38,6 @@ import net.sf.mzmine.util.PeakSorter;
 import net.sf.mzmine.util.SortingDirection;
 import net.sf.mzmine.util.SortingProperty;
 
-import javax.annotation.Nullable;
-
 /**
  * Implementation of PeakListRow
  */
@@ -54,9 +52,6 @@ public class SimplePeakListRow implements PeakListRow {
   private PeakInformation information;
   private int myID;
   private double maxDataPointIntensity = 0;
-
-  @Nullable
-  private Integer parentRowID;
 
   /**
    * These variables are used for caching the average values, so we don't need to calculate them
@@ -416,17 +411,5 @@ public class SimplePeakListRow implements PeakListRow {
     this.calculateAverageValues();
   }
   // End Gauthier edit
-
-
-  @Override
-  public void setParentRowID(@Nullable Integer id) {
-    parentRowID = id;
-  }
-
-  @Override
-  @Nullable
-  public Integer getParentRowID() {
-    return parentRowID;
-  }
 }
 // End DorresteinLab edit

--- a/src/main/java/net/sf/mzmine/datamodel/impl/SimplePeakListRow.java
+++ b/src/main/java/net/sf/mzmine/datamodel/impl/SimplePeakListRow.java
@@ -38,6 +38,8 @@ import net.sf.mzmine.util.PeakSorter;
 import net.sf.mzmine.util.SortingDirection;
 import net.sf.mzmine.util.SortingProperty;
 
+import javax.annotation.Nullable;
+
 /**
  * Implementation of PeakListRow
  */
@@ -52,6 +54,7 @@ public class SimplePeakListRow implements PeakListRow {
   private PeakInformation information;
   private int myID;
   private double maxDataPointIntensity = 0;
+  private Integer parentRowID;
 
   /**
    * These variables are used for caching the average values, so we don't need to calculate them
@@ -413,5 +416,15 @@ public class SimplePeakListRow implements PeakListRow {
   // End Gauthier edit
 
 
+  @Override
+  public void setParentRowID(Integer id) {
+    parentRowID = id;
+  }
+
+  @Override
+  @Nullable
+  public Integer getParentRowID() {
+    return parentRowID;
+  }
 }
 // End DorresteinLab edit

--- a/src/main/java/net/sf/mzmine/datamodel/impl/SimplePeakListRow.java
+++ b/src/main/java/net/sf/mzmine/datamodel/impl/SimplePeakListRow.java
@@ -54,6 +54,8 @@ public class SimplePeakListRow implements PeakListRow {
   private PeakInformation information;
   private int myID;
   private double maxDataPointIntensity = 0;
+
+  @Nullable
   private Integer parentRowID;
 
   /**
@@ -417,7 +419,7 @@ public class SimplePeakListRow implements PeakListRow {
 
 
   @Override
-  public void setParentRowID(Integer id) {
+  public void setParentRowID(@Nullable Integer id) {
     parentRowID = id;
   }
 

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/adap3decompositionV2/ADAP3DecompositionV2Parameters.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/adap3decompositionV2/ADAP3DecompositionV2Parameters.java
@@ -46,7 +46,7 @@ public class ADAP3DecompositionV2Parameters extends SimpleParameterSet {
     public static final DoubleParameter PREF_WINDOW_WIDTH =
             new DoubleParameter("Deconvolution window width (min)",
                     "Preferred width of deconvolution windows (in minutes).",
-                    NumberFormat.getNumberInstance(), 0.5);
+                    NumberFormat.getNumberInstance(), 0.05);
 
     // ------------------------------------------------------------------------
     // ----- End of First-phase parameters ------------------------------------

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/adap3decompositionV2/ADAP3DecompositionV2Parameters.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/adap3decompositionV2/ADAP3DecompositionV2Parameters.java
@@ -46,7 +46,7 @@ public class ADAP3DecompositionV2Parameters extends SimpleParameterSet {
     public static final DoubleParameter PREF_WINDOW_WIDTH =
             new DoubleParameter("Deconvolution window width (min)",
                     "Preferred width of deconvolution windows (in minutes).",
-                    NumberFormat.getNumberInstance(), 0.05);
+                    NumberFormat.getNumberInstance(), 0.5);
 
     // ------------------------------------------------------------------------
     // ----- End of First-phase parameters ------------------------------------

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/ADAPpeakpicking/ADAPDetector.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/ADAPpeakpicking/ADAPDetector.java
@@ -110,7 +110,7 @@ public class ADAPDetector implements PeakResolver {
   }
 
   @Override
-  public Feature[] resolvePeaks(final Feature chromatogram, final ParameterSet parameters,
+  public ResolvedPeak[] resolvePeaks(final Feature chromatogram, final ParameterSet parameters,
       RSessionWrapper rSession, CenterFunction mzCenterFunction, double msmsRange,
       double rTRangeMSMS) throws RSessionWrapperException {
 

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/DeconvolutionTask.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/DeconvolutionTask.java
@@ -250,15 +250,12 @@ public class DeconvolutionTask extends AbstractTask {
     int peakId = 1;
 
     // Process each chromatogram.
-//    final Feature[] chromatograms = peakList.getPeaks(dataFile);
-//    final int chromatogramCount = chromatograms.length;
     final PeakListRow[] peakListRows = peakList.getRows();
     final int chromatogramCount = peakListRows.length;
     for (int index = 0; !isCanceled() && index < chromatogramCount; index++) {
 
       final PeakListRow currentRow = peakListRows[index];
       final Feature chromatogram = currentRow.getPeak(dataFile);
-//      final Feature chromatogram = chromatograms[index];
 
       // Resolve peaks.
       final PeakResolver resolverModule = resolver.getModule();

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/DeconvolutionTask.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/DeconvolutionTask.java
@@ -250,11 +250,15 @@ public class DeconvolutionTask extends AbstractTask {
     int peakId = 1;
 
     // Process each chromatogram.
-    final Feature[] chromatograms = peakList.getPeaks(dataFile);
-    final int chromatogramCount = chromatograms.length;
+//    final Feature[] chromatograms = peakList.getPeaks(dataFile);
+//    final int chromatogramCount = chromatograms.length;
+    final PeakListRow[] peakListRows = peakList.getRows();
+    final int chromatogramCount = peakListRows.length;
     for (int index = 0; !isCanceled() && index < chromatogramCount; index++) {
 
-      final Feature chromatogram = chromatograms[index];
+      final PeakListRow currentRow = peakListRows[index];
+      final Feature chromatogram = currentRow.getPeak(dataFile);
+//      final Feature chromatogram = chromatograms[index];
 
       // Resolve peaks.
       final PeakResolver resolverModule = resolver.getModule();
@@ -267,6 +271,7 @@ public class DeconvolutionTask extends AbstractTask {
 
         final PeakListRow newRow = new SimplePeakListRow(peakId++);
         newRow.addPeak(dataFile, peak);
+        newRow.setParentRowID(currentRow.getID());
         newRow.setPeakInformation(peak.getPeakInformation());
         resolvedPeaks.addRow(newRow);
       }

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/DeconvolutionTask.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/DeconvolutionTask.java
@@ -260,15 +260,16 @@ public class DeconvolutionTask extends AbstractTask {
       // Resolve peaks.
       final PeakResolver resolverModule = resolver.getModule();
       final ParameterSet resolverParams = resolver.getParameterSet();
-      final Feature[] peaks = resolverModule.resolvePeaks(chromatogram, resolverParams, rSession,
+      final ResolvedPeak[] peaks = resolverModule.resolvePeaks(chromatogram, resolverParams, rSession,
           mzCenterFunction, msmsRange, RTRangeMSMS);
 
       // Add peaks to the new peak list.
-      for (final Feature peak : peaks) {
+      for (final ResolvedPeak peak : peaks) {
+
+        peak.setParentChromatogramRowID(currentRow.getID());
 
         final PeakListRow newRow = new SimplePeakListRow(peakId++);
         newRow.addPeak(dataFile, peak);
-        newRow.setParentRowID(currentRow.getID());
         newRow.setPeakInformation(peak.getPeakInformation());
         resolvedPeaks.addRow(newRow);
       }

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/PeakResolver.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/PeakResolver.java
@@ -65,7 +65,7 @@ public interface PeakResolver extends MZmineModule {
    * 
    * @throws RSessionWrapperException
    */
-  public Feature[] resolvePeaks(Feature chromatogram, ParameterSet parameters,
+  public ResolvedPeak[] resolvePeaks(Feature chromatogram, ParameterSet parameters,
       RSessionWrapper rSession, CenterFunction mzCenterFunction, double msmsRange,
       double rTRangeMSMS) throws RSessionWrapperException;
 

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/ResolvedPeak.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/ResolvedPeak.java
@@ -20,6 +20,8 @@ package net.sf.mzmine.modules.peaklistmethods.peakpicking.deconvolution;
 
 import java.util.Arrays;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import com.google.common.collect.Range;
 import net.sf.mzmine.datamodel.DataPoint;
 import net.sf.mzmine.datamodel.Feature;
@@ -68,6 +70,10 @@ public class ResolvedPeak implements Feature {
   // method.
   private IsotopePattern isotopePattern = null;
   private int charge = 0;
+
+  // PeakListRow.ID of the chromatogram where this feature is detected. Null by default but can be set by
+  // chromatogram deconvolution method.
+  private Integer parentChromatogramRowID = null;
 
   /**
    * Initializes this peak using data points from a given chromatogram - regionStart marks the index
@@ -349,4 +355,13 @@ public class ResolvedPeak implements Feature {
   }
   // End dulab Edit
 
+  public void setParentChromatogramRowID(@Nullable Integer id) {
+    this.parentChromatogramRowID = id;
+  }
+
+  @Override
+  @Nullable
+  public Integer getParentChromatogramRowID() {
+    return this.parentChromatogramRowID;
+  }
 }

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/baseline/BaselinePeakDetector.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/baseline/BaselinePeakDetector.java
@@ -47,7 +47,7 @@ public class BaselinePeakDetector implements PeakResolver {
   }
 
   @Override
-  public Feature[] resolvePeaks(final Feature chromatogram, ParameterSet parameters,
+  public ResolvedPeak[] resolvePeaks(final Feature chromatogram, ParameterSet parameters,
       RSessionWrapper rSession, CenterFunction mzCenterFunction, double msmsRange,
       double rTRangeMSMS) {
 

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/centwave/CentWaveDetector.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/centwave/CentWaveDetector.java
@@ -98,7 +98,7 @@ public class CentWaveDetector implements PeakResolver {
   }
 
   @Override
-  public Feature[] resolvePeaks(final Feature chromatogram, final ParameterSet parameters,
+  public ResolvedPeak[] resolvePeaks(final Feature chromatogram, final ParameterSet parameters,
       RSessionWrapper rSession, CenterFunction mzCenterFunction, double msmsRange,
       double rTRangeMSMS) throws RSessionWrapperException {
 

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/minimumsearch/MinimumSearchPeakDetector.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/minimumsearch/MinimumSearchPeakDetector.java
@@ -52,7 +52,7 @@ public class MinimumSearchPeakDetector implements PeakResolver {
   }
 
   @Override
-  public Feature[] resolvePeaks(final Feature chromatogram, ParameterSet parameters,
+  public ResolvedPeak[] resolvePeaks(final Feature chromatogram, ParameterSet parameters,
       RSessionWrapper rSession, CenterFunction mzCenterFunction, double msmsRange,
       double rTRangeMSMS) {
     int scanNumbers[] = chromatogram.getScanNumbers();
@@ -195,7 +195,7 @@ public class MinimumSearchPeakDetector implements PeakResolver {
       }
     }
 
-    return resolvedPeaks.toArray(new Feature[resolvedPeaks.size()]);
+    return resolvedPeaks.toArray(new ResolvedPeak[resolvedPeaks.size()]);
   }
 
   @Override

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/noiseamplitude/NoiseAmplitudePeakDetector.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/noiseamplitude/NoiseAmplitudePeakDetector.java
@@ -51,7 +51,7 @@ public class NoiseAmplitudePeakDetector implements PeakResolver {
   }
 
   @Override
-  public Feature[] resolvePeaks(final Feature chromatogram, ParameterSet parameters,
+  public ResolvedPeak[] resolvePeaks(final Feature chromatogram, ParameterSet parameters,
       RSessionWrapper rSession, CenterFunction mzCenterFunction, double msmsRange,
       double rTRangeMSMS) {
 

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/savitzkygolay/SavitzkyGolayPeakDetector.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/peakpicking/deconvolution/savitzkygolay/SavitzkyGolayPeakDetector.java
@@ -55,7 +55,7 @@ public class SavitzkyGolayPeakDetector implements PeakResolver {
   }
 
   @Override
-  public Feature[] resolvePeaks(final Feature chromatogram, ParameterSet parameters,
+  public ResolvedPeak[] resolvePeaks(final Feature chromatogram, ParameterSet parameters,
       RSessionWrapper rSession, CenterFunction mzCenterFunction, double msmsRange,
       double rTRangeMSMS) {
 
@@ -119,7 +119,7 @@ public class SavitzkyGolayPeakDetector implements PeakResolver {
       }
     }
 
-    return resolvedPeaks.toArray(new Feature[resolvedPeaks.size()]);
+    return resolvedPeaks.toArray(new ResolvedPeak[resolvedPeaks.size()]);
   }
 
   /**

--- a/src/main/java/net/sf/mzmine/modules/projectmethods/projectload/version_2_5/PeakListElementName_2_5.java
+++ b/src/main/java/net/sf/mzmine/modules/projectmethods/projectload/version_2_5/PeakListElementName_2_5.java
@@ -34,7 +34,7 @@ public enum PeakListElementName_2_5 {
                                               "method_parameters"), REPRESENTATIVE_SCAN(
                                                   "best_scan"), FRAGMENT_SCAN(
                                                       "fragment_scan"), ALL_MS2_FRAGMENT_SCANS(
-                                                          "all_MS2_fragment_scans");
+                                                          "all_MS2_fragment_scans"), PARENT_ROW_ID("parent_row_id");
 
   private String elementName;
 

--- a/src/main/java/net/sf/mzmine/modules/projectmethods/projectload/version_2_5/PeakListElementName_2_5.java
+++ b/src/main/java/net/sf/mzmine/modules/projectmethods/projectload/version_2_5/PeakListElementName_2_5.java
@@ -34,7 +34,8 @@ public enum PeakListElementName_2_5 {
                                               "method_parameters"), REPRESENTATIVE_SCAN(
                                                   "best_scan"), FRAGMENT_SCAN(
                                                       "fragment_scan"), ALL_MS2_FRAGMENT_SCANS(
-                                                          "all_MS2_fragment_scans"), PARENT_ROW_ID("parent_row_id");
+                                                          "all_MS2_fragment_scans"), PARENT_CHROMATOGRAM_ROW_ID(
+                                                              "parent_chromatogram_row_id");
 
   private String elementName;
 

--- a/src/main/java/net/sf/mzmine/modules/projectmethods/projectload/version_2_5/PeakListOpenHandler_2_5.java
+++ b/src/main/java/net/sf/mzmine/modules/projectmethods/projectload/version_2_5/PeakListOpenHandler_2_5.java
@@ -86,6 +86,8 @@ public class PeakListOpenHandler_2_5 extends DefaultHandler implements PeakListO
   private int currentPeakCharge;
   private String currentIsotopePatternDescription;
 
+  private Integer parentChromatogramRowID = null;
+
   private Hashtable<String, RawDataFile> dataFilesIDMap;
 
   private int parsedRows, totalRows;
@@ -165,12 +167,6 @@ public class PeakListOpenHandler_2_5 extends DefaultHandler implements PeakListO
       }
       int rowID = Integer.parseInt(attrs.getValue(PeakListElementName_2_5.ID.getElementName()));
       buildingRow = new SimplePeakListRow(rowID);
-      try {
-        int parentRowID = Integer.parseInt(attrs.getValue(PeakListElementName_2_5.PARENT_ROW_ID.getElementName()));
-        buildingRow.setParentRowID(parentRowID);
-      } catch (NumberFormatException e) {
-        buildingRow.setParentRowID(null);
-      }
       String comment = attrs.getValue(PeakListElementName_2_5.COMMENT.getElementName());
       buildingRow.setComment(comment);
     }
@@ -213,7 +209,13 @@ public class PeakListOpenHandler_2_5 extends DefaultHandler implements PeakListO
         currentPeakCharge = Integer.valueOf(chargeString);
       else
         currentPeakCharge = 0;
-
+      try {
+        parentChromatogramRowID = Integer.parseInt(
+                attrs.getValue(
+                        PeakListElementName_2_5.PARENT_CHROMATOGRAM_ROW_ID.getElementName()));
+      } catch (NumberFormatException e) {
+        parentChromatogramRowID = null;
+      }
     }
 
     // <MZPEAK>
@@ -400,6 +402,8 @@ public class PeakListOpenHandler_2_5 extends DefaultHandler implements PeakListO
         peak.setIsotopePattern(newPattern);
         currentIsotopes.clear();
       }
+
+      peak.setParentChromatogramRowID(parentChromatogramRowID);
 
       buildingRow.addPeak(dataFile, peak);
 

--- a/src/main/java/net/sf/mzmine/modules/projectmethods/projectload/version_2_5/PeakListOpenHandler_2_5.java
+++ b/src/main/java/net/sf/mzmine/modules/projectmethods/projectload/version_2_5/PeakListOpenHandler_2_5.java
@@ -165,6 +165,12 @@ public class PeakListOpenHandler_2_5 extends DefaultHandler implements PeakListO
       }
       int rowID = Integer.parseInt(attrs.getValue(PeakListElementName_2_5.ID.getElementName()));
       buildingRow = new SimplePeakListRow(rowID);
+      try {
+        int parentRowID = Integer.parseInt(attrs.getValue(PeakListElementName_2_5.PARENT_ROW_ID.getElementName()));
+        buildingRow.setParentRowID(parentRowID);
+      } catch (NumberFormatException e) {
+        buildingRow.setParentRowID(null);
+      }
       String comment = attrs.getValue(PeakListElementName_2_5.COMMENT.getElementName());
       buildingRow.setComment(comment);
     }

--- a/src/main/java/net/sf/mzmine/modules/projectmethods/projectsave/PeakListElementName.java
+++ b/src/main/java/net/sf/mzmine/modules/projectmethods/projectsave/PeakListElementName.java
@@ -35,7 +35,8 @@ enum PeakListElementName {
                                                   "best_scan"), FRAGMENT_SCAN(
                                                       "fragment_scan"), ALL_MS2_FRAGMENT_SCANS(
                                                           "all_MS2_fragment_scans"), INDEX(
-                                                              "index"), SHARPNESS("sharpness");
+                                                              "index"), SHARPNESS(
+                                                                  "sharpness"), PARENT_ROW_ID("parent_row_id");
   private String elementName;
 
   private PeakListElementName(String itemName) {

--- a/src/main/java/net/sf/mzmine/modules/projectmethods/projectsave/PeakListElementName.java
+++ b/src/main/java/net/sf/mzmine/modules/projectmethods/projectsave/PeakListElementName.java
@@ -36,7 +36,8 @@ enum PeakListElementName {
                                                       "fragment_scan"), ALL_MS2_FRAGMENT_SCANS(
                                                           "all_MS2_fragment_scans"), INDEX(
                                                               "index"), SHARPNESS(
-                                                                  "sharpness"), PARENT_ROW_ID("parent_row_id");
+                                                                  "sharpness"), PARENT_CHROMATOGRAM_ROW_ID(
+                                                                          "parent_chromatogram_row_id");
   private String elementName;
 
   private PeakListElementName(String itemName) {

--- a/src/main/java/net/sf/mzmine/modules/projectmethods/projectsave/PeakListSaveHandler.java
+++ b/src/main/java/net/sf/mzmine/modules/projectmethods/projectsave/PeakListSaveHandler.java
@@ -163,6 +163,8 @@ public class PeakListSaveHandler {
       row = peakList.getRow(i);
       atts.addAttribute("", "", PeakListElementName.ID.getElementName(), "CDATA",
           String.valueOf(row.getID()));
+      atts.addAttribute("", "", PeakListElementName.PARENT_ROW_ID.getElementName(), "CDATA",
+          row.getParentRowID() != null ? String.valueOf(row.getParentRowID()) : "");
       if (row.getComment() != null) {
         atts.addAttribute("", "", PeakListElementName.COMMENT.getElementName(), "CDATA",
             row.getComment());

--- a/src/main/java/net/sf/mzmine/modules/projectmethods/projectsave/PeakListSaveHandler.java
+++ b/src/main/java/net/sf/mzmine/modules/projectmethods/projectsave/PeakListSaveHandler.java
@@ -163,8 +163,6 @@ public class PeakListSaveHandler {
       row = peakList.getRow(i);
       atts.addAttribute("", "", PeakListElementName.ID.getElementName(), "CDATA",
           String.valueOf(row.getID()));
-      atts.addAttribute("", "", PeakListElementName.PARENT_ROW_ID.getElementName(), "CDATA",
-          row.getParentRowID() != null ? String.valueOf(row.getParentRowID()) : "");
       if (row.getComment() != null) {
         atts.addAttribute("", "", PeakListElementName.COMMENT.getElementName(), "CDATA",
             row.getComment());
@@ -247,6 +245,8 @@ public class PeakListSaveHandler {
           p.getFeatureStatus().toString());
       atts.addAttribute("", "", PeakListElementName.CHARGE.getElementName(), "CDATA",
           String.valueOf(p.getCharge()));
+      atts.addAttribute("", "", PeakListElementName.PARENT_CHROMATOGRAM_ROW_ID.getElementName(), "CDATA",
+          p.getParentChromatogramRowID() != null ? String.valueOf(p.getParentChromatogramRowID()) : "");
       hd.startElement("", "", PeakListElementName.PEAK.getElementName(), atts);
 
       fillPeakElement(p, hd);

--- a/src/main/java/net/sf/mzmine/modules/visualization/peaklisttable/table/DataFileColumnType.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/peaklisttable/table/DataFileColumnType.java
@@ -28,7 +28,8 @@ public enum DataFileColumnType {
           Double.class), DURATION("Duration", Double.class), HEIGHT("Height", Double.class), AREA(
               "Area", Double.class), CHARGE("Charge", Integer.class), DATAPOINTS("# Data points",
                   Integer.class), FWHM("FWHM", Double.class), TF("Tailing factor",
-                      Double.class), AF("Asymmetry factor", Double.class);
+                      Double.class), AF("Asymmetry factor",
+                          Double.class), PARENT_ROW_ID("Parent Row ID", Integer.class);
 
   private final String columnName;
   private final Class<?> columnClass;

--- a/src/main/java/net/sf/mzmine/modules/visualization/peaklisttable/table/PeakListTableModel.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/peaklisttable/table/PeakListTableModel.java
@@ -148,7 +148,7 @@ public class PeakListTableModel extends AbstractTableModel {
         case AF:
           return peak.getAsymmetryFactor();
         case PARENT_ROW_ID:
-          return peakListRow.getParentRowID();
+          return peak.getParentChromatogramRowID();
       }
 
     }

--- a/src/main/java/net/sf/mzmine/modules/visualization/peaklisttable/table/PeakListTableModel.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/peaklisttable/table/PeakListTableModel.java
@@ -147,6 +147,8 @@ public class PeakListTableModel extends AbstractTableModel {
           return peak.getTailingFactor();
         case AF:
           return peak.getAsymmetryFactor();
+        case PARENT_ROW_ID:
+          return peakListRow.getParentRowID();
       }
 
     }


### PR DESCRIPTION
Hi Tomas,

These are changes to store ID of a parent row. A few comments about my changes:

1. As I understood our discussion in #553, we have decided to use the field ID of PeakListRow as an identifier of a parent feature (chromatogram). In this case, I believe that it makes sense to store the parent ID as a property of PeakListRow instead of Feature. Let me know if you want to change it.

2. I've noticed that there are several versions of ProjectLoad... methods. I've changed the latest version (2_5). I'm not sure if I should change the older versions or make a new version for my changes?

3. I'll push changes to spectral deconvolution that are using this new feature in a separate PL.

Alex.