### PR TITLE
Import GNPS library matching results

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,8 +107,27 @@
 			<name>MZmine local libraries</name>
 			<url>file://${project.basedir}/src/main/lib</url>
 		</repository>
+		<!--  for graphstream -->
+    <repository>
+        <id>jitpack.io</id>
+        <url>https://jitpack.io</url>
+    </repository>
 	</repositories>
+	
 	<dependencies>
+		<!-- https://mvnrepository.com/artifact/org.graphstream/gs-core 
+		Networks visualisation-->
+		<dependency>
+	    	<groupId>com.github.graphstream</groupId>
+	    	<artifactId>gs-core</artifactId>
+	    	<version>2.0-alpha</version>
+		</dependency>
+		<dependency>
+	    	<groupId>com.github.graphstream</groupId>
+    		<artifactId>gs-ui-swing</artifactId>
+	    	<version>2.0-alpha</version>
+		</dependency>
+	
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>

--- a/src/main/java/net/sf/mzmine/datamodel/PeakList.java
+++ b/src/main/java/net/sf/mzmine/datamodel/PeakList.java
@@ -216,4 +216,12 @@ public interface PeakList {
    */
   public Range<Double> getRowsRTRange();
 
+  /**
+   * Find row by ID
+   * 
+   * @param id
+   * @return the peaklist row or null
+   */
+  public PeakListRow findRowByID(int id);
+
 }

--- a/src/main/java/net/sf/mzmine/datamodel/impl/SimplePeakList.java
+++ b/src/main/java/net/sf/mzmine/datamodel/impl/SimplePeakList.java
@@ -88,6 +88,7 @@ public class SimplePeakList implements PeakList {
   /**
    * Returns number of raw data files participating in the alignment
    */
+  @Override
   public int getNumberOfRawDataFiles() {
     return dataFiles.length;
   }
@@ -95,10 +96,12 @@ public class SimplePeakList implements PeakList {
   /**
    * Returns all raw data files participating in the alignment
    */
+  @Override
   public RawDataFile[] getRawDataFiles() {
     return dataFiles;
   }
 
+  @Override
   public RawDataFile getRawDataFile(int position) {
     return dataFiles[position];
   }
@@ -106,6 +109,7 @@ public class SimplePeakList implements PeakList {
   /**
    * Returns number of rows in the alignment result
    */
+  @Override
   public int getNumberOfRows() {
     return peakListRows.size();
   }
@@ -116,6 +120,7 @@ public class SimplePeakList implements PeakList {
    * @param row Row of the alignment result
    * @param rawDataFile Raw data file where the peak is detected/estimated
    */
+  @Override
   public Feature getPeak(int row, RawDataFile rawDataFile) {
     return peakListRows.get(row).getPeak(rawDataFile);
   }
@@ -123,6 +128,7 @@ public class SimplePeakList implements PeakList {
   /**
    * Returns all peaks for a raw data file
    */
+  @Override
   public Feature[] getPeaks(RawDataFile rawDataFile) {
     Vector<Feature> peakSet = new Vector<Feature>();
     for (int row = 0; row < getNumberOfRows(); row++) {
@@ -136,24 +142,29 @@ public class SimplePeakList implements PeakList {
   /**
    * Returns all peaks on one row
    */
+  @Override
   public PeakListRow getRow(int row) {
     return peakListRows.get(row);
   }
 
+  @Override
   public PeakListRow[] getRows() {
     return peakListRows.toArray(new PeakListRow[0]);
   }
 
+  @Override
   public PeakListRow[] getRowsInsideMZRange(Range<Double> mzRange) {
     Range<Double> all = Range.all();
     return getRowsInsideScanAndMZRange(all, mzRange);
   }
 
+  @Override
   public PeakListRow[] getRowsInsideScanRange(Range<Double> rtRange) {
     Range<Double> all = Range.all();
     return getRowsInsideScanAndMZRange(rtRange, all);
   }
 
+  @Override
   public PeakListRow[] getRowsInsideScanAndMZRange(Range<Double> rtRange, Range<Double> mzRange) {
     Vector<PeakListRow> rowsInside = new Vector<PeakListRow>();
 
@@ -165,6 +176,7 @@ public class SimplePeakList implements PeakList {
     return rowsInside.toArray(new PeakListRow[0]);
   }
 
+  @Override
   public void addRow(PeakListRow row) {
     List<RawDataFile> myFiles = Arrays.asList(this.getRawDataFiles());
     for (RawDataFile testFile : row.getRawDataFiles()) {
@@ -193,6 +205,7 @@ public class SimplePeakList implements PeakList {
    * @param endRT End of the retention time range
    * @return
    */
+  @Override
   public Feature[] getPeaksInsideScanRange(RawDataFile file, Range<Double> rtRange) {
     Range<Double> all = Range.all();
     return getPeaksInsideScanAndMZRange(file, rtRange, all);
@@ -201,6 +214,7 @@ public class SimplePeakList implements PeakList {
   /**
    * @see net.sf.mzmine.datamodel.PeakList#getPeaksInsideMZRange(double, double)
    */
+  @Override
   public Feature[] getPeaksInsideMZRange(RawDataFile file, Range<Double> mzRange) {
     Range<Double> all = Range.all();
     return getPeaksInsideScanAndMZRange(file, all, mzRange);
@@ -210,6 +224,7 @@ public class SimplePeakList implements PeakList {
    * @see net.sf.mzmine.datamodel.PeakList#getPeaksInsideScanAndMZRange(double, double, double,
    *      double)
    */
+  @Override
   public Feature[] getPeaksInsideScanAndMZRange(RawDataFile file, Range<Double> rtRange,
       Range<Double> mzRange) {
     Vector<Feature> peaksInside = new Vector<Feature>();
@@ -226,6 +241,7 @@ public class SimplePeakList implements PeakList {
   /**
    * @see net.sf.mzmine.datamodel.PeakList#removeRow(net.sf.mzmine.datamodel.PeakListRow)
    */
+  @Override
   public void removeRow(PeakListRow row) {
     peakListRows.remove(row);
 
@@ -241,6 +257,7 @@ public class SimplePeakList implements PeakList {
   /**
    * @see net.sf.mzmine.datamodel.PeakList#removeRow(net.sf.mzmine.datamodel.PeakListRow)
    */
+  @Override
   public void removeRow(int rowNum) {
     removeRow(peakListRows.get(rowNum));
   }
@@ -276,6 +293,7 @@ public class SimplePeakList implements PeakList {
   /**
    * @see net.sf.mzmine.datamodel.PeakList#getPeakRowNum(net.sf.mzmine.datamodel.Feature)
    */
+  @Override
   public int getPeakRowNum(Feature peak) {
 
     PeakListRow rows[] = getRows();
@@ -291,14 +309,17 @@ public class SimplePeakList implements PeakList {
   /**
    * @see net.sf.mzmine.datamodel.PeakList#getDataPointMaxIntensity()
    */
+  @Override
   public double getDataPointMaxIntensity() {
     return maxDataPointIntensity;
   }
 
+  @Override
   public boolean hasRawDataFile(RawDataFile hasFile) {
     return Arrays.asList(dataFiles).contains(hasFile);
   }
 
+  @Override
   public PeakListRow getPeakRow(Feature peak) {
     PeakListRow rows[] = getRows();
 
@@ -310,14 +331,17 @@ public class SimplePeakList implements PeakList {
     return null;
   }
 
+  @Override
   public void setName(String name) {
     this.name = name;
   }
 
+  @Override
   public void addDescriptionOfAppliedTask(PeakListAppliedMethod appliedMethod) {
     descriptionOfAppliedTasks.add(appliedMethod);
   }
 
+  @Override
   public PeakListAppliedMethod[] getAppliedMethods() {
     return descriptionOfAppliedTasks.toArray(new PeakListAppliedMethod[0]);
   }
@@ -330,14 +354,20 @@ public class SimplePeakList implements PeakList {
     this.dateCreated = date;
   }
 
+  @Override
   public Range<Double> getRowsMZRange() {
     updateMaxIntensity(); // Update range before returning value
     return mzRange;
   }
 
+  @Override
   public Range<Double> getRowsRTRange() {
     updateMaxIntensity(); // Update range before returning value
     return rtRange;
   }
 
+  @Override
+  public PeakListRow findRowByID(int id) {
+    return stream().filter(r -> r.getID() == id).findFirst().orElse(null);
+  }
 }

--- a/src/main/java/net/sf/mzmine/main/MZmineModulesList.java
+++ b/src/main/java/net/sf/mzmine/main/MZmineModulesList.java
@@ -50,6 +50,7 @@ import net.sf.mzmine.modules.peaklistmethods.identification.customdbsearch.Custo
 import net.sf.mzmine.modules.peaklistmethods.identification.formulaprediction.FormulaPredictionModule;
 import net.sf.mzmine.modules.peaklistmethods.identification.formulapredictionpeaklist.FormulaPredictionPeakListModule;
 import net.sf.mzmine.modules.peaklistmethods.identification.fragmentsearch.FragmentSearchModule;
+import net.sf.mzmine.modules.peaklistmethods.identification.gnpsresultsimport.GNPSResultsImportModule;
 import net.sf.mzmine.modules.peaklistmethods.identification.lipididentification.LipidSearchModule;
 import net.sf.mzmine.modules.peaklistmethods.identification.ms2search.Ms2SearchModule;
 import net.sf.mzmine.modules.peaklistmethods.identification.nist.NistMsSearchModule;
@@ -108,10 +109,10 @@ import net.sf.mzmine.modules.visualization.intensityplot.IntensityPlotModule;
 import net.sf.mzmine.modules.visualization.kendrickmassplot.KendrickMassPlotModule;
 import net.sf.mzmine.modules.visualization.mzhistogram.MZDistributionHistoModule;
 import net.sf.mzmine.modules.visualization.neutralloss.NeutralLossVisualizerModule;
-import net.sf.mzmine.modules.visualization.productionfilter.ProductIonFilterVisualizerModule;
 import net.sf.mzmine.modules.visualization.peaklisttable.PeakListTableModule;
 import net.sf.mzmine.modules.visualization.peaklisttable.export.IsotopePatternExportModule;
 import net.sf.mzmine.modules.visualization.peaklisttable.export.MSMSExportModule;
+import net.sf.mzmine.modules.visualization.productionfilter.ProductIonFilterVisualizerModule;
 import net.sf.mzmine.modules.visualization.scatterplot.ScatterPlotVisualizerModule;
 import net.sf.mzmine.modules.visualization.spectra.msms.MsMsVisualizerModule;
 import net.sf.mzmine.modules.visualization.spectra.simplespectra.SpectraVisualizerModule;
@@ -177,13 +178,15 @@ public class MZmineModulesList {
 
       // Data analysis
       CVPlotModule.class, LogratioPlotModule.class, PCAPlotModule.class, CDAPlotModule.class,
-      SammonsPlotModule.class, ClusteringModule.class, HeatMapModule.class, SignificanceModule.class,
+      SammonsPlotModule.class, ClusteringModule.class, HeatMapModule.class,
+      SignificanceModule.class,
 
       // Identification
       CustomDBSearchModule.class, FormulaPredictionModule.class, FragmentSearchModule.class,
       AdductSearchModule.class, ComplexSearchModule.class, OnlineDBSearchModule.class,
       LipidSearchModule.class, CameraSearchModule.class, NistMsSearchModule.class,
       FormulaPredictionPeakListModule.class, Ms2SearchModule.class, SiriusProcessingModule.class,
+      GNPSResultsImportModule.class,
 
       // Visualizers
       TICVisualizerModule.class, SpectraVisualizerModule.class, TwoDVisualizerModule.class,

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/gnpsresultsimport/GNPSResultsIdentity.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/gnpsresultsimport/GNPSResultsIdentity.java
@@ -63,6 +63,7 @@ public class GNPSResultsIdentity extends SimplePeakIdentity {
     super(MessageFormat.format("{0} ({1})", compound, adduct));
     this.results = results;
     setPropertyValue(PROPERTY_METHOD, "GNPS results import");
+    setPropertyValue(PROPERTY_URL, results.get(ATT.GNPS_LIBRARY_URL.getKey()).toString());
   }
 
   public HashMap<String, Object> getResults() {

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/gnpsresultsimport/GNPSResultsIdentity.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/gnpsresultsimport/GNPSResultsIdentity.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2006-2018 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package net.sf.mzmine.modules.peaklistmethods.identification.gnpsresultsimport;
+
+import java.text.MessageFormat;
+import java.util.HashMap;
+import net.sf.mzmine.datamodel.impl.SimplePeakIdentity;
+
+/**
+ * Identity of GNPS library matching results import.
+ */
+public class GNPSResultsIdentity extends SimplePeakIdentity {
+  public enum ATT {
+    CLUSTER_INDEX("cluster index", Integer.class), // GNPS cluster - similarity
+    COMPOUND_NAME("Compound_Name", String.class), // library match
+    ADDUCT("Adduct", String.class), // from GNPS library match
+    MASS_DIFF("MassDiff", Double.class), // absolute diff from gnps
+    LIBRARY_MATCH_SCORE("MQScore", Double.class), // cosine score to library spec
+    SHARED_SIGNALS("SharedPeaks", String.class), // shared signals library <-> query
+    INCHI("INCHI", String.class), SMILES("Smiles", String.class), // structures
+    IONSOURCE("Ion_Source", String.class), IONMODE("IonMode",
+        String.class), INSTRUMENT("Instrument", String.class), // instrument
+    GNPS_LIBRARY_URL("GNPSLibraryURL", String.class), // link to library entry
+    GNPS_NETWORK_URL("GNPSLinkout_Network", String.class), // link to network
+    GNPS_CLUSTER_URL("GNPSLinkout_Cluster", String.class); // link to cluster
+
+    private String key;
+    private Class c;
+
+    private ATT(String key, Class c) {
+      this.c = c;
+      this.key = key;
+    }
+
+    public Class getValueClass() {
+      return c;
+    }
+
+    public String getKey() {
+      return key;
+    }
+  }
+
+  private HashMap<String, Object> results;
+
+  public GNPSResultsIdentity(HashMap<String, Object> results, String compound, String adduct) {
+    super(MessageFormat.format("{0} ({1})", compound, adduct));
+    this.results = results;
+    setPropertyValue(PROPERTY_METHOD, "GNPS results import");
+  }
+
+  public HashMap<String, Object> getResults() {
+    return results;
+  }
+
+  public Object getResult(ATT att) {
+    return results.get(att.toString());
+  }
+}

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/gnpsresultsimport/GNPSResultsImportModule.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/gnpsresultsimport/GNPSResultsImportModule.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2006-2018 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package net.sf.mzmine.modules.peaklistmethods.identification.gnpsresultsimport;
+
+import java.util.Collection;
+import javax.annotation.Nonnull;
+import net.sf.mzmine.datamodel.MZmineProject;
+import net.sf.mzmine.datamodel.PeakList;
+import net.sf.mzmine.modules.MZmineModuleCategory;
+import net.sf.mzmine.modules.MZmineProcessingModule;
+import net.sf.mzmine.parameters.ParameterSet;
+import net.sf.mzmine.taskcontrol.Task;
+import net.sf.mzmine.util.ExitCode;
+
+public class GNPSResultsImportModule implements MZmineProcessingModule {
+
+  private static final String MODULE_NAME = "Import GNPS results";
+  private static final String MODULE_DESCRIPTION =
+      "Imports GNPS feature based molecular networking results into the selected peak list (library matches)";
+
+  @Override
+  public @Nonnull String getName() {
+    return MODULE_NAME;
+  }
+
+  @Override
+  public @Nonnull String getDescription() {
+    return MODULE_DESCRIPTION;
+  }
+
+  @Override
+  @Nonnull
+  public ExitCode runModule(@Nonnull MZmineProject project, @Nonnull ParameterSet parameters,
+      @Nonnull Collection<Task> tasks) {
+
+    // max 1
+    PeakList peakList = parameters.getParameter(GNPSResultsImportParameters.PEAK_LIST).getValue()
+        .getMatchingPeakLists()[0];
+
+    Task newTask = new GNPSResultsImportTask(parameters, peakList);
+    tasks.add(newTask);
+
+    return ExitCode.OK;
+  }
+
+  @Override
+  public @Nonnull MZmineModuleCategory getModuleCategory() {
+    return MZmineModuleCategory.IDENTIFICATION;
+  }
+
+  @Override
+  public @Nonnull Class<? extends ParameterSet> getParameterSetClass() {
+    return GNPSResultsImportParameters.class;
+  }
+
+}

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/gnpsresultsimport/GNPSResultsImportParameters.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/gnpsresultsimport/GNPSResultsImportParameters.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2006-2018 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package net.sf.mzmine.modules.peaklistmethods.identification.gnpsresultsimport;
+
+import net.sf.mzmine.parameters.Parameter;
+import net.sf.mzmine.parameters.impl.SimpleParameterSet;
+import net.sf.mzmine.parameters.parametertypes.filenames.FileNameParameter;
+import net.sf.mzmine.parameters.parametertypes.selectors.PeakListsParameter;
+
+public class GNPSResultsImportParameters extends SimpleParameterSet {
+
+  public static final PeakListsParameter PEAK_LIST = new PeakListsParameter(1, 1);
+
+  public static final FileNameParameter FILE = new FileNameParameter("GNPS graphml file",
+      "GNPS results in the graphml file (download cytoscape data)", "graphml");
+
+  public GNPSResultsImportParameters() {
+    super(new Parameter[] {PEAK_LIST, FILE});
+  }
+
+}

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/gnpsresultsimport/GNPSResultsImportTask.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/gnpsresultsimport/GNPSResultsImportTask.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2006-2018 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package net.sf.mzmine.modules.peaklistmethods.identification.gnpsresultsimport;
+
+import java.io.File;
+import java.io.IOException;
+import java.text.MessageFormat;
+import java.util.HashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.graphstream.graph.Graph;
+import org.graphstream.graph.implementations.DefaultGraph;
+import org.graphstream.stream.file.FileSource;
+import org.graphstream.stream.file.FileSourceGraphML;
+import com.google.common.util.concurrent.AtomicDouble;
+import net.sf.mzmine.datamodel.PeakList;
+import net.sf.mzmine.datamodel.PeakListRow;
+import net.sf.mzmine.datamodel.impl.SimplePeakList;
+import net.sf.mzmine.datamodel.impl.SimplePeakListAppliedMethod;
+import net.sf.mzmine.desktop.Desktop;
+import net.sf.mzmine.desktop.impl.HeadLessDesktop;
+import net.sf.mzmine.main.MZmineCore;
+import net.sf.mzmine.modules.peaklistmethods.grouping.metacorrelate.datastructure.R2RMap;
+import net.sf.mzmine.modules.peaklistmethods.grouping.metacorrelate.msms.similarity.MS2Similarity;
+import net.sf.mzmine.modules.peaklistmethods.grouping.metacorrelate.msms.similarity.R2RMS2Similarity;
+import net.sf.mzmine.modules.peaklistmethods.identification.gnpsresultsimport.GNPSResultsIdentity.ATT;
+import net.sf.mzmine.parameters.ParameterSet;
+import net.sf.mzmine.taskcontrol.AbstractTask;
+import net.sf.mzmine.taskcontrol.TaskStatus;
+
+/**
+ * Import library matches
+ * 
+ * @author
+ *
+ */
+public class GNPSResultsImportTask extends AbstractTask {
+  private Logger logger = Logger.getLogger(this.getClass().getName());
+
+  private PeakList peakList;
+  private File file;
+
+  private AtomicDouble progress = new AtomicDouble(0);
+  private ParameterSet parameters;
+
+  public enum EdgeAtt {
+    EDGE_TYPE("EdgeType", String.class), // edgetype
+    EDGE_SCORE("EdgeScore", Double.class), EDGE_ANNOTATION("EdgeAnnotation", String.class);
+
+    private String key;
+    private Class c;
+
+    private EdgeAtt(String key, Class c) {
+      this.c = c;
+      this.key = key;
+    }
+
+    public Class getValueClass() {
+      return c;
+    }
+
+    public String getKey() {
+      return key;
+    }
+  }
+
+  public enum EdgeType {
+    MS1_ANNOTATION("MS1 annotation"), COSINE("Cosine");
+    private String key;
+
+    private EdgeType(String key) {
+      this.key = key;
+    }
+  }
+
+  /**
+   * @param parameters
+   * @param peakList
+   */
+  public GNPSResultsImportTask(ParameterSet parameters, PeakList peakList) {
+    this.parameters = parameters;
+    this.peakList = peakList;
+    file = parameters.getParameter(GNPSResultsImportParameters.FILE).getValue();
+  }
+
+  /**
+   * @see net.sf.mzmine.taskcontrol.Task#getFinishedPercentage()
+   */
+  @Override
+  public double getFinishedPercentage() {
+    return progress.get();
+  }
+
+  /**
+   * @see net.sf.mzmine.taskcontrol.Task#getTaskDescription()
+   */
+  @Override
+  public String getTaskDescription() {
+    return "Importing GNPS results for " + peakList + " in file " + file;
+  }
+
+  /**
+   * @see java.lang.Runnable#run()
+   */
+  @Override
+  public void run() {
+    setStatus(TaskStatus.PROCESSING);
+    logger.info("Importing GNPS results for " + peakList);
+
+    Graph graph = new DefaultGraph("GNPS");
+    if (importGraphData(graph, file)) {
+      // import library matches from nodes
+      importLibraryMatches(graph);
+
+      // import MS2 similarity from GNPS edges
+      importMS2SimilarityEdges(graph);
+
+      // Add task description to peakList
+      ((SimplePeakList) peakList).addDescriptionOfAppliedTask(
+          new SimplePeakListAppliedMethod("Identification of complexes", parameters));
+
+      // Repaint the window to reflect the change in the peak list
+      Desktop desktop = MZmineCore.getDesktop();
+      if (!(desktop instanceof HeadLessDesktop))
+        desktop.getMainWindow().repaint();
+
+      setStatus(TaskStatus.FINISHED);
+      logger.info("Finished import of GNPS results for " + peakList);
+    }
+  }
+
+  private void importMS2SimilarityEdges(Graph graph) {
+    AtomicInteger missingRows = new AtomicInteger(0);
+    AtomicInteger r2rSimilarities = new AtomicInteger(0);
+
+    R2RMap<R2RMS2Similarity> map = peakList.getR2RSimilarityMap();
+
+    graph.edges().forEach(edge -> {
+      // edge type is gnps? (Cosine)
+      String type = (String) edge.getAttribute(EdgeAtt.EDGE_TYPE.getKey());
+      if (type.equals(EdgeType.COSINE.key)) {
+        // get rows
+        int ida = Integer.parseInt(edge.getSourceNode().getId());
+        int idb = Integer.parseInt(edge.getTargetNode().getId());
+        PeakListRow a = peakList.findRowByID(ida);
+        PeakListRow b = peakList.findRowByID(idb);
+        if (a != null && b != null) {
+          r2rSimilarities.getAndIncrement();
+          // get existing similarity
+          R2RMS2Similarity similarity = map != null ? map.get(a, b) : null;
+          // create new if empty
+          if (similarity == null) {
+            similarity = new R2RMS2Similarity(a, b);
+          }
+          // add gnps results
+          double cosine = (double) edge.getAttribute(EdgeAtt.EDGE_SCORE.getKey());
+          MS2Similarity sim = new MS2Similarity(cosine, 1);
+          similarity.addGNPSSim(sim);
+
+          // add r2r similarity
+          peakList.addR2RSimilarity(a, b, similarity);
+        } else
+          missingRows.getAndIncrement();
+      }
+    });
+
+
+    if (missingRows.get() > 0)
+      logger.info(missingRows.get()
+          + " rows (features) that were present in the GNPS results were not found in the peakList. Check if you selected the correct peak list, did some filtering or applied renumbering (IDs have to match).");
+
+    logger.info(r2rSimilarities.get() + " cosine score edges");
+  }
+
+  private void importLibraryMatches(Graph graph) {
+    AtomicInteger missingRows = new AtomicInteger(0);
+    AtomicInteger libraryMatches = new AtomicInteger(0);
+    // go through all nodes and add info
+    graph.nodes().forEach(node -> {
+      int id = Integer.parseInt(node.getId());
+      // has library match?
+      String compoundName = (String) node.getAttribute(ATT.COMPOUND_NAME.getKey());
+      PeakListRow row = peakList.findRowByID(id);
+      if (row != null) {
+        if (compoundName != null && !compoundName.isEmpty()) {
+          libraryMatches.getAndIncrement();
+          // add identity
+          String adduct = (String) node.getAttribute(ATT.ADDUCT.getKey());
+
+          // find all results
+          HashMap<String, Object> results = new HashMap<>();
+          for (ATT att : ATT.values()) {
+            Object result = node.getAttribute(att.getKey());
+            if (result != null) {
+              results.put(att.getKey(), result);
+            }
+          }
+
+          // add identity
+          GNPSResultsIdentity identity = new GNPSResultsIdentity(results, compoundName, adduct);
+          row.addPeakIdentity(identity, true);
+          // Notify the GUI about the change in the project
+          MZmineCore.getProjectManager().getCurrentProject().notifyObjectChanged(row, false);
+        }
+      } else
+        missingRows.getAndIncrement();
+    });
+
+    if (missingRows.get() > 0)
+      logger.info(missingRows.get()
+          + " rows (features) that were present in the GNPS results were not found in the peakList. Check if you selected the correct peak list, did some filtering or applied renumbering (IDs have to match).");
+
+    logger.info(libraryMatches.get() + " rows found with library matches");
+  }
+
+  private boolean importGraphData(Graph graph, File file) {
+    boolean result = true;
+    FileSource fs = null;
+    logger.info("Importing graphml data");
+    try {
+      fs = new FileSourceGraphML();
+      fs.addSink(graph);
+      fs.readAll(file.getAbsolutePath());
+      logger.info(() -> MessageFormat.format("GNPS results: nodes={0} edges={1}",
+          graph.getNodeCount(), graph.getEdgeCount()));
+    } catch (IOException e) {
+      logger.log(Level.SEVERE, "NOT LOADED", e);
+      setErrorMessage("Cannot load graphml file: " + file.getAbsolutePath());
+      setStatus(TaskStatus.ERROR);
+      cancel();
+      result = false;
+    } finally {
+      if (fs != null)
+        fs.removeSink(graph);
+    }
+    return result;
+  }
+
+}

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/gnpsresultsimport/help/help.html
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/gnpsresultsimport/help/help.html
@@ -1,0 +1,18 @@
+<html>
+	<head>
+		<title>Identification - GNPS results import</title>
+		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+		<link rel="stylesheet" type="text/css" href="/net/sf/mzmine/desktop/impl/helpsystem/HelpStyles.css">
+    </head>
+
+<body>
+
+<h1>GNPS library results import</h1>
+
+<p>
+After running GNPS feature based molecular networking (see the GNPS export and submit module), go to the results page and download the cytoscape data file (Export/Download Network Files/ Download Cytoscape Data). 
+Unzip the downloaded file and use this module to open the .graphml file.
+</p>
+
+</body>
+</html>

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/gnpsresultsimport/help/help.html
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/gnpsresultsimport/help/help.html
@@ -12,6 +12,8 @@
 <p>
 After running GNPS feature based molecular networking (see the GNPS export and submit module), go to the results page and download the cytoscape data file (Export/Download Network Files/ Download Cytoscape Data). 
 Unzip the downloaded file and use this module to open the .graphml file.
+<br><br>
+<b>IMPORTANT:</b> The import loads all library matches based on the peaklist row ID. Do only import GNPS results for peaklists with the same peaklist row IDs. (Filtering is ok; renumbering is not)
 </p>
 
 </body>


### PR DESCRIPTION
Hey Tomas,

this is a small module that imports all GNPS library matching results from a graphml file that is provided by the GNPS results export. In another branch, that I still need to make ready for merging, the whole GNPS network is imported to MZmine and visualised.

They are only added as identities - but there is much more interesting information in the GNPSResultsIdentity (e.g., the library entry link). Can you think of a good way to enable the user to open the hidden information that also leads to the GNPS webpage)
![image](https://user-images.githubusercontent.com/10366914/56045859-5530d880-5d42-11e9-9de4-17b3a6b58b40.png)

Best
Robin