### PR TITLE
Fix: Formula in neutral loss filter

### DIFF
--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/filtering/neutralloss/NeutralLossFilterParameters.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/filtering/neutralloss/NeutralLossFilterParameters.java
@@ -19,7 +19,9 @@
 package net.sf.mzmine.modules.peaklistmethods.filtering.neutralloss;
 
 import java.text.NumberFormat;
+import java.util.Collection;
 import java.util.Locale;
+import org.openscience.cdk.interfaces.IMolecularFormula;
 import net.sf.mzmine.parameters.Parameter;
 import net.sf.mzmine.parameters.impl.SimpleParameterSet;
 import net.sf.mzmine.parameters.parametertypes.BooleanParameter;
@@ -28,6 +30,7 @@ import net.sf.mzmine.parameters.parametertypes.StringParameter;
 import net.sf.mzmine.parameters.parametertypes.selectors.PeakListsParameter;
 import net.sf.mzmine.parameters.parametertypes.tolerances.MZToleranceParameter;
 import net.sf.mzmine.parameters.parametertypes.tolerances.RTToleranceParameter;
+import net.sf.mzmine.util.FormulaUtils;
 
 public class NeutralLossFilterParameters extends SimpleParameterSet {
 
@@ -58,5 +61,24 @@ public class NeutralLossFilterParameters extends SimpleParameterSet {
   public NeutralLossFilterParameters() {
     super(new Parameter[] {PEAK_LISTS, mzTolerance, checkRT, rtTolerance, minHeight, neutralLoss,
         molecule, suffix});
+  }
+
+  @Override
+  public boolean checkParameterValues(Collection<String> errorMessages) {
+    if (super.checkParameterValues(errorMessages) == false)
+      return false;
+
+    String molecule = this.getParameter(NeutralLossFilterParameters.molecule).getValue();
+
+    // no formula -> use deltaMass
+    if (molecule.isEmpty())
+      return true;
+    // formula can be parsed
+    IMolecularFormula formula = FormulaUtils.createMajorIsotopeMolFormula(molecule);
+    if (formula != null) {
+      return true;
+    }
+    errorMessages.add("Formula cannot be parsed. Enter valid formula.");
+    return false;
   }
 }

--- a/src/main/java/net/sf/mzmine/util/FormulaUtils.java
+++ b/src/main/java/net/sf/mzmine/util/FormulaUtils.java
@@ -268,10 +268,16 @@ public class FormulaUtils {
   }
 
 
+  /**
+   * Creates a formula with the major isotopes (important to use this method for exact mass
+   * calculation over the CDK version, which generates formulas without an exact mass)
+   * 
+   * @param formula
+   * @return
+   */
   public static IMolecularFormula createMajorIsotopeMolFormula(String formula) {
     try {
-      if (formula.endsWith("-"))
-        System.out.println();
+      // new formula consists of isotopes without exact mass
       IChemObjectBuilder builder = SilentChemObjectBuilder.getInstance();
       IMolecularFormula f = MolecularFormulaManipulator
           .getMajorIsotopeMolecularFormula(formula.replace(" ", ""), builder);
@@ -293,6 +299,13 @@ public class FormulaUtils {
 
   }
 
+  /**
+   * Searches for all isotopes exactmass=null and replaces them with the major isotope
+   * 
+   * @param f
+   * @return
+   * @throws IOException
+   */
   public static IMolecularFormula replaceAllIsotopesWithoutExactMass(IMolecularFormula f)
       throws IOException {
     for (IIsotope iso : f.isotopes()) {

--- a/src/main/java/net/sf/mzmine/util/FormulaUtils.java
+++ b/src/main/java/net/sf/mzmine/util/FormulaUtils.java
@@ -273,7 +273,7 @@ public class FormulaUtils {
    * calculation over the CDK version, which generates formulas without an exact mass)
    * 
    * @param formula
-   * @return
+   * @return the formula or null
    */
   public static IMolecularFormula createMajorIsotopeMolFormula(String formula) {
     try {


### PR DESCRIPTION
This is a fix for the issue #556 

It only includes the correct calculation of exact masses from string formulae. It also provides checking for correct formulae.