### PR TITLE
Add retention time to the output of Export to MSP files

### DIFF
--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/mspexport/MSPExportTask.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/mspexport/MSPExportTask.java
@@ -164,6 +164,8 @@ public class MSPExportTask extends AbstractTask {
       if (rowID != null)
         writer.write("DB#: " + rowID + newLine);
 
+      writer.write("RT: " + row.getAverageRT() + newLine);
+
       DataPoint[] dataPoints = ip.getDataPoints();
 
       if (!fractionalMZ)


### PR DESCRIPTION
Hi Tomas,

For our data analysis, we needed to output the retention time of a compound into MSP file.  Would you mind make this changes in the official MZmine 2?

Alex.