### PR TITLE
Merge MS/MS when exporting for GNPS or SIRIUS

### DIFF
--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/gnpsexport/GNPSExportAndSubmitParameters.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/gnpsexport/GNPSExportAndSubmitParameters.java
@@ -30,13 +30,16 @@
 package net.sf.mzmine.modules.peaklistmethods.io.gnpsexport;
 
 import java.awt.Window;
+import java.text.NumberFormat;
+import java.util.Locale;
+
 import net.sf.mzmine.datamodel.PeakListRow;
+import net.sf.mzmine.modules.peaklistmethods.io.siriusexport.SiriusExportParameters;
 import net.sf.mzmine.parameters.Parameter;
+import net.sf.mzmine.parameters.ParameterSet;
 import net.sf.mzmine.parameters.dialogs.ParameterSetupDialog;
 import net.sf.mzmine.parameters.impl.SimpleParameterSet;
-import net.sf.mzmine.parameters.parametertypes.BooleanParameter;
-import net.sf.mzmine.parameters.parametertypes.ComboParameter;
-import net.sf.mzmine.parameters.parametertypes.MassListParameter;
+import net.sf.mzmine.parameters.parametertypes.*;
 import net.sf.mzmine.parameters.parametertypes.filenames.FileNameParameter;
 import net.sf.mzmine.parameters.parametertypes.selectors.PeakListsParameter;
 import net.sf.mzmine.parameters.parametertypes.submodules.OptionalModuleParameter;
@@ -95,6 +98,27 @@ public class GNPSExportAndSubmitParameters extends SimpleParameterSet {
       "Filter rows", "Limit the exported rows to those with MS/MS data or annotated rows",
       RowFilter.values(), RowFilter.ONLY_WITH_MS2);
 
+
+  /**
+   * kaidu edit: add some options for merging MS/MS of feature rows
+   */
+
+  public static final PercentParameter COSINE_PARAMETER = new PercentParameter("Cosine threshold (%)", "Threshold for the cosine similarity between two spectra for merging. Set to 0 if the spectra may have different collision energy!", 0.8d, 0d, 1d);
+
+  public static final PercentParameter PEAK_COUNT_PARAMETER = new PercentParameter("Peak count threshold ", "After merging, remove all peaks which occur in less than X % of the merged spectra.", 0.2d, 0d, 1d);
+
+  public static final IntegerParameter MASS_ACCURACY = new IntegerParameter("expected mass deviation (ppm)", "Expected mass deviation of your measurement in ppm (parts per million). We recommend to use a rather large value, e.g. 5 for Orbitrap, 15 for Q-ToF, 100 for QQQ.", 10, 1, 100);
+
+  public static final BooleanParameter AVERAGE_OVER_MASS = new BooleanParameter("Average over m/z", "When merging two peaks, the m/z of the merged peak is set to the weighted average of the source peaks. If unchecked, the m/z of the peak with largest intensity is used instead.", false);
+
+  public static final ComboParameter<SiriusExportParameters.MERGE_MODE> MERGE =
+          new ComboParameter<SiriusExportParameters.MERGE_MODE>("Merge mode", "How to merge MS/MS spectra",
+                  SiriusExportParameters.MERGE_MODE.values(), SiriusExportParameters.MERGE_MODE.MERGE_CONSECUTIVE_SCANS);
+
+  public static final DoubleParameter isolationWindowOffset = new DoubleParameter("isolation window offset", "isolation window offset from the precursor m/z", NumberFormat.getNumberInstance(Locale.US), 0d);
+  public static final DoubleParameter isolationWindowWidth = new DoubleParameter("isolation window width", "width (left and right from offset) of the isolation window", NumberFormat.getNumberInstance(Locale.US), 1d);
+
+
   // public static final BooleanParameter OPEN_GNPS = new BooleanParameter("Open GNPS website",
   // "Opens the super quick start of GNPS feature based networking in the standard browser.",
   // false);
@@ -102,8 +126,9 @@ public class GNPSExportAndSubmitParameters extends SimpleParameterSet {
   public static final BooleanParameter OPEN_FOLDER =
       new BooleanParameter("Open folder", "Opens the export folder", false);
 
+
   public GNPSExportAndSubmitParameters() {
-    super(new Parameter[] {PEAK_LISTS, FILENAME, MASS_LIST, FILTER, SUBMIT, OPEN_FOLDER});
+    super(new Parameter[] {PEAK_LISTS, FILENAME, MASS_LIST, FILTER, SUBMIT, OPEN_FOLDER, MERGE, AVERAGE_OVER_MASS, PEAK_COUNT_PARAMETER,  COSINE_PARAMETER, MASS_ACCURACY,isolationWindowOffset, isolationWindowWidth});
   }
 
   @Override

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/gnpsexport/GNPSExportAndSubmitParameters.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/gnpsexport/GNPSExportAndSubmitParameters.java
@@ -103,7 +103,7 @@ public class GNPSExportAndSubmitParameters extends SimpleParameterSet {
    * kaidu edit: add some options for merging MS/MS of feature rows
    */
 
-  public static final PercentParameter COSINE_PARAMETER = new PercentParameter("Cosine threshold (%)", "Threshold for the cosine similarity between two spectra for merging. Set to 0 if the spectra may have different collision energy!", 0.8d, 0d, 1d);
+  public static final PercentParameter COSINE_PARAMETER = new PercentParameter("Cosine threshold (%)", "Threshold for the cosine similarity between two spectra for merging. Set to 0 if the spectra may have different collision energy!", 0.7d, 0d, 1d);
 
   public static final PercentParameter PEAK_COUNT_PARAMETER = new PercentParameter("Peak count threshold ", "After merging, remove all peaks which occur in less than X % of the merged spectra.", 0.2d, 0d, 1d);
 

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/gnpsexport/GNPSmgfExportTask.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/gnpsexport/GNPSmgfExportTask.java
@@ -35,20 +35,22 @@ import java.io.IOException;
 import java.text.DecimalFormat;
 import java.text.MessageFormat;
 import java.text.NumberFormat;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
+
+import com.google.common.collect.Range;
 import io.github.msdk.MSDKRuntimeException;
-import net.sf.mzmine.datamodel.DataPoint;
-import net.sf.mzmine.datamodel.Feature;
-import net.sf.mzmine.datamodel.MassList;
-import net.sf.mzmine.datamodel.PeakList;
-import net.sf.mzmine.datamodel.PeakListRow;
-import net.sf.mzmine.datamodel.Scan;
+import net.sf.mzmine.datamodel.*;
 import net.sf.mzmine.datamodel.impl.SimpleFeature;
 import net.sf.mzmine.datamodel.impl.SimplePeakListRow;
 import net.sf.mzmine.main.MZmineCore;
 import net.sf.mzmine.modules.peaklistmethods.io.gnpsexport.GNPSExportAndSubmitParameters.RowFilter;
+import net.sf.mzmine.modules.peaklistmethods.io.siriusexport.MergeUtils;
+import net.sf.mzmine.modules.peaklistmethods.io.siriusexport.SiriusExportParameters;
 import net.sf.mzmine.parameters.ParameterSet;
 import net.sf.mzmine.taskcontrol.AbstractTask;
 import net.sf.mzmine.taskcontrol.TaskStatus;
@@ -82,6 +84,10 @@ public class GNPSmgfExportTask extends AbstractTask {
 
   private RowFilter filter;
 
+  // by kaidu
+  private MergeUtils mergeUtils;
+  private SiriusExportParameters.MERGE_MODE mergeMode;
+
   GNPSmgfExportTask(ParameterSet parameters) {
     this.peakLists =
         parameters.getParameter(GNPSExportAndSubmitParameters.PEAK_LISTS).getValue().getMatchingPeakLists();
@@ -89,6 +95,15 @@ public class GNPSmgfExportTask extends AbstractTask {
     this.fileName = parameters.getParameter(GNPSExportAndSubmitParameters.FILENAME).getValue();
     this.massListName = parameters.getParameter(GNPSExportAndSubmitParameters.MASS_LIST).getValue();
     this.filter = parameters.getParameter(GNPSExportAndSubmitParameters.FILTER).getValue();
+    this.mergeUtils = new MergeUtils();
+    mergeUtils.setPeakRemovalThreshold(parameters.getParameter(GNPSExportAndSubmitParameters.PEAK_COUNT_PARAMETER).getValue());
+    mergeUtils.setCosineThreshold(parameters.getParameter(GNPSExportAndSubmitParameters.COSINE_PARAMETER).getValue());
+    mergeUtils.setExpectedPPM(parameters.getParameter(GNPSExportAndSubmitParameters.MASS_ACCURACY).getValue());
+    mergeUtils.setMergeMasses(parameters.getParameter(GNPSExportAndSubmitParameters.AVERAGE_OVER_MASS).getValue());
+    final double offset = parameters.getParameter(GNPSExportAndSubmitParameters.isolationWindowOffset).getValue();
+    final double width = parameters.getParameter(GNPSExportAndSubmitParameters.isolationWindowWidth).getValue();
+    mergeUtils.setIsolationWindow(Range.closed(offset-width, offset+width));
+    mergeMode = parameters.getParameter(GNPSExportAndSubmitParameters.MERGE).getValue();
   }
 
   @Override
@@ -165,8 +180,8 @@ public class GNPSmgfExportTask extends AbstractTask {
   }
 
   private int export(PeakList peakList, FileWriter writer, File curFile) throws IOException {
-    final String newLine = System.lineSeparator();
-
+    final ErrorStatistics stats = new ErrorStatistics();
+    HashMap<String, int[]> fragmentScansNumbers = getFragmentScansNumbers(peakList.getRawDataFiles());
     // count exported
     int count = 0;
     int countMissingMassList = 0;
@@ -175,88 +190,21 @@ public class GNPSmgfExportTask extends AbstractTask {
       if (!filter.filter(row))
         continue;
 
-      String rowID = Integer.toString(row.getID());
-      double retTimeInSeconds = ((row.getAverageRT() * 60 * 100.0) / 100.);
-
       // Get the MS/MS scan number
       Feature bestPeak = row.getBestPeak();
       if (bestPeak == null)
         continue;
-      int msmsScanNumber = bestPeak.getMostIntenseFragmentScanNumber();
-      if (rowID != null) {
-        PeakListRow copyRow = copyPeakRow(row);
-        // Best peak always exists, because peak list row has at least one peak
-        bestPeak = copyRow.getBestPeak();
 
-        // Get the heighest peak with a MS/MS scan number (with mass list)
-        boolean missingMassList = false;
-        msmsScanNumber = bestPeak.getMostIntenseFragmentScanNumber();
-        while (msmsScanNumber < 1
-            || getScan(bestPeak, msmsScanNumber).getMassList(massListName) == null) {
-          // missing masslist
-          if (msmsScanNumber > 0)
-            missingMassList = true;
 
-          copyRow.removePeak(bestPeak.getDataFile());
-          if (copyRow.getPeaks().length == 0)
-            break;
-
-          bestPeak = copyRow.getBestPeak();
-          msmsScanNumber = bestPeak.getMostIntenseFragmentScanNumber();
-        }
-        if (missingMassList)
-          countMissingMassList++;
+      if (mergeMode== SiriusExportParameters.MERGE_MODE.NO_MERGE) {
+        gnpsOutputNoMerge(row, bestPeak, writer, stats);
+      } else {
+        gnpsOutputMerge(row, writer, stats,fragmentScansNumbers);
       }
-      if (msmsScanNumber >= 1) {
-        // MS/MS scan must exist, because msmsScanNumber was > 0
-        Scan msmsScan = bestPeak.getDataFile().getScan(msmsScanNumber);
 
-        MassList massList = msmsScan.getMassList(massListName);
-
-
-        if (massList == null) {
-          continue;
-        }
-
-        writer.write("BEGIN IONS" + newLine);
-
-        if (rowID != null)
-          writer.write("FEATURE_ID=" + rowID + newLine);
-
-        String mass = mzForm.format(row.getAverageMZ());
-        if (mass != null)
-          writer.write("PEPMASS=" + mass + newLine);
-
-        if (rowID != null) {
-          writer.write("SCANS=" + rowID + newLine);
-          writer.write("RTINSECONDS=" + rtsForm.format(retTimeInSeconds) + newLine);
-        }
-
-        int msmsCharge = msmsScan.getPrecursorCharge();
-        String msmsPolarity = msmsScan.getPolarity().asSingleChar();
-        if (msmsPolarity.equals("0"))
-          msmsPolarity = "";
-        if (msmsCharge == 0) {
-          msmsCharge = 1;
-          msmsPolarity = "";
-        }
-        writer.write("CHARGE=" + msmsCharge + msmsPolarity + newLine);
-
-        writer.write("MSLEVEL=2" + newLine);
-
-        DataPoint peaks[] = massList.getDataPoints();
-        for (DataPoint peak : peaks) {
-          writer.write(mzForm.format(peak.getMZ()) + " " + intensityForm.format(peak.getIntensity())
-              + newLine);
-        }
-
-        writer.write("END IONS" + newLine);
-        writer.write(newLine);
-        count++;
-      }
     }
-    if (count == 0)
-      if (countMissingMassList > 0)
+    if (stats.count == 0)
+      if (stats.missingMassList > 0)
         throw new MSDKRuntimeException("No MS/MS scans exported: " + countMissingMassList
             + " scans have no mass list " + massListName);
       else
@@ -271,6 +219,163 @@ public class GNPSmgfExportTask extends AbstractTask {
           countMissingMassList, peakList.getName()));
 
     return count;
+  }
+
+  private void gnpsOutputMerge(PeakListRow row, FileWriter writer, ErrorStatistics stats, HashMap<String,int[]> ms2ScanNumbers) throws IOException {
+    final MergeUtils.MergedSpectrum ms2;
+    if (mergeMode == SiriusExportParameters.MERGE_MODE.MERGE_CONSECUTIVE_SCANS) {
+      ms2 = mergeUtils.mergeConsecutiveScans(row,row.getBestPeak());
+    } else {
+      ms2 = mergeUtils.mergeScansFromDifferentOrigins(row);
+    }
+    double retTimeInSeconds = ((row.getAverageRT() * 60 * 100.0) / 100.);
+    final String newLine = System.lineSeparator();
+    PeakListRow copyRow = copyPeakRow(row);
+    // Best peak always exists, because peak list row has at least one peak
+    Feature bestPeak = copyRow.getBestPeak();
+
+    // Get the heighest peak with a MS/MS scan number (with mass list)
+    boolean missingMassList = false;
+    writer.write("BEGIN IONS" + newLine);
+
+    writer.write("FEATURE_ID=" + row.getID() + newLine);
+
+    String mass = mzForm.format(row.getAverageMZ());
+    if (mass != null)
+        writer.write("PEPMASS=" + mass + newLine);
+
+      writer.write("SCANS=" + row.getID() + newLine);
+      writer.write("RTINSECONDS=" + rtsForm.format(retTimeInSeconds) + newLine);
+
+      int msmsCharge = ms2.precursorCharge;
+      String msmsPolarity = ms2.polarity.asSingleChar();
+      if (msmsPolarity.equals("0"))
+        msmsPolarity = "";
+      if (msmsCharge == 0) {
+        msmsCharge = 1;
+        msmsPolarity = "";
+      }
+      writer.write("CHARGE=" + msmsCharge + msmsPolarity + newLine);
+
+    writer.write("MERGED_STATS=");
+    writer.write(String.valueOf(ms2.scanIds.length));
+    writer.write(" / ");
+    writer.write(String.valueOf(ms2.totalNumberOfScans()));
+    writer.write(" (");
+    writer.write(String.valueOf(ms2.removedScansByLowQuality));
+    writer.write(" removed due to low quality, ");
+    writer.write(String.valueOf(ms2.removedScansByLowCosine));
+    writer.write(" removed due to low cosine).");
+    writer.write(newLine);
+
+      writer.write("MSLEVEL=2" + newLine);
+
+      MergeUtils.MergeDataPoint peaks[] = ms2.data;
+      for (MergeUtils.MergeDataPoint peak : peaks) {
+        writer.write(mzForm.format(peak.getMZ()) + " " + intensityForm.format(peak.getSumIntensity())
+                + newLine);
+      }
+
+      writer.write("END IONS" + newLine);
+      writer.write(newLine);
+      stats.count++;
+
+  }
+
+  private HashMap<String, int[]> getFragmentScansNumbers(RawDataFile[] rawDataFiles) {
+    final HashMap<String, int[]> fragmentScans = new HashMap<>();
+    for (RawDataFile r : rawDataFiles) {
+      int[] scans = new int[0];
+      for (int msLevel : r.getMSLevels()) {
+        if (msLevel > 1) {
+          int[] concat = r.getScanNumbers(msLevel);
+          int offset = scans.length;
+          scans = Arrays.copyOf(scans, scans.length + concat.length);
+          System.arraycopy(concat, 0, scans, offset, concat.length);
+        }
+      }
+      Arrays.sort(scans);
+      fragmentScans.put(r.getName(), scans);
+    }
+    return fragmentScans;
+  }
+
+  protected static class ErrorStatistics {
+    protected int missingMassList = 0;
+    protected int count = 0;
+  }
+
+  private void gnpsOutputNoMerge(PeakListRow row, Feature bestPeak, FileWriter writer, ErrorStatistics stats) throws IOException {
+    double retTimeInSeconds = ((row.getAverageRT() * 60 * 100.0) / 100.);
+    final String newLine = System.lineSeparator();
+    int msmsScanNumber = bestPeak.getMostIntenseFragmentScanNumber();
+      PeakListRow copyRow = copyPeakRow(row);
+      // Best peak always exists, because peak list row has at least one peak
+      bestPeak = copyRow.getBestPeak();
+
+      // Get the heighest peak with a MS/MS scan number (with mass list)
+      boolean missingMassList = false;
+      msmsScanNumber = bestPeak.getMostIntenseFragmentScanNumber();
+      while (msmsScanNumber < 1
+              || getScan(bestPeak, msmsScanNumber).getMassList(massListName) == null) {
+        // missing masslist
+        if (msmsScanNumber > 0)
+          missingMassList = true;
+
+        copyRow.removePeak(bestPeak.getDataFile());
+        if (copyRow.getPeaks().length == 0)
+          break;
+
+        bestPeak = copyRow.getBestPeak();
+        msmsScanNumber = bestPeak.getMostIntenseFragmentScanNumber();
+      }
+      if (missingMassList)
+        stats.missingMassList++;
+
+    if (msmsScanNumber >= 1) {
+      // MS/MS scan must exist, because msmsScanNumber was > 0
+      Scan msmsScan = bestPeak.getDataFile().getScan(msmsScanNumber);
+
+      MassList massList = msmsScan.getMassList(massListName);
+
+
+      if (massList == null) {
+        return;
+      }
+
+      writer.write("BEGIN IONS" + newLine);
+
+      writer.write("FEATURE_ID=" + row.getID() + newLine);
+
+      String mass = mzForm.format(row.getAverageMZ());
+      if (mass != null)
+        writer.write("PEPMASS=" + mass + newLine);
+
+      writer.write("SCANS=" + row.getID() + newLine);
+      writer.write("RTINSECONDS=" + rtsForm.format(retTimeInSeconds) + newLine);
+
+      int msmsCharge = msmsScan.getPrecursorCharge();
+      String msmsPolarity = msmsScan.getPolarity().asSingleChar();
+      if (msmsPolarity.equals("0"))
+        msmsPolarity = "";
+      if (msmsCharge == 0) {
+        msmsCharge = 1;
+        msmsPolarity = "";
+      }
+      writer.write("CHARGE=" + msmsCharge + msmsPolarity + newLine);
+
+      writer.write("MSLEVEL=2" + newLine);
+
+      DataPoint peaks[] = massList.getDataPoints();
+      for (DataPoint peak : peaks) {
+        writer.write(mzForm.format(peak.getMZ()) + " " + intensityForm.format(peak.getIntensity())
+                + newLine);
+      }
+
+      writer.write("END IONS" + newLine);
+      writer.write(newLine);
+      stats.count++;
+    }
   }
 
   public Scan getScan(Feature f, int msmsscan) {

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/gnpsexport/GNPSmgfExportTask.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/gnpsexport/GNPSmgfExportTask.java
@@ -35,12 +35,10 @@ import java.io.IOException;
 import java.text.DecimalFormat;
 import java.text.MessageFormat;
 import java.text.NumberFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
+import java.util.*;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import com.google.common.collect.Range;
 import io.github.msdk.MSDKRuntimeException;
@@ -224,7 +222,11 @@ public class GNPSmgfExportTask extends AbstractTask {
   private void gnpsOutputMerge(PeakListRow row, FileWriter writer, ErrorStatistics stats, HashMap<String,int[]> ms2ScanNumbers) throws IOException {
     final MergeUtils.MergedSpectrum ms2;
     if (mergeMode == SiriusExportParameters.MERGE_MODE.MERGE_CONSECUTIVE_SCANS) {
-      ms2 = mergeUtils.mergeConsecutiveScans(row,row.getBestPeak());
+      //ms2 = mergeUtils.mergeConsecutiveScans(row,row.getBestPeak());
+      final List<MergeUtils.MergedSpectrum> merged = Arrays.stream(row.getPeaks()).map(f->mergeUtils.mergeConsecutiveScans(row,f)).collect(Collectors.toList());;
+      merged.sort(Comparator.comparingDouble(m->-m.getTIC()));
+      ms2 = merged.get(0);
+
     } else {
       ms2 = mergeUtils.mergeScansFromDifferentOrigins(row);
     }

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/siriusexport/MergeUtils.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/siriusexport/MergeUtils.java
@@ -1,0 +1,739 @@
+package net.sf.mzmine.modules.peaklistmethods.io.siriusexport;
+
+import com.google.common.collect.Range;
+import net.sf.mzmine.datamodel.DataPoint;
+import net.sf.mzmine.datamodel.MassList;
+import net.sf.mzmine.datamodel.RawDataFile;
+import net.sf.mzmine.datamodel.Scan;
+import net.sf.mzmine.datamodel.impl.SimpleDataPoint;
+import org.apache.commons.math3.special.Erf;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/*
+    Merge several MS/MS scans into one
+ */
+public class MergeUtils {
+
+    /**
+     * Peaks below this threshold will not be counted as chimerics. The reasoning is that peaks with low intensity
+     * won't contaminate the MS/MS scans anyways.
+     */
+    public static final double CHIMERIC_INTENSITY_THRESHOLD = 0.1;
+    /**
+     * The masslist to use. If null, always pick all peaks
+     */
+    protected String masslist;
+
+    /**
+     * expected average mass deviation of fragment peaks
+     */
+    protected double expectedPPM;
+
+    /**
+     * width and offset (from precursor m/z) of the isolation window.
+     * Note that the window is centered at the precursor m/z
+     */
+    protected Range<Double> isolationWindow;
+
+    /**
+     * Only merge spectra if their cosine is above this threshold.
+     * Important: If your spectra come from different collision energies, you might want to set this threshold very low!
+     */
+    protected double cosineThreshold;
+
+    /**
+     * If true, the fragment m/z is calculated as weighted average over the merged fragment peaks
+     * If false, the fragment m/z is the m/z of the most intensive fragment peak.
+     *
+     * I guess first option may sometimes have more accurate m/z, while latter one is more safe and will rarely fail
+     */
+    protected boolean mergeMasses;
+
+    /**
+     * Only merge spectra if their MS1 precursor intensity is above this threshold (relative to most intensive precursor
+     * peak).
+     */
+    protected double minPrecursorIntensityRelativeToBestPeak;
+
+    /**
+     * Remove spectra which chimeric contamination is above this threshold
+     */
+    protected double maximalChimericIntensity;
+
+
+    /**
+     * do not merge if the chimeric contamination is larger than X times the contamination of the best peak
+     */
+    protected double maximalChimericContaminationRelativeToBestPeak;
+
+    /**
+     * do not merge if the chimeric contamination is larger than X times the absolute contamination of the best peak
+     */
+    protected double maximalAbsoluteChimericContaminationRelativeToBestPeak;
+
+    public MergeUtils() {
+        this.expectedPPM = 10;
+        this.isolationWindow = Range.closed(-1d,1d);
+        this.cosineThreshold = 0.8;
+        this.mergeMasses = true;
+        this.masslist = null;
+        this.minPrecursorIntensityRelativeToBestPeak = 0.25;
+        this.maximalChimericIntensity = 0.66;
+        this.maximalChimericContaminationRelativeToBestPeak = 1.33;
+        this.maximalAbsoluteChimericContaminationRelativeToBestPeak = 1.33;
+    }
+
+    public String getMasslist() {
+        return masslist;
+    }
+
+    public void setMasslist(String masslist) {
+        this.masslist = masslist;
+    }
+
+    public double getExpectedPPM() {
+        return expectedPPM;
+    }
+
+    public void setExpectedPPM(double expectedPPM) {
+        this.expectedPPM = expectedPPM;
+    }
+
+    public Range<Double> getIsolationWindow() {
+        return isolationWindow;
+    }
+
+    public void setIsolationWindow(Range<Double> isolationWindow) {
+        this.isolationWindow = isolationWindow;
+    }
+
+    public double getCosineThreshold() {
+        return cosineThreshold;
+    }
+
+    public void setCosineThreshold(double cosineThreshold) {
+        this.cosineThreshold = cosineThreshold;
+    }
+
+    public boolean isMergeMasses() {
+        return mergeMasses;
+    }
+
+    public void setMergeMasses(boolean mergeMasses) {
+        this.mergeMasses = mergeMasses;
+    }
+
+    protected double getTIC(DataPoint[] scan, double parentPeakThreshold) {
+        double TIC = 0d;
+        for (DataPoint p : scan) {
+            if (p.getMZ() > parentPeakThreshold)
+                break;
+            TIC += p.getIntensity();
+        }
+        return TIC;
+    }
+
+
+    //////////////////////////////////////////////////////////////////
+
+
+    /**
+     * Merge a list of scans from different origins into one spectrum. Each peak in the merged spectrum remembers its original
+     * peaks.
+     * @param name just for debugging purposes: some name string to identify the origin of the fragment scan
+     * @param parentPeak the m/z of the precursor ion
+     * @param scans a list of scans which should be merged
+     * @return merged spectrum
+     */
+    public MergedSpectrum mergeScansFromDifferentOrigins(String name, double parentPeak, List<FragmentScan> scans) {
+        if (scans.isEmpty()) return MergedSpectrum.empty();
+        // first split of list by origins
+        final HashMap<String, List<FragmentScan>> byName = new HashMap<>();
+        for (FragmentScan s : scans) {
+            byName.computeIfAbsent(s.origin.getName(), (x) -> new ArrayList<FragmentScan>()).add(s);
+        }
+        final List<List<FragmentScan>> allFs = new ArrayList<>(byName.values().stream().filter(x->!x.isEmpty()).collect(Collectors.toList()));
+        if (allFs.size()==1) {
+            return mergeConsecutiveScans(name, parentPeak,allFs.get(0));
+        }
+        // sort the scans by their best scan
+        allFs.sort(Comparator.comparingDouble(x->x.stream().max(Comparator.comparingDouble(FragmentScan::getScore)).get().getScore()));
+        // now merge spectrum by spectrum. Use cosine threshold between merged spectra
+        MergedSpectrum left = mergeConsecutiveScans(name,parentPeak,allFs.get(0));
+        if (left.data.length==0) return MergedSpectrum.empty();
+        for (int k=1; k < allFs.size(); ++k) {
+            MergedSpectrum right = mergeConsecutiveScans(name,parentPeak,allFs.get(k));
+            final double cosine = highResolutionCosine(left.data,right.data,expectedPPM,parentPeak-1.5);
+            if (cosine>=cosineThreshold) {
+                Arrays.sort(right.data, CompareDataPointsByDecreasingInt);
+                left = left.merge(right, merge(left.data, right.data));
+            }
+        }
+        return left;
+
+    }
+
+    /**
+     * Removes all MS/MS scans from the list which do not satisfy the threshold conditions
+     */
+    public List<DataPoint[]> extractHighQualityScans(double parentPeak, List<FragmentScan> scans, List<Integer> extractedScanNumbers) {
+        List<DataPoint[]> dps = new ArrayList<>();
+        findhighQualityScans(parentPeak, scans, dps,extractedScanNumbers);
+        return dps;
+    }
+
+    /**
+     * Merge a list of consecutive scans into one spectrum. Each peak in the merged spectrum remembers its original
+     * peaks.
+     * @param name just for debugging purposes: some name string to identify the origin of the fragment scan
+     * @param parentPeak the m/z of the precursor ion
+     * @param scans a list of scans which should be merged
+     * @return merged spectrum
+     */
+    public MergedSpectrum mergeConsecutiveScans(String name, double parentPeak, List<FragmentScan> scans) {
+        if (scans.isEmpty()) return MergedSpectrum.empty();
+        // we start with the highest TIC and then merge in both directions
+        boolean usecosine = cosineThreshold > 0;
+
+        // just to ensure that our scans are all ordered by m/z.
+        final List<DataPoint[]> mzOrderedCopy = new ArrayList<>();
+
+        // sort scans such that consecutive scans are always next to each other
+        scans.sort(Comparator.comparing((FragmentScan x)->x.origin.getName()).thenComparing(x->x.ms2ScanNumbers[0]));
+
+        // add all high quality scans to mzOrderedCopy and return index of best scan
+        final List<Integer> scanNumbers = new ArrayList<>();
+        int bestScan = findhighQualityScans(parentPeak, scans, mzOrderedCopy, scanNumbers);
+        if (mzOrderedCopy.isEmpty()) return MergedSpectrum.empty();
+
+        // calculate highres cosine normalization factor
+        final double[] cosines = new double[mzOrderedCopy.size()];
+        for (int k = 0; k < mzOrderedCopy.size(); ++k) {
+            if (usecosine) {
+                cosines[k] = probabilityProduct(mzOrderedCopy.get(k), mzOrderedCopy.get(k), getExpectedPPM(), parentPeak);
+            }
+        }
+
+        // remember how many scans we had initially
+        int numberOfTotalScans = 0;
+        for (FragmentScan f : scans) numberOfTotalScans += f.ms2ScanNumbers.length;
+
+        final int numberOfScansRemovedDueToLowQuality = numberOfTotalScans - mzOrderedCopy.size();
+        final List<Integer> usedScanNumbers = new ArrayList<>();
+        // now, start from best scan and merge in both direction if cosine is large enough. For simplicity, we only
+        // compute cosine between the original scans, not the merged scan. This is slightly more efficient.
+        int numberOfMerges = 1;
+        DataPoint[] dataPoints = mzOrderedCopy.get(bestScan);
+        usedScanNumbers.add(scanNumbers.get(bestScan));
+        MergeDataPoint[] mergedSpectrum = new MergeDataPoint[dataPoints.length];
+        {
+            for (int k = 0; k < dataPoints.length; ++k) mergedSpectrum[k] = new MergeDataPoint(dataPoints[k]);
+        }
+
+        int i = bestScan - 1, j = bestScan + 1;
+        while (i > 0 || j < mzOrderedCopy.size()) {
+            if (i > 0) {
+                MergeDataPoint[] merged = merge(mzOrderedCopy.get(bestScan), mergedSpectrum, mzOrderedCopy.get(i), cosines[bestScan], cosines[i], cosineThreshold, parentPeak);
+                if (merged != null) {
+                    mergedSpectrum = merged;
+                    ++numberOfMerges;
+                    usedScanNumbers.add(scanNumbers.get(i));
+                }
+                --i;
+            }
+            if (j < mzOrderedCopy.size()) {
+                MergeDataPoint[] merged = merge(mzOrderedCopy.get(bestScan), mergedSpectrum, mzOrderedCopy.get(j), cosines[bestScan], cosines[j], cosineThreshold, parentPeak);
+                if (merged != null) {
+                    mergedSpectrum = merged;
+                    ++numberOfMerges;
+                    usedScanNumbers.add(scanNumbers.get(j));
+                }
+                ++j;
+            }
+        }
+
+        final int numberOfScansRemovedDueToLowCosine = mzOrderedCopy.size()-numberOfMerges;
+
+        // write a warning if too many scans are filtered out due to low cosine
+        if (mzOrderedCopy.size() >= 4 && ((double) numberOfMerges) / mzOrderedCopy.size() < 0.5) {
+            LoggerFactory.getLogger(MergeUtils.class).warn(name + ": Only " + numberOfMerges + " of " + mzOrderedCopy.size() + " spectra are merged. All other have a too low cosine similarity. Cosines between most intensive scan and other scans are: " + Arrays.toString(cosines));
+        }
+        return new MergedSpectrum(mergedSpectrum, new RawDataFile[]{scans.get(0).origin}, scanNumbers.stream().mapToInt(x->x).toArray(), numberOfScansRemovedDueToLowQuality, numberOfScansRemovedDueToLowCosine);
+    }
+
+    /**
+     * extract all high quality scans from the list that satisfy the threshold conditions. Adds them to the provided
+     * list. Returns index of best quality scan
+     * @param parentPeak precursor m/z
+     * @param scans list of scans
+     * @param mzOrderedCopy an empty list for the results
+     * @return index of best scan from the result list
+     */
+    private int findhighQualityScans(double parentPeak, List<FragmentScan> scans, List<DataPoint[]> mzOrderedCopy, List<Integer> extractedScanNumbers) {
+        // find best scan, which is scan with high MS1 intensity, low chimeric contamination and high TIC
+        int bestScan = 0;
+        {
+            // search best scan
+            int best = 0; double bestScore = Double.NEGATIVE_INFINITY; double highestInt=0d;
+            for (int k=0; k < scans.size(); ++k) {
+                highestInt = scans.get(k).precursorIntensity;
+                double score = scans.get(k).getScore();
+                if (score >bestScore) {
+                    bestScore = score;
+                    best = k;
+                }
+            }
+            int bestOffset=0;
+            final FragmentScan bestScanF = scans.get(best);
+            for (FragmentScan scan : scans) {
+                int o=0;
+                double bestTIC = Double.NEGATIVE_INFINITY;
+                if (scan== bestScanF) {
+                    for (int k=0; k < scan.ms2ScanNumbers.length; ++k) {
+                        final Scan s = scan.origin.getScan(scan.ms2ScanNumbers[k]);
+                        DataPoint[] dps = useMassList(s);
+                        double tic = getTIC(dps, parentPeak-1.5);
+                        if (tic==0)
+                            continue;
+                        mzOrderedCopy.add(dps);
+                        if (extractedScanNumbers!=null) extractedScanNumbers.add(scan.ms2ScanNumbers[k]);
+                        if (tic > bestTIC) {
+                            o=k;
+                            bestTIC = tic;
+                        }
+                    }
+                    bestScan = bestOffset + o;
+                } else {
+                    // check for thresholds
+                    final double ms1Int = scan.precursorIntensity/highestInt;
+                    final double chimericInt = (scan.getChimericIntensityWithPseudocount()/scan.precursorIntensity)/(bestScanF.getChimericIntensityWithPseudocount()/bestScanF.precursorIntensity);
+                    final boolean lowChimericIntensiy = scan.chimericIntensity <= scan.precursorIntensity*0.1;
+                    if ((ms1Int >= minPrecursorIntensityRelativeToBestPeak) && (lowChimericIntensiy || (maximalChimericContaminationRelativeToBestPeak >= chimericInt && maximalChimericIntensity >= scan.chimericIntensity/scan.precursorIntensity ))) {
+                        for (int id : scan.ms2ScanNumbers) {
+                            DataPoint[] spectrum = useMassList(scan.origin.getScan(id));
+                            if (spectrum.length==0)
+                                continue;
+                            mzOrderedCopy.add(spectrum);
+                            if (extractedScanNumbers!=null) extractedScanNumbers.add(id);
+                            ++bestOffset;
+                        }
+                    }
+                }
+
+            }
+        }
+        return bestScan;
+    }
+
+    /**
+     * Use peaks from the given mass list, or all peaks if mass list is null
+     */
+    private DataPoint[] useMassList(Scan s) {
+        if (masslist==null) {
+            return orderIfNotOrdered(s.getDataPoints());
+        } else {
+            MassList massList = s.getMassList(masslist);
+            if (massList==null)
+                throw new NullPointerException("No masslist with name " + masslist + " in scan " + s.getScanNumber() + ", m/z = " + s.getPrecursorMZ() + ", retention time = " + s.getRetentionTime());
+            return orderIfNotOrdered(massList.getDataPoints());
+        }
+    }
+
+    private static DataPoint[] orderIfNotOrdered(DataPoint[] scan) {
+        for (int k = 1; k < scan.length; ++k) {
+            if (scan[k].getMZ() < scan[k - 1].getMZ()) {
+                DataPoint[] copy = scan.clone();
+                Arrays.sort(copy, CompareDataPointsByMz);
+                return copy;
+            }
+        }
+        return scan;
+    }
+
+    /**
+     * Internal method. Merge spectra if cosine is above cosine threshold
+     * @return
+     */
+    protected MergeDataPoint[] merge(DataPoint[] origin, MergeDataPoint[] left, DataPoint[] right, double cosineLeft, double cosineRight, double cosineThreshold, double parentPeak) {
+        if (cosineLeft==0 || cosineRight==0) return null;
+        if (cosineThreshold > 0) {
+            double cosine = probabilityProduct(origin, right, expectedPPM, parentPeak);
+            final double oldcs = cosine;
+            cosine /= Math.sqrt(cosineLeft * cosineRight);
+            if (cosine < cosineThreshold) {
+                if (cosine < 0.25)
+                    LoggerFactory.getLogger(MergeUtils.class).warn("Detect a very low cosine between two fragment scans: " + cosine  + " for precursor m/z = " + parentPeak);
+                return null;
+            }
+        }
+        // sort right list by intensity
+        final DataPoint[] rightInt = right.clone();
+        Arrays.sort(rightInt, CompareDataPointsByDecreasingInt);
+        return merge(left, right);
+    }
+
+    /**
+     * Merge a scan into a merged spectrum.
+     * @param orderedByMz peaks from merged spectrum, sorted by ascending m/z
+     * @param orderedByInt peaks from scan, sorted by ascending intensity
+     * @return a merged spectrum. Might be the original one if no new peaks were added.
+     */
+    protected MergeDataPoint[] merge(MergeDataPoint[] orderedByMz, DataPoint[] orderedByInt) {
+        // we assume a rather large deviation as signal peaks should be contained in more than one
+        // measurement
+        final List<MergeDataPoint> append = new ArrayList<>();
+        final double absoluteDeviation = 600 * expectedPPM * 1e-6;
+        for (int k = 0; k < orderedByInt.length; ++k) {
+            final DataPoint peak = orderedByInt[k];
+            final double dev = Math.max(absoluteDeviation, peak.getMZ() * 3 * expectedPPM * 1e-6);
+            final double lb = peak.getMZ() - dev, ub = peak.getMZ() + dev;
+            int mz1 = Arrays.binarySearch(orderedByMz, peak, CompareDataPointsByMz);
+            if (mz1 < 0) {
+                mz1 = -(mz1 + 1);
+            }
+            int mz0 = mz1 - 1;
+            while (mz1 < orderedByMz.length && orderedByMz[mz1].getMZ() <= ub)
+                ++mz1;
+            --mz1;
+            while (mz0 >= 0 && orderedByMz[mz0].getMZ() >= lb)
+                --mz0;
+            ++mz0;
+            if (mz0 <= mz1) {
+                // merge!
+                int mostIntensive = mz0;
+                double bestScore = Double.NEGATIVE_INFINITY;
+                for (int i = mz0; i <= mz1; ++i) {
+                    final double massDiff = orderedByMz[i].getMZ() - peak.getMZ();
+                    final double score =
+                            Erf.erfc(3 * massDiff) / (dev * Math.sqrt(2)) * orderedByMz[i].getIntensity();
+                    if (score > bestScore) {
+                        bestScore = score;
+                        mostIntensive = i;
+                    }
+                }
+
+                orderedByMz[mostIntensive] = orderedByMz[mostIntensive].merge(peak, mergeMasses);
+
+            } else {
+                // append
+                append.add(new MergeDataPoint(peak));
+            }
+        }
+        if (append.size() > 0) {
+            int offset = orderedByMz.length;
+            orderedByMz = Arrays.copyOf(orderedByMz, orderedByMz.length + append.size());
+            for (MergeDataPoint p : append) {
+                orderedByMz[offset++] = p;
+            }
+            Arrays.sort(orderedByMz, CompareDataPointsByMz);
+        }
+        return orderedByMz;
+    }
+
+    public static double highResolutionCosine(DataPoint[] left, DataPoint[] right, double expectedPPM, double maxMz) {
+        double a = probabilityProduct(left, left, expectedPPM, maxMz);
+        if(a==0) return 0;
+        double b = probabilityProduct(right, right, expectedPPM, maxMz);
+        if (b==0) return 0;
+        return probabilityProduct(left, right,expectedPPM,maxMz) / Math.sqrt(a * b);
+    }
+
+    /**
+     * Calculate the integral product between two spectra. Highres version of the well known dot product.
+     * To get a cosine score, you have to normalize this score!
+     * @param left first spectrum
+     * @param right second spectrum
+     * @param expectedPPM expected average mass deviation
+     * @param maxMz usually the parent mass. Peaks behind this value are ignored
+     * @return
+     */
+    public static double probabilityProduct(DataPoint[] left, DataPoint[] right, double expectedPPM, double maxMz) {
+        int i = 0, j = 0;
+        double score = 0d;
+        final double allowedDifference = Math.min(1, 1000 * expectedPPM * 5e-6);
+        final int nl, nr;//=left.length, nr=right.length;
+        {
+            int maxi = Arrays.binarySearch(left, new SimpleDataPoint(maxMz + 0.5d, 0), CompareDataPointsByMz);
+            if (maxi < 0) maxi = -(maxi + 1);
+            nl = maxi;
+            maxi = Arrays.binarySearch(right, new SimpleDataPoint(maxMz + 0.5d, 0), CompareDataPointsByMz);
+            if (maxi < 0) maxi = -(maxi + 1);
+            nr = maxi;
+        }
+
+        while (i < nl && j < nr) {
+            DataPoint lp = left[i];
+            DataPoint rp = right[j];
+            final double difference = lp.getMZ() - rp.getMZ();
+            if (Math.abs(difference) <= allowedDifference) {
+                final double mzabs = Math.max(200 * expectedPPM * 1e-6, expectedPPM * 1e-6 * Math.round(lp.getMZ() + rp.getMZ()) / 2d);
+                final double variance = mzabs * mzabs;
+                double matchScore = scorePeaks(lp, rp, variance);
+                score += matchScore;
+                for (int k = i + 1; k < nl; ++k) {
+                    DataPoint lp2 = left[k];
+                    final double difference2 = lp2.getMZ() - rp.getMZ();
+                    if (Math.abs(difference2) <= allowedDifference) {
+                        matchScore = scorePeaks(lp2, rp, variance);
+                        score += matchScore;
+                    } else break;
+                }
+                for (int l = j + 1; l < nr; ++l) {
+                    DataPoint rp2 = right[l];
+                    final double difference2 = lp.getMZ() - rp2.getMZ();
+                    if (Math.abs(difference2) <= allowedDifference) {
+                        matchScore = scorePeaks(lp, rp2, variance);
+                        score += matchScore;
+                    } else break;
+                }
+                ++i;
+                ++j;
+            } else if (difference > 0) {
+                ++j;
+
+            } else {
+                ++i;
+            }
+        }
+        return score;
+
+    }
+
+    /**
+     * Internal method for calculating the gaussian integral product
+     */
+    protected static double scorePeaks(DataPoint lp, DataPoint rp, double variance) {
+        //formula from Jebara: Probability Product Kernels. multiplied by intensities
+        // (1/(4*pi*sigma**2))*exp(-(mu1-mu2)**2/(4*sigma**2))
+        final double mzDiff = Math.abs(lp.getMZ() - rp.getMZ());
+        final double constTerm = 1.0 / (Math.PI * variance * 4);
+
+        final double propOverlap = constTerm * Math.exp(-(mzDiff * mzDiff) / (4 * variance));
+        return (lp.getIntensity() * rp.getIntensity()) * propOverlap;
+    }
+
+    protected static final Comparator<DataPoint> CompareDataPointsByMz = new Comparator<DataPoint>() {
+        @Override
+        public int compare(DataPoint o1, DataPoint o2) {
+            return Double.compare(o1.getMZ(), o2.getMZ());
+        }
+    };
+    protected static final Comparator<DataPoint> CompareDataPointsByDecreasingInt = new Comparator<DataPoint>() {
+        @Override
+        public int compare(DataPoint o1, DataPoint o2) {
+            return Double.compare(o2.getIntensity(), o1.getIntensity());
+        }
+    };
+
+    ////////////////////////////////////////////////////////////////////////////////////////
+
+    /**
+     * An MS/MS scan with some statistics about its precursor in MS
+     */
+    protected static class FragmentScan {
+
+        /**
+         * The raw data file this scans are derived from
+         */
+        protected final RawDataFile origin;
+        /**
+         * the MS1 scan that comes before the first MS/MS
+         */
+        protected final int ms1ScanNumber;
+        /**
+         * all consecutive(!) MS/MS scans. There should ne no other MS1 scan between them
+         */
+        protected final int[] ms2ScanNumbers;
+        /**
+         * the intensity of the precursor peak in MS
+         */
+        protected double precursorIntensity;
+        /**
+         * the sumed up intensity of chimeric peaks
+         */
+        protected double chimericIntensity;
+
+        public FragmentScan(RawDataFile origin, double precursorMass, int ms1ScanNumber, int[] ms2ScanNumbers, Range<Double> isolationWindow, double massAccuracyInPPM) {
+            this.origin = origin;
+            this.ms1ScanNumber = ms1ScanNumber;
+            this.ms2ScanNumbers = ms2ScanNumbers;
+            if (ms1ScanNumber >= 0) {
+                detectPrecursor(precursorMass, isolationWindow, massAccuracyInPPM);
+            } else {
+                this.precursorIntensity = 0d;
+                this.chimericIntensity = 0d;
+            }
+        }
+
+        /**
+         * the score describes how good this MS/MS are. Should incorporate the intensity of MS1 precursor peak
+         * and the intensity of closeby chimeric peaks
+         */
+        private double getScore() {
+            return precursorIntensity * (precursorIntensity/getChimericIntensityWithPseudocount());
+        }
+
+        protected double getChimericIntensityWithPseudocount() {
+            return (chimericIntensity+precursorIntensity*CHIMERIC_INTENSITY_THRESHOLD);
+        }
+
+        /**
+         * search for precursor peak in MS1
+         */
+        private void detectPrecursor(double precursorMass, Range<Double> isolationWindow, double ppm) {
+            Scan spectrum = origin.getScan(ms1ScanNumber);
+            DataPoint[] dps = spectrum.getDataPointsByMass(Range.closed(precursorMass+isolationWindow.lowerEndpoint(), precursorMass+isolationWindow.upperEndpoint()));
+            // for simplicity, just use the most intensive peak within ppm range
+            int bestPeak = -1;
+            double highestIntensity = 0d;
+            for (int mppm = 1; mppm < 3; ++mppm) {
+                final double maxDiff = (mppm * ppm) * 1e-6 * Math.max(200, precursorMass);
+                for (int i = 0; i < dps.length; ++i) {
+                    final DataPoint p = dps[i];
+                    if (p.getIntensity() <= highestIntensity)
+                        continue;
+                    final double mzdiff = Math.abs(p.getMZ() - precursorMass);
+                    if (mzdiff <= maxDiff) {
+                        highestIntensity = p.getIntensity();
+                        bestPeak = i;
+                    }
+                }
+                if (bestPeak >= 0)
+                    break;
+            }
+            // now sum up all remaining intensities. Leave out isotopes. leave out peaks with intensity below 10%
+            // of the precursor. They won't contaminate fragment scans anyways
+            this.precursorIntensity = highestIntensity;
+            this.chimericIntensity = 0d;
+            final double threshold = precursorIntensity* CHIMERIC_INTENSITY_THRESHOLD;
+            foreachpeak:
+            for (int i = 0; i < dps.length; ++i) {
+                if (i != bestPeak && dps[i].getIntensity()>threshold) {
+                    // check for isotope peak
+                    final double maxDiff = ppm * 1e-6 * Math.max(200, precursorMass) + 0.03;
+                    for (int k = 1; k < 5; ++k) {
+                        final double isoMz = precursorMass + k * 1.0015;
+                        final double diff = isoMz - dps[i].getMZ();
+                        if (Math.abs(diff) <= maxDiff) {
+                            continue foreachpeak;
+                        } else if (diff > 0.5) {
+                            break;
+                        }
+                    }
+                    chimericIntensity += dps[i].getIntensity();
+                }
+            }
+        }
+    }
+
+    protected static class MergedSpectrum {
+        protected final MergeDataPoint[] data;
+        protected final RawDataFile[] origins;
+        protected final int[] scanIds;
+        protected final int removedScansByLowQuality;
+        protected final int removedScansByLowCosine;
+        private final static MergedSpectrum EMPTY = new MergedSpectrum(new MergeDataPoint[0],new RawDataFile[0],new int[0], 0,0);
+        public static MergedSpectrum empty() {
+            return EMPTY;
+        }
+
+        public MergedSpectrum(MergeDataPoint[] data, Set<RawDataFile> origins, Set<Integer> scanIds, int removedScansByLowQuality, int removedScansByLowCosine) {
+            this(data, origins.toArray(new RawDataFile[origins.size()]), scanIds.stream().sorted().mapToInt(x->x).toArray(), removedScansByLowQuality, removedScansByLowCosine);
+        }
+
+        public MergedSpectrum(MergeDataPoint[] data, RawDataFile[] origins, int[] scanIds, int removedScansByLowQuality, int removedScansByLowCosine) {
+            this.data = data;
+            this.origins = origins;
+            this.scanIds = scanIds;
+            this.removedScansByLowQuality = removedScansByLowQuality;
+            this.removedScansByLowCosine = removedScansByLowCosine;
+        }
+
+        public int totalNumberOfScans() {
+            return scanIds.length+removedScansByLowCosine+removedScansByLowQuality;
+        }
+
+        public MergedSpectrum merge(MergedSpectrum right, MergeDataPoint[] mergedSpectrum) {
+            final RawDataFile[] norigs = Arrays.copyOf(origins, origins.length+right.origins.length);
+            System.arraycopy(right.origins, 0, norigs, origins.length, right.origins.length);
+            final int[] nscans = Arrays.copyOf(scanIds, scanIds.length+right.scanIds.length);
+            System.arraycopy(right.scanIds, 0, nscans, scanIds.length, right.scanIds.length);
+            return new MergedSpectrum(mergedSpectrum, norigs, nscans, removedScansByLowQuality+right.removedScansByLowQuality, removedScansByLowCosine+right.removedScansByLowCosine);
+        }
+    }
+
+    protected static class MergeDataPoint implements DataPoint {
+
+        private final DataPoint[] sources;
+        private final double mz, intensity;
+
+        private final double sumMz, maxInt;
+
+        private MergeDataPoint(DataPoint[] sources, double mz, double intens, double sumMz, double maxIntens) {
+            this.sources = sources;
+            this.mz = mz;
+            this.intensity = intens;
+            this.sumMz = sumMz;
+            this.maxInt = maxIntens;
+        }
+
+        private MergeDataPoint(DataPoint single) {
+            this.sources = new DataPoint[]{single};
+            this.mz = single.getMZ();
+            this.intensity = single.getIntensity();
+            this.sumMz = this.mz * this.intensity;
+            this.maxInt = single.getIntensity();
+        }
+
+        protected MergeDataPoint merge(DataPoint additional, boolean mergeMz) {
+            if (additional instanceof MergeDataPoint) {
+                final MergeDataPoint ad = (MergeDataPoint)additional;
+                DataPoint[] cop = Arrays.copyOf(sources, sources.length + ad.sources.length);
+                System.arraycopy(ad.sources, 0, cop, sources.length, ad.sources.length );
+                final double sumMz2 = sumMz + additional.getMZ() * additional.getIntensity();
+                final double sumInt = intensity + additional.getIntensity();
+                return new MergeDataPoint(cop, mergeMz ? sumMz2 / sumInt : (additional.getIntensity() > maxInt ? additional.getMZ() : mz), sumInt, sumMz2, Math.max(maxInt, additional.getIntensity()));
+            } else {
+                DataPoint[] cop = Arrays.copyOf(sources, sources.length + 1);
+                cop[cop.length - 1] = additional;
+                final double sumMz2 = sumMz + additional.getMZ() * additional.getIntensity();
+                final double sumInt = intensity + additional.getIntensity();
+                return new MergeDataPoint(cop, mergeMz ? sumMz2 / sumInt : (additional.getIntensity() > maxInt ? additional.getMZ() : mz), sumInt, sumMz2, Math.max(maxInt, additional.getIntensity()));
+            }
+        }
+
+        public String getComment() {
+            double smallest = Double.POSITIVE_INFINITY, largest = Double.NEGATIVE_INFINITY, average = 0d;
+            int apex = 0;
+            for (int k = 0; k < sources.length; ++k) {
+                final DataPoint p = sources[k];
+                smallest = Math.min(smallest, p.getMZ());
+                largest = Math.max(largest, p.getMZ());
+                average += Math.abs(p.getMZ() - mz);
+                if (p.getIntensity() > sources[apex].getIntensity()) apex = k;
+            }
+            average /= sources.length;
+            // median
+            final DataPoint[] copy = sources.clone();
+            Arrays.sort(copy, CompareDataPointsByMz);
+            double medianMz = copy[copy.length / 2].getMZ();
+            if (copy.length > 1 && copy.length % 2 == 0)
+                medianMz = (medianMz + copy[(copy.length) / 2 - 1].getMZ()) / 2d;
+            return String.format(Locale.US, "%.5f ... %.5f  (median = %.5f, apex = %.5f). Standard deviation = %.5f. Peaks: %d", smallest, largest, medianMz, sources[apex].getMZ(), average, sources.length);
+        }
+
+        @Override
+        public double getMZ() {
+            return mz;
+        }
+
+        @Override
+        public double getIntensity() {
+            return intensity;
+        }
+    }
+
+}

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/siriusexport/SiriusExportModule.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/siriusexport/SiriusExportModule.java
@@ -102,10 +102,9 @@ public class SiriusExportModule implements MZmineProcessingModule {
 }
 
 /*
- * "If you use the SIRIUS export module, cite MZmine2 and the following articles: Dührkop et al.,
- * Proc Natl Acad Sci USA 112(41):12580-12585 and Boecker et al., Journal of Cheminformatics (2016)
+ * "If you use the SIRIUS export module, cite MZmine2 and the following articlel. Dührkop, M. Fleischauer, M. Ludwig, A. A. Aksenov, A. V. Melnik, M. Meusel, P. C. Dorrestein, J. Rousu, and S. Böcker, “Sirius 4: a rapid tool for turning tandem mass spectra into metabolite structure information,” Nat methods, 2019.
  * 8:5
  * 
- * [Link](http://www.pnas.org/content/112/41/12580.abstract), and
+ * [Link](http://dx.doi.org/10.1038/s41592-019-0344-8), and
  * [Link](https://jcheminf.springeropen.com/articles/10.1186/s13321-016-0116-8)
  */

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/siriusexport/SiriusExportParameters.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/siriusexport/SiriusExportParameters.java
@@ -29,18 +29,22 @@ import java.util.Locale;
 public class SiriusExportParameters extends SimpleParameterSet {
 
 
-  public static final IntegerParameter COSINE_PARAMETER = new IntegerParameter("Cosine threshold (%)", "Threshold for the cosine similarity between two spectra for merging. Set to 0 if the spectra may have different collision energy!", 80, 0, 100);
+  public static final PercentParameter COSINE_PARAMETER = new PercentParameter("Cosine threshold (%)", "Threshold for the cosine similarity between two spectra for merging. Set to 0 if the spectra may have different collision energy!", 0.8d, 0d, 1d);
 
-  public static final IntegerParameter MASS_ACCURACY = new IntegerParameter("expected mass deviation (ppm)", "Expected mass deviation of your measurement in ppm (parts per million).", 10, 1, 100);
+  public static final PercentParameter PEAK_COUNT_PARAMETER = new PercentParameter("Peak count threshold ", "After merging, remove all peaks which occur in less than X % of the merged spectra.", 0.2d, 0d, 1d);
+
+  public static final IntegerParameter MASS_ACCURACY = new IntegerParameter("expected mass deviation (ppm)", "Expected mass deviation of your measurement in ppm (parts per million). We recommend to use a rather large value, e.g. 5 for Orbitrap, 15 for Q-ToF, 100 for QQQ.", 10, 1, 100);
 
   public static final BooleanParameter AVERAGE_OVER_MASS = new BooleanParameter("Average over m/z", "When merging two peaks, the m/z of the merged peak is set to the weighted average of the source peaks. If unchecked, the m/z of the peak with largest intensity is used instead.", false);
+
+  public static final BooleanParameter DEBUG_INFORMATION = new BooleanParameter("Add DEBUG information", "Add statistics about merged peaks for debugging purpose.", false);
 
   public static final ComboParameter<MERGE_MODE> MERGE =
       new ComboParameter<MERGE_MODE>("Merge mode", "How to merge MS/MS spectra",
           MERGE_MODE.values(), MERGE_MODE.MERGE_CONSECUTIVE_SCANS);
 
   public SiriusExportParameters() {
-    super(new Parameter[] {PEAK_LISTS, FILENAME, MERGE, AVERAGE_OVER_MASS,  COSINE_PARAMETER, MASS_ACCURACY,  MASS_LIST, isolationWindowOffset, isolationWindowWidth});
+    super(new Parameter[] {PEAK_LISTS, FILENAME, MERGE, AVERAGE_OVER_MASS, PEAK_COUNT_PARAMETER,  COSINE_PARAMETER, MASS_ACCURACY,  MASS_LIST, isolationWindowOffset, isolationWindowWidth, DEBUG_INFORMATION});
   }
 
   public static final DoubleParameter isolationWindowOffset = new DoubleParameter("isolation window offset", "isolation window offset from the precursor m/z", NumberFormat.getNumberInstance(Locale.US), 0d);
@@ -88,9 +92,7 @@ public class SiriusExportParameters extends SimpleParameterSet {
 
   public ExitCode showSetupDialog(Window parent, boolean valueCheckRequired) {
     String message = "<html>SIRIUS Module Disclaimer:"
-        + "<br>    - If you use the SIRIUS export module, cite <a href=\"https://bmcbioinformatics.biomedcentral.com/articles/10.1186/1471-2105-11-395\">MZmine2 paper</a> and the following articles: "
-        + "<br>     <a href=\"http://www.pnas.org/content/112/41/12580.abstract\">Dührkop et al., Proc Natl Acad Sci USA 112(41):12580-12585</a> "
-        + "and <a href=\"https://jcheminf.springeropen.com/articles/10.1186/s13321-016-0116-8\">Boecker et al., Journal of Cheminformatics (2016) 8:5</a>"
+        + "<br>    - If you use the SIRIUS export module, cite <a href=\"https://bmcbioinformatics.biomedcentral.com/articles/10.1186/1471-2105-11-395\">MZmine2 paper</a> and the following article: <a href=\"http://dx.doi.org/10.1038/s41592-019-0344-8\"> K. Dührkop, et al. “Sirius 4: a rapid tool for turning tandem mass spectra into metabolite structure information”, Nat methods, 2019.</a>"
         + "<br>    - Sirius can be downloaded at the following address: <a href=\"https://bio.informatik.uni-jena.de/software/sirius/\">https://bio.informatik.uni-jena.de/software/sirius/</a>"
         + "<br>    - Sirius results can be mapped into <a href=\"http://gnps.ucsd.edu/\">GNPS</a> molecular networks. <a href=\"https://bix-lab.ucsd.edu/display/Public/Mass+spectrometry+data+pre-processing+for+GNPS\">See the documentation</a>.";
     ParameterSetupDialog dialog =

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/siriusexport/SiriusExportParameters.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/siriusexport/SiriusExportParameters.java
@@ -15,24 +15,36 @@ package net.sf.mzmine.modules.peaklistmethods.io.siriusexport;
 import net.sf.mzmine.parameters.Parameter;
 import net.sf.mzmine.parameters.dialogs.ParameterSetupDialog;
 import net.sf.mzmine.parameters.impl.SimpleParameterSet;
-import net.sf.mzmine.parameters.parametertypes.ComboParameter;
-import net.sf.mzmine.parameters.parametertypes.MassListParameter;
+import net.sf.mzmine.parameters.parametertypes.*;
 import net.sf.mzmine.parameters.parametertypes.filenames.FileNameParameter;
+import net.sf.mzmine.parameters.parametertypes.ranges.DoubleRangeParameter;
 import net.sf.mzmine.parameters.parametertypes.selectors.PeakListsParameter;
 import net.sf.mzmine.util.ExitCode;
 
 import java.awt.*;
+import java.text.NumberFormat;
+import java.util.Locale;
 
 
 public class SiriusExportParameters extends SimpleParameterSet {
+
+
+  public static final IntegerParameter COSINE_PARAMETER = new IntegerParameter("Cosine threshold (%)", "Threshold for the cosine similarity between two spectra for merging. Set to 0 if the spectra may have different collision energy!", 80, 0, 100);
+
+  public static final IntegerParameter MASS_ACCURACY = new IntegerParameter("expected mass deviation (ppm)", "Expected mass deviation of your measurement in ppm (parts per million).", 10, 1, 100);
+
+  public static final BooleanParameter AVERAGE_OVER_MASS = new BooleanParameter("Average over m/z", "When merging two peaks, the m/z of the merged peak is set to the weighted average of the source peaks. If unchecked, the m/z of the peak with largest intensity is used instead.", false);
 
   public static final ComboParameter<MERGE_MODE> MERGE =
       new ComboParameter<MERGE_MODE>("Merge mode", "How to merge MS/MS spectra",
           MERGE_MODE.values(), MERGE_MODE.MERGE_CONSECUTIVE_SCANS);
 
   public SiriusExportParameters() {
-    super(new Parameter[] {PEAK_LISTS, FILENAME, MERGE, MASS_LIST});
+    super(new Parameter[] {PEAK_LISTS, FILENAME, MERGE, AVERAGE_OVER_MASS,  COSINE_PARAMETER, MASS_ACCURACY,  MASS_LIST, isolationWindowOffset, isolationWindowWidth});
   }
+
+  public static final DoubleParameter isolationWindowOffset = new DoubleParameter("isolation window offset", "isolation window offset from the precursor m/z", NumberFormat.getNumberInstance(Locale.US), 0d);
+  public static final DoubleParameter isolationWindowWidth = new DoubleParameter("isolation window width", "width (left and right from offset) of the isolation window", NumberFormat.getNumberInstance(Locale.US), 1d);
 
 
   public static final PeakListsParameter PEAK_LISTS = new PeakListsParameter();
@@ -60,6 +72,8 @@ public class SiriusExportParameters extends SimpleParameterSet {
     NO_MERGE("Do not merge"), MERGE_CONSECUTIVE_SCANS(
         "Merge consecutive scans"), MERGE_OVER_SAMPLES(
             "Merge all MS/MS belonging to the same feature");
+
+
     private final String name;
 
     private MERGE_MODE(String name) {

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/siriusexport/SiriusExportTask.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/siriusexport/SiriusExportTask.java
@@ -16,6 +16,7 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.text.NumberFormat;
 import java.util.*;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -29,6 +30,7 @@ import net.sf.mzmine.datamodel.PeakList;
 import net.sf.mzmine.datamodel.PeakListRow;
 import net.sf.mzmine.datamodel.RawDataFile;
 import net.sf.mzmine.datamodel.Scan;
+import net.sf.mzmine.main.MZmineCore;
 import net.sf.mzmine.parameters.ParameterSet;
 import net.sf.mzmine.taskcontrol.AbstractTask;
 import net.sf.mzmine.taskcontrol.TaskStatus;
@@ -58,6 +60,8 @@ public class SiriusExportTask extends AbstractTask {
     protected final SiriusExportParameters.MERGE_MODE mergeMsMs;
     protected double cosineThreshold;
     protected double expectedPPM;
+
+    private NumberFormat intensityForm = MZmineCore.getConfiguration().getIntensityFormat();
 
     protected boolean mergeMasses;
 
@@ -239,46 +243,7 @@ public class SiriusExportTask extends AbstractTask {
          */
         final List<MergeUtils.FragmentScan> allFragmentScans = new ArrayList<>();
         for (Feature f : row.getPeaks()) {
-            final List<MergeUtils.FragmentScan> scans = new ArrayList<>();
-            if (f.getFeatureStatus() == Feature.FeatureStatus.DETECTED
-                    && f.getMostIntenseFragmentScanNumber() >= 0) {
-
-                final TIntArrayList scanIds = new TIntArrayList(f.getScanNumbers());
-                scanIds.addAll(f.getAllMS2FragmentScanNumbers());
-                int[] fs = fragmentScans.get(f.getDataFile().getName());
-
-                int j = Arrays.binarySearch(fs, scanIds.get(0));
-                if (j < 0)
-                    j = (-j - 1);
-                for (int k=j; k < fs.length; ++k) {
-                    final Scan scan = f.getDataFile().getScan(fs[k]);
-                    if (scan.getRetentionTime() > f.getRawDataPointsRTRange().upperEndpoint())
-                        break;
-                    if (Math.abs(f.getDataFile().getScan(fs[k]).getPrecursorMZ() - f.getMZ()) < 0.1) {
-                        scanIds.add(fs[k]);
-                    }
-                }
-                scanIds.sort();
-                final TIntArrayList ms2Scans = new TIntArrayList();
-                int ms1ScanNumber = -1;
-
-                for (int scanId : scanIds.toArray()) {
-
-                    final Scan scan = f.getDataFile().getScan(scanId);
-                    if (scan.getMSLevel() == 1) {
-                        if (!ms2Scans.isEmpty())
-                            scans.add(new MergeUtils.FragmentScan(f.getDataFile(), row.getAverageMZ(), ms1ScanNumber, ms2Scans.toArray(), isolationWindow, expectedPPM));
-                        ms1ScanNumber = scan.getScanNumber();
-                        ms2Scans.clear();
-                    } else {
-                        ms2Scans.add(scan.getScanNumber());
-                    }
-                }
-                if (!ms2Scans.isEmpty()) {
-                    scans.add(new MergeUtils.FragmentScan(f.getDataFile(), row.getAverageMZ(), ms1ScanNumber, ms2Scans.toArray(), isolationWindow, expectedPPM));
-                }
-
-            }
+            final List<MergeUtils.FragmentScan> scans = mergeUtils.extractFragmentScansFor(row, f);
             if (scans.isEmpty())
                 continue;
             if (mergeMsMs == SiriusExportParameters.MERGE_MODE.MERGE_CONSECUTIVE_SCANS) {
@@ -431,7 +396,7 @@ public class SiriusExportTask extends AbstractTask {
             final MergeUtils.MergeDataPoint mp = (dp instanceof MergeUtils.MergeDataPoint ? (MergeUtils.MergeDataPoint)dp : null);
             writer.write(String.valueOf(dp.getMZ()));
             writer.write(' ');
-            writer.write(mp != null ? String.valueOf(mp.getSumIntensity()) : String.valueOf(dp.getIntensity()));
+            writer.write(mp != null ? intensityForm.format(mp.getSumIntensity()) : intensityForm.format(dp.getIntensity()));
             if (DEBUG_MODE && mp!=null) {
                 writer.write(' ');
                 writer.write('#');

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/siriusexport/SiriusExportTask.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/siriusexport/SiriusExportTask.java
@@ -16,480 +16,426 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
+import java.util.*;
 import java.util.regex.Pattern;
-import org.apache.commons.math3.special.Erf;
+import java.util.stream.Collectors;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.Range;
+import gnu.trove.list.array.TIntArrayList;
 import net.sf.mzmine.datamodel.DataPoint;
 import net.sf.mzmine.datamodel.Feature;
-import net.sf.mzmine.datamodel.MassList;
 import net.sf.mzmine.datamodel.PeakList;
 import net.sf.mzmine.datamodel.PeakListRow;
 import net.sf.mzmine.datamodel.RawDataFile;
 import net.sf.mzmine.datamodel.Scan;
-import net.sf.mzmine.datamodel.impl.SimpleDataPoint;
 import net.sf.mzmine.parameters.ParameterSet;
 import net.sf.mzmine.taskcontrol.AbstractTask;
 import net.sf.mzmine.taskcontrol.TaskStatus;
-import net.sf.mzmine.util.DataPointSorter;
-import net.sf.mzmine.util.SortingDirection;
-import net.sf.mzmine.util.SortingProperty;
 
 public class SiriusExportTask extends AbstractTask {
 
-  private final static String plNamePattern = "{}";
-  protected static final Comparator<DataPoint> CompareDataPointsByMz = new Comparator<DataPoint>() {
-    @Override
-    public int compare(DataPoint o1, DataPoint o2) {
-      return Double.compare(o1.getMZ(), o2.getMZ());
-    }
-  };
-  private final PeakList[] peakLists;
-  private final File fileName;
-  // private final boolean fractionalMZ;
-  private final String massListName;
-  protected long finishedRows, totalRows;
-  protected final SiriusExportParameters.MERGE_MODE mergeMsMs;
+    private final static boolean DEBUG_MODE = true;
 
-
-  public double getFinishedPercentage() {
-    return (totalRows == 0 ? 0.0 : (double) finishedRows / (double) totalRows);
-  }
-
-  public String getTaskDescription() {
-    return "Exporting peak list(s) " + Arrays.toString(peakLists) + " to MGF file(s)";
-  }
-
-  SiriusExportTask(ParameterSet parameters) {
-    this.peakLists = parameters.getParameter(SiriusExportParameters.PEAK_LISTS).getValue()
-        .getMatchingPeakLists();
-
-    this.fileName = parameters.getParameter(SiriusExportParameters.FILENAME).getValue();
-
-    // this.fractionalMZ =
-    // parameters.getParameter(SiriusExportParameters.FRACTIONAL_MZ)
-    // .getValue();
-
-    this.massListName = parameters.getParameter(SiriusExportParameters.MASS_LIST).getValue();
-    this.mergeMsMs = parameters.getParameter(SiriusExportParameters.MERGE).getValue();
-  }
-
-  public void run() {
-    setStatus(TaskStatus.PROCESSING);
-
-    // Shall export several files?
-    boolean substitute = fileName.getPath().contains(plNamePattern);
-
-    for (PeakList l : peakLists)
-      this.totalRows += l.getNumberOfRows();
-
-    // Process peak lists
-    for (PeakList peakList : peakLists) {
-
-      // Filename
-      File curFile = fileName;
-      if (substitute) {
-        // Cleanup from illegal filename characters
-        String cleanPlName = peakList.getName().replaceAll("[^a-zA-Z0-9.-]", "_");
-        // Substitute
-        String newFilename =
-            fileName.getPath().replaceAll(Pattern.quote(plNamePattern), cleanPlName);
-        curFile = new File(newFilename);
-      }
-
-      // Open file
-      try (final BufferedWriter bw = new BufferedWriter(new FileWriter(curFile, true))) {
-        exportPeakList(peakList, bw);
-      } catch (IOException e) {
-        setStatus(TaskStatus.ERROR);
-        setErrorMessage("Could not open file " + curFile + " for writing.");
-      }
-
-      // If peak list substitution pattern wasn't found,
-      // treat one peak list only
-      if (!substitute)
-        break;
-    }
-
-    if (getStatus() == TaskStatus.PROCESSING)
-      setStatus(TaskStatus.FINISHED);
-  }
-
-  private static DataPoint[] merge(double parentPeak, List<DataPoint[]> scans) {
-    final DataPointSorter descendingIntensitySorter =
-        new DataPointSorter(SortingProperty.Intensity, SortingDirection.Descending);
-    double maxTIC = 0d;
-    int best = 0;
-    for (int i = 0; i < scans.size(); ++i) {
-      final DataPoint[] scan = scans.get(i);
-      Arrays.sort(scan, descendingIntensitySorter);
-      double tic = 0d;
-      for (int j = 0; j < Math.min(40, scan.length); ++j) {
-        tic += scan[j].getIntensity();
-      }
-      if (tic > maxTIC) {
-        maxTIC = tic;
-        best = i;
-      }
-      DataPoint[] m = scans.get(0);
-      scans.set(0, scans.get(best));
-      scans.set(best, m);
-    }
-    final DataPoint[] mergedSpectrum = scans.get(0).clone();
-    Arrays.sort(mergedSpectrum, CompareDataPointsByMz);
-    for (int i = 1; i < scans.size(); ++i) {
-      merge(mergedSpectrum, scans.get(i));
-    }
-    // remove noise
-    if (mergedSpectrum.length > 60) {
-      double lowestIntensity = Double.POSITIVE_INFINITY,
-          secondLowestIntensity = Double.POSITIVE_INFINITY;
-      for (int i = 0; i < mergedSpectrum.length; ++i) {
-        final double z = mergedSpectrum[i].getIntensity();
-        if (z < secondLowestIntensity) {
-          if (z < lowestIntensity) {
-            secondLowestIntensity = lowestIntensity;
-            lowestIntensity = z;
-          } else
-            secondLowestIntensity = z;
+    private final static String plNamePattern = "{}";
+    protected static final Comparator<DataPoint> CompareDataPointsByMz = new Comparator<DataPoint>() {
+        @Override
+        public int compare(DataPoint o1, DataPoint o2) {
+            return Double.compare(o1.getMZ(), o2.getMZ());
         }
-      }
-      double baseline = lowestIntensity + secondLowestIntensity;
-      int behindParent = Arrays.binarySearch(mergedSpectrum,
-          new SimpleDataPoint(parentPeak + 5, 0d), CompareDataPointsByMz);
-      if (behindParent < 0) {
-        behindParent = -(behindParent + 1);
-      }
-      final int noisePeaksBehindParentPeak = mergedSpectrum.length - behindParent;
-      if (noisePeaksBehindParentPeak >= 10) {
-        final DataPoint[] subspec = new DataPoint[noisePeaksBehindParentPeak];
-        System.arraycopy(mergedSpectrum, 0, subspec, 0, noisePeaksBehindParentPeak);
-        Arrays.sort(subspec, descendingIntensitySorter);
-        int q75 = (int) (subspec.length * 0.75);
-        baseline = Math.max(subspec[q75].getIntensity(), baseline);
-      }
-      final List<DataPoint> keep = new ArrayList<>();
-      for (int i = 0; i < mergedSpectrum.length; ++i) {
-        if (mergedSpectrum[i].getIntensity() > baseline)
-          keep.add(mergedSpectrum[i]);
-      }
-      return keep.toArray(new DataPoint[keep.size()]);
-    }
-    return mergedSpectrum;
-  }
-
-  private static void merge(DataPoint[] orderedByMz, DataPoint[] orderedByInt) {
-    // we assume a rather large deviation as signal peaks should be contained in more than one
-    // measurement
-    final List<DataPoint> append = new ArrayList<>();
-    final double absoluteDeviation = 0.005;
-    for (int k = 0; k < orderedByInt.length; ++k) {
-      final DataPoint peak = orderedByInt[k];
-      final double dev = Math.max(absoluteDeviation, peak.getMZ() * 10e-6);
-      final double lb = peak.getMZ() - dev, ub = peak.getMZ() + dev;
-      int mz1 = Arrays.binarySearch(orderedByMz, peak, CompareDataPointsByMz);
-      if (mz1 < 0) {
-        mz1 = -(mz1 + 1);
-      }
-      int mz0 = mz1 - 1;
-      while (mz1 < orderedByMz.length && orderedByMz[mz1].getMZ() <= ub)
-        ++mz1;
-      --mz1;
-      while (mz0 >= 0 && orderedByMz[mz0].getMZ() >= lb)
-        --mz0;
-      ++mz0;
-      if (mz0 <= mz1) {
-        // merge!
-        int mostIntensive = mz0;
-        double bestScore = Double.NEGATIVE_INFINITY;
-        for (int i = mz0; i <= mz1; ++i) {
-          final double massDiff = orderedByMz[i].getMZ() - peak.getMZ();
-          final double score =
-              Erf.erfc(3 * massDiff) / (dev * Math.sqrt(2)) * orderedByMz[i].getIntensity();
-          if (score > bestScore) {
-            bestScore = score;
-            mostIntensive = i;
-          }
+    };
+    protected static final Comparator<DataPoint> CompareDataPointsByDecreasingInt = new Comparator<DataPoint>() {
+        @Override
+        public int compare(DataPoint o1, DataPoint o2) {
+            return Double.compare(o2.getIntensity(), o1.getIntensity());
         }
-        final double mzValue =
-            peak.getIntensity() > orderedByMz[mostIntensive].getIntensity() ? peak.getMZ()
-                : orderedByMz[mostIntensive].getMZ();
-        orderedByMz[mostIntensive] = new SimpleDataPoint(mzValue,
-            peak.getIntensity() + orderedByMz[mostIntensive].getIntensity());
-      } else {
-        // append
-        append.add(peak);
-      }
+    };
+    private final PeakList[] peakLists;
+    private final File fileName;
+    // private final boolean fractionalMZ;
+    private final String massListName;
+    protected long finishedRows, totalRows;
+    protected final SiriusExportParameters.MERGE_MODE mergeMsMs;
+    protected double cosineThreshold;
+    protected double expectedPPM;
+
+    protected boolean mergeMasses;
+
+    protected Range<Double> isolationWindow;
+
+
+    public double getFinishedPercentage() {
+        return (totalRows == 0 ? 0.0 : (double) finishedRows / (double) totalRows);
     }
-    if (append.size() > 0) {
-      int offset = orderedByMz.length;
-      orderedByMz = Arrays.copyOf(orderedByMz, orderedByMz.length + append.size());
-      for (DataPoint p : append) {
-        orderedByMz[offset++] = p;
-      }
-      Arrays.sort(orderedByMz, CompareDataPointsByMz);
+
+    public String getTaskDescription() {
+        return "Exporting peak list(s) " + Arrays.toString(peakLists) + " to MGF file(s)";
     }
-  }
 
-  public void runSingleRow(PeakListRow row) {
-    setStatus(TaskStatus.PROCESSING);
-    try (final BufferedWriter bw = new BufferedWriter(new FileWriter(fileName, true))) {
-      exportPeakListRow(row, bw, getFragmentScans(row.getRawDataFiles()));
-    } catch (IOException e) {
-      setStatus(TaskStatus.ERROR);
-      setErrorMessage("Could not open file " + fileName + " for writing.");
+    SiriusExportTask(ParameterSet parameters) {
+        this.peakLists = parameters.getParameter(SiriusExportParameters.PEAK_LISTS).getValue()
+                .getMatchingPeakLists();
+
+        this.fileName = parameters.getParameter(SiriusExportParameters.FILENAME).getValue();
+
+        // this.fractionalMZ =
+        // parameters.getParameter(SiriusExportParameters.FRACTIONAL_MZ)
+        // .getValue();
+
+        this.massListName = parameters.getParameter(SiriusExportParameters.MASS_LIST).getValue();
+        this.mergeMsMs = parameters.getParameter(SiriusExportParameters.MERGE).getValue();
+
+        this.cosineThreshold = parameters.getParameter(SiriusExportParameters.COSINE_PARAMETER).getValue() / 100d;
+        this.expectedPPM = parameters.getParameter(SiriusExportParameters.MASS_ACCURACY).getValue();
+
+        this.mergeMasses = parameters.getParameter(SiriusExportParameters.AVERAGE_OVER_MASS).getValue();
+
+        double offset = parameters.getParameter(SiriusExportParameters.isolationWindowOffset).getValue();
+        double width = parameters.getParameter(SiriusExportParameters.isolationWindowWidth).getValue();
+        this.isolationWindow = Range.closed(offset - width, offset + width);
     }
-    if (getStatus() == TaskStatus.PROCESSING)
-      setStatus(TaskStatus.FINISHED);
-  }
 
+    public void run() {
+        setStatus(TaskStatus.PROCESSING);
 
-  public void runSingleRows(PeakListRow[] rows) {
-    setStatus(TaskStatus.PROCESSING);
-    try (final BufferedWriter bw = new BufferedWriter(new FileWriter(fileName, true))) {
-      for (PeakListRow row : rows)
-        exportPeakListRow(row, bw, getFragmentScans(row.getRawDataFiles()));
-    } catch (IOException e) {
-      setStatus(TaskStatus.ERROR);
-      setErrorMessage("Could not open file " + fileName + " for writing.");
-    }
-    if (getStatus() == TaskStatus.PROCESSING)
-      setStatus(TaskStatus.FINISHED);
-  }
+        // Shall export several files?
+        boolean substitute = fileName.getPath().contains(plNamePattern);
 
+        for (PeakList l : peakLists)
+            this.totalRows += l.getNumberOfRows();
 
-  private void exportPeakList(PeakList peakList, BufferedWriter writer) throws IOException {
+        // Process peak lists
+        for (PeakList peakList : peakLists) {
 
-    final HashMap<String, int[]> fragmentScans = getFragmentScans(peakList.getRawDataFiles());
-
-    for (PeakListRow row : peakList.getRows()) {
-      exportPeakListRow(row, writer, fragmentScans);
-      finishedRows++;
-    }
-  }
-
-  private HashMap<String, int[]> getFragmentScans(RawDataFile[] rawDataFiles) {
-    final HashMap<String, int[]> fragmentScans = new HashMap<>();
-    for (RawDataFile r : rawDataFiles) {
-      int[] scans = new int[0];
-      for (int msLevel : r.getMSLevels()) {
-        if (msLevel > 1) {
-          int[] concat = r.getScanNumbers(msLevel);
-          int offset = scans.length;
-          scans = Arrays.copyOf(scans, scans.length + concat.length);
-          System.arraycopy(concat, 0, scans, offset, concat.length);
-        }
-      }
-      Arrays.sort(scans);
-      fragmentScans.put(r.getName(), scans);
-    }
-    return fragmentScans;
-  }
-
-  private void exportPeakListRow(PeakListRow row, BufferedWriter writer,
-      final HashMap<String, int[]> fragmentScans) throws IOException {
-    if (isSkipRow(row))
-      return;
-    // get row charge and polarity
-    char polarity = 0;
-    for (Feature f : row.getPeaks()) {
-      char pol = f.getDataFile().getScan(f.getRepresentativeScanNumber()).getPolarity()
-          .asSingleChar().charAt(0);
-      if (pol != polarity && polarity != 0) {
-        setErrorMessage(
-            "Joined features have different polarity. This is most likely a bug. If not, please separate them as individual features and/or write a feature request on github.");
-        setStatus(TaskStatus.ERROR);
-        return;
-      } else {
-        polarity = pol;
-      }
-    }
-    // write correlation spectrum
-    writeHeader(writer, row, row.getBestPeak().getDataFile(), polarity, MsType.CORRELATED, -1);
-    writeCorrelationSpectrum(writer, row.getBestPeak());
-
-    List<DataPoint[]> toMerge = new ArrayList<>();
-    List<String> sources = new ArrayList<>();
-
-    // for each MS/MS write corresponding MS1 and MSMS spectrum
-    for (Feature f : row.getPeaks()) {
-      if (mergeMsMs == SiriusExportParameters.MERGE_MODE.MERGE_CONSECUTIVE_SCANS)
-        toMerge.clear();
-      if (f.getFeatureStatus() == Feature.FeatureStatus.DETECTED
-          && f.getMostIntenseFragmentScanNumber() >= 0) {
-        final int[] scanNumbers = f.getScanNumbers().clone();
-        Arrays.sort(scanNumbers);
-        int[] fs = fragmentScans.get(f.getDataFile().getName());
-        int startWith = scanNumbers[0];
-        int j = Arrays.binarySearch(fs, startWith);
-        if (j < 0)
-          j = (-j - 1);
-        for (int k = j; k < fs.length; ++k) {
-          final Scan scan = f.getDataFile().getScan(fs[k]);
-          if (scan.getMSLevel() > 1 && Math.abs(scan.getPrecursorMZ() - f.getMZ()) < 0.1) {
-            /*
-             * if (includeMs1) { // find precursor scan int prec = Arrays.binarySearch(scanNumbers,
-             * fs[k]); if (prec < 0) prec = -prec - 1; prec = Math.max(0, prec - 1); for (; prec <
-             * scanNumbers.length && scanNumbers[prec] < fs[k]; ++prec) { final Scan precursorScan =
-             * f.getDataFile().getScan(scanNumbers[prec]); if (precursorScan.getMSLevel() == 1) {
-             * writeHeader(writer, row, f.getDataFile(), polarity, MsType.MS,
-             * precursorScan.getScanNumber()); writeSpectrum(writer, massListName != null ?
-             * precursorScan.getMassList(massListName).getDataPoints() :
-             * precursorScan.getDataPoints()); } } }
-             */ // Do not include MS1 scans (except for isotope pattern)
-            final MassList massList = scan.getMassList(massListName);
-            if (massList == null) {
-              setStatus(TaskStatus.ERROR);
-              String msg = "Scan " + f.getDataFile().getName() + "#" + scan.getScanNumber()
-                  + " does not have a mass list named " + massListName;
-              setErrorMessage(msg);
-              return;
+            // Filename
+            File curFile = fileName;
+            if (substitute) {
+                // Cleanup from illegal filename characters
+                String cleanPlName = peakList.getName().replaceAll("[^a-zA-Z0-9.-]", "_");
+                // Substitute
+                String newFilename =
+                        fileName.getPath().replaceAll(Pattern.quote(plNamePattern), cleanPlName);
+                curFile = new File(newFilename);
             }
-            final DataPoint exportDataPoints[] = massList.getDataPoints();
 
-            // Skip empty mass lists
-            if (exportDataPoints.length == 0)
-              continue;
+            // Open file
+            try (final BufferedWriter bw = new BufferedWriter(new FileWriter(curFile, true))) {
+                exportPeakList(peakList, bw);
+            } catch (IOException e) {
+                setStatus(TaskStatus.ERROR);
+                setErrorMessage("Could not open file " + curFile + " for writing.");
+            }
 
-            if (mergeMsMs == SiriusExportParameters.MERGE_MODE.NO_MERGE) {
-              writeHeader(writer, row, f.getDataFile(), polarity, MsType.MSMS,
-                  scan.getScanNumber());
-              writeSpectrum(writer, exportDataPoints);
+            // If peak list substitution pattern wasn't found,
+            // treat one peak list only
+            if (!substitute)
+                break;
+        }
+
+        if (getStatus() == TaskStatus.PROCESSING)
+            setStatus(TaskStatus.FINISHED);
+    }
+
+    public void runSingleRow(PeakListRow row) {
+        setStatus(TaskStatus.PROCESSING);
+        try (final BufferedWriter bw = new BufferedWriter(new FileWriter(fileName, true))) {
+            exportPeakListRow(row, bw, getFragmentScansNumbers(row.getRawDataFiles()));
+        } catch (IOException e) {
+            setStatus(TaskStatus.ERROR);
+            setErrorMessage("Could not open file " + fileName + " for writing.");
+        }
+        if (getStatus() == TaskStatus.PROCESSING)
+            setStatus(TaskStatus.FINISHED);
+    }
+
+
+    public void runSingleRows(PeakListRow[] rows) {
+        setStatus(TaskStatus.PROCESSING);
+        try (final BufferedWriter bw = new BufferedWriter(new FileWriter(fileName, true))) {
+            for (PeakListRow row : rows)
+                exportPeakListRow(row, bw, getFragmentScansNumbers(row.getRawDataFiles()));
+        } catch (IOException e) {
+            setStatus(TaskStatus.ERROR);
+            setErrorMessage("Could not open file " + fileName + " for writing.");
+        }
+        if (getStatus() == TaskStatus.PROCESSING)
+            setStatus(TaskStatus.FINISHED);
+    }
+
+
+    private void exportPeakList(PeakList peakList, BufferedWriter writer) throws IOException {
+
+        final HashMap<String, int[]> fragmentScans = getFragmentScansNumbers(peakList.getRawDataFiles());
+
+        for (PeakListRow row : peakList.getRows()) {
+            exportPeakListRow(row, writer, fragmentScans);
+            finishedRows++;
+        }
+    }
+
+    private HashMap<String, int[]> getFragmentScansNumbers(RawDataFile[] rawDataFiles) {
+        final HashMap<String, int[]> fragmentScans = new HashMap<>();
+        for (RawDataFile r : rawDataFiles) {
+            int[] scans = new int[0];
+            for (int msLevel : r.getMSLevels()) {
+                if (msLevel > 1) {
+                    int[] concat = r.getScanNumbers(msLevel);
+                    int offset = scans.length;
+                    scans = Arrays.copyOf(scans, scans.length + concat.length);
+                    System.arraycopy(concat, 0, scans, offset, concat.length);
+                }
+            }
+            Arrays.sort(scans);
+            fragmentScans.put(r.getName(), scans);
+        }
+        return fragmentScans;
+    }
+
+    private void exportPeakListRow(PeakListRow row, BufferedWriter writer,
+                                   final HashMap<String, int[]> fragmentScans) throws IOException {
+        if (isSkipRow(row))
+            return;
+        // get row charge and polarity
+        char polarity = 0;
+        for (Feature f : row.getPeaks()) {
+            char pol = f.getDataFile().getScan(f.getRepresentativeScanNumber()).getPolarity()
+                    .asSingleChar().charAt(0);
+            if (pol != polarity && polarity != 0) {
+                setErrorMessage(
+                        "Joined features have different polarity. This is most likely a bug. If not, please separate them as individual features and/or write a feature request on github.");
+                setStatus(TaskStatus.ERROR);
+                return;
             } else {
-              if (mergeMsMs == SiriusExportParameters.MERGE_MODE.MERGE_OVER_SAMPLES)
-                sources.add(f.getDataFile().getName());
-              toMerge.add(exportDataPoints);
+                polarity = pol;
             }
-          }
         }
-        if (mergeMsMs == SiriusExportParameters.MERGE_MODE.MERGE_CONSECUTIVE_SCANS
-            && toMerge.size() > 0) {
-          writeHeader(writer, row, f.getDataFile(), polarity, MsType.MSMS, null);
-          writeSpectrum(writer, merge(f.getMZ(), toMerge));
+        // write correlation spectrum
+        writeHeader(writer, row, row.getBestPeak().getDataFile(), polarity, MsType.CORRELATED, -1);
+        writeCorrelationSpectrum(writer, row.getBestPeak());
+        final MergeUtils mergeUtils = new MergeUtils();
+        mergeUtils.setCosineThreshold(this.cosineThreshold);
+        mergeUtils.setExpectedPPM(this.expectedPPM);
+        mergeUtils.setIsolationWindow(this.isolationWindow);
+        mergeUtils.setMasslist(this.massListName);
+        mergeUtils.setMergeMasses(this.mergeMasses);
+
+
+        /*
+         * first we check if we have at least one good fragment scan per
+         */
+        final List<MergeUtils.FragmentScan> allFragmentScans = new ArrayList<>();
+        for (Feature f : row.getPeaks()) {
+            final List<MergeUtils.FragmentScan> scans = new ArrayList<>();
+            if (f.getFeatureStatus() == Feature.FeatureStatus.DETECTED
+                    && f.getMostIntenseFragmentScanNumber() >= 0) {
+
+                final TIntArrayList scanIds = new TIntArrayList(f.getScanNumbers());
+                scanIds.addAll(f.getAllMS2FragmentScanNumbers());
+                int[] fs = fragmentScans.get(f.getDataFile().getName());
+
+                int j = Arrays.binarySearch(fs, scanIds.get(0));
+                if (j < 0)
+                    j = (-j - 1);
+                for (int k=j; k < fs.length; ++k) {
+                    final Scan scan = f.getDataFile().getScan(fs[k]);
+                    if (scan.getRetentionTime() > f.getRawDataPointsRTRange().upperEndpoint())
+                        break;
+                    if (Math.abs(f.getDataFile().getScan(fs[k]).getPrecursorMZ() - f.getMZ()) < 0.1) {
+                        scanIds.add(fs[k]);
+                    }
+                }
+                scanIds.sort();
+                final TIntArrayList ms2Scans = new TIntArrayList();
+                int ms1ScanNumber = -1;
+
+                for (int scanId : scanIds.toArray()) {
+
+                    final Scan scan = f.getDataFile().getScan(scanId);
+                    if (scan.getMSLevel() == 1) {
+                        if (!ms2Scans.isEmpty())
+                            scans.add(new MergeUtils.FragmentScan(f.getDataFile(), row.getAverageMZ(), ms1ScanNumber, ms2Scans.toArray(), isolationWindow, expectedPPM));
+                        ms1ScanNumber = scan.getScanNumber();
+                        ms2Scans.clear();
+                    } else {
+                        ms2Scans.add(scan.getScanNumber());
+                    }
+                }
+                if (!ms2Scans.isEmpty()) {
+                    scans.add(new MergeUtils.FragmentScan(f.getDataFile(), row.getAverageMZ(), ms1ScanNumber, ms2Scans.toArray(), isolationWindow, expectedPPM));
+                }
+
+            }
+            if (mergeMsMs == SiriusExportParameters.MERGE_MODE.MERGE_CONSECUTIVE_SCANS) {
+                MergeUtils.MergedSpectrum dps = mergeUtils.mergeConsecutiveScans(f.getDataFile().getName() + ", m/z = " + f.getMZ() + ", rt = " + f.getRT(), f.getMZ(), scans);
+                if (dps!=null && dps.data.length>0) {
+                    writeHeader(writer, row, scans.get(0).origin, polarity, MsType.MSMS, dps);
+                    writeSpectrum(writer, dps.data);
+                }
+            } else if (mergeMsMs == SiriusExportParameters.MERGE_MODE.NO_MERGE) {
+                List<Integer> scanNumbers = new ArrayList<>();
+                final List<DataPoint[]> spectra = mergeUtils.extractHighQualityScans(f.getMZ(), scans, scanNumbers);
+                for (int k=0; k < spectra.size(); ++k) {
+                    writeHeader(writer, row, scans.get(0).origin, polarity, MsType.MSMS, scanNumbers.get(k)); // TODO: add scan number
+                    writeSpectrum(writer, spectra.get(k));
+                }
+            } else {
+                allFragmentScans.addAll(scans);
+            }
         }
-      }
-    }
-    if (mergeMsMs == SiriusExportParameters.MERGE_MODE.MERGE_OVER_SAMPLES && toMerge.size() > 0) {
-      writeHeader(writer, row, row.getBestPeak().getDataFile(), polarity, MsType.MSMS, null,
-          sources);
-      writeSpectrum(writer, merge(row.getAverageMZ(), toMerge));
-    }
-  }
 
-  private boolean isSkipRow(PeakListRow row) {
-    // skip rows which have no isotope pattern and no MS/MS spectrum
-    for (Feature f : row.getPeaks()) {
-      if (f.getFeatureStatus() == Feature.FeatureStatus.DETECTED) {
-        if ((f.getIsotopePattern() != null && f.getIsotopePattern().getDataPoints().length > 1)
-            || f.getMostIntenseFragmentScanNumber() >= 0)
-          return false;
-      }
+        if (mergeMsMs == SiriusExportParameters.MERGE_MODE.MERGE_OVER_SAMPLES ) {
+            MergeUtils.MergedSpectrum dps = mergeUtils.mergeScansFromDifferentOrigins("m/z = " + row.getAverageMZ() + ", retention time = " + row.getAverageRT(), row.getAverageMZ(), allFragmentScans);
+            if (dps.data.length > 0) {
+                writeHeader(writer, row, row.getBestPeak().getDataFile(), polarity, MsType.MSMS, dps);
+                writeSpectrum(writer, dps.data);
+            }
+        }
+
     }
-    return true;
-  }
 
-  private void writeHeader(BufferedWriter writer, PeakListRow row, RawDataFile raw, char polarity,
-      MsType msType, Integer scanNumber) throws IOException {
-    writeHeader(writer, row, raw, polarity, msType, scanNumber, null);
-  }
+    private boolean isSkipRow(PeakListRow row) {
+        // skip rows which have no isotope pattern and no MS/MS spectrum
+        for (Feature f : row.getPeaks()) {
+            if (f.getFeatureStatus() == Feature.FeatureStatus.DETECTED) {
+                if ((f.getIsotopePattern() != null && f.getIsotopePattern().getDataPoints().length > 1)
+                        || f.getMostIntenseFragmentScanNumber() >= 0)
+                    return false;
+            }
+        }
+        return true;
+    }
 
-  private void writeHeader(BufferedWriter writer, PeakListRow row, RawDataFile raw, char polarity,
-      MsType msType, Integer scanNumber, List<String> sources) throws IOException {
-    final Feature feature = row.getPeak(raw);
-    writer.write("BEGIN IONS");
-    writer.newLine();
-    writer.write("FEATURE_ID=");
-    writer.write(String.valueOf(row.getID()));
-    writer.newLine();
-    writer.write("PEPMASS=");
-    writer.write(String.valueOf(row.getBestPeak().getMZ()));
-    writer.newLine();
-    writer.write("CHARGE=");
-    if (polarity == '-')
-      writer.write("-");
-    writer.write(String.valueOf(Math.abs(row.getRowCharge())));
-    writer.newLine();
-    writer.write("RTINSECONDS=");
-    writer.write(String.valueOf(feature.getRT() * 60d));
-    writer.newLine();
-    switch (msType) {
-      case CORRELATED:
-        writer.write("SPECTYPE=CORRELATED MS");
+    private void writeHeader(BufferedWriter writer, PeakListRow row, RawDataFile raw, char polarity,
+                             MsType msType, MergeUtils.MergedSpectrum mergedSpectrum) throws IOException {
+        writeHeader(writer, row, raw, polarity, msType, row.getID(), Arrays.stream(mergedSpectrum.origins).map(RawDataFile::getName).collect(Collectors.toList()));
+        // add additional fields
+        writer.write("MERGED_SCANS=");
+        writer.write(String.valueOf(mergedSpectrum.scanIds[0]));
+        for (int k=1; k < mergedSpectrum.scanIds.length; ++k) {
+            writer.write(',');
+            writer.write(String.valueOf(mergedSpectrum.scanIds[k]));
+        }
         writer.newLine();
-      case MS:
-        writer.write("MSLEVEL=1");
-        writer.newLine();
-        break;
-      case MSMS:
-        writer.write("MSLEVEL=2");
+        writer.write("MERGED_STATS=");
+        writer.write(String.valueOf(mergedSpectrum.scanIds.length));
+        writer.write(" / ");
+        writer.write(String.valueOf(mergedSpectrum.totalNumberOfScans()));
+        writer.write(" (");
+        writer.write(String.valueOf(mergedSpectrum.removedScansByLowQuality));
+        writer.write(" removed due to low quality, ");
+        writer.write(String.valueOf(mergedSpectrum.removedScansByLowCosine));
+        writer.write(" removed due to low cosine).");
         writer.newLine();
     }
-    writer.write("FILENAME=");
-    if (sources != null) {
-      writer.write(escape(sources.get(0), ";"));
-      for (int i = 1; i < sources.size(); ++i) {
-        writer.write(";");
-        writer.write(escape(sources.get(i), ";"));
-      }
-      writer.newLine();
-    } else if (msType == MsType.CORRELATED) {
-      RawDataFile[] raws = row.getRawDataFiles();
-      writer.write(escape(raws[0].getName(), ";"));
-      for (int i = 1; i < raws.length; ++i) {
-        writer.write(";");
-        writer.write(escape(raws[i].getName(), ";"));
-      }
-      writer.newLine();
-    } else {
-      writer.write(feature.getDataFile().getName());
-      writer.newLine();
+
+    private void writeHeader(BufferedWriter writer, PeakListRow row, RawDataFile raw, char polarity,
+                             MsType msType, Integer scanNumber) throws IOException {
+        writeHeader(writer, row, raw, polarity, msType, scanNumber, null);
     }
-    if (scanNumber != null) {
-      writer.write("SCANS=");
-      writer.write(String.valueOf(scanNumber));
-      writer.newLine();
+
+    private void writeHeader(BufferedWriter writer, PeakListRow row, RawDataFile raw, char polarity,
+                             MsType msType, Integer scanNumber, List<String> sources) throws IOException {
+        final Feature feature = row.getPeak(raw);
+        writer.write("BEGIN IONS");
+        writer.newLine();
+        writer.write("FEATURE_ID=");
+        writer.write(String.valueOf(row.getID()));
+        writer.newLine();
+        writer.write("PEPMASS=");
+        writer.write(String.valueOf(row.getBestPeak().getMZ()));
+        writer.newLine();
+        writer.write("CHARGE=");
+        if (polarity == '-')
+            writer.write("-");
+        writer.write(String.valueOf(Math.abs(row.getRowCharge())));
+        writer.newLine();
+        writer.write("RTINSECONDS=");
+        writer.write(String.valueOf(feature.getRT() * 60d));
+        writer.newLine();
+        switch (msType) {
+            case CORRELATED:
+                writer.write("SPECTYPE=CORRELATED MS");
+                writer.newLine();
+            case MS:
+                writer.write("MSLEVEL=1");
+                writer.newLine();
+                break;
+            case MSMS:
+                writer.write("MSLEVEL=2");
+                writer.newLine();
+        }
+        writer.write("FILENAME=");
+        if (sources != null) {
+            final String[] uniqSources = new HashSet<>(sources).toArray(new String[0]);
+            writer.write(escape(uniqSources[0], ";"));
+            for (int i = 1; i < uniqSources.length; ++i) {
+                writer.write(";");
+                writer.write(escape(uniqSources[i], ";"));
+            }
+            writer.newLine();
+        } else if (msType == MsType.CORRELATED) {
+            RawDataFile[] raws = row.getRawDataFiles();
+            final Set<String> set = new HashSet<>();
+            for (RawDataFile f : raws) set.add(f.getName());
+            final String[] uniqSources = set.toArray(new String[0]);
+            writer.write(escape(uniqSources[0], ";"));
+            for (int i = 1; i < uniqSources.length; ++i) {
+                writer.write(";");
+                writer.write(escape(uniqSources[i], ";"));
+            }
+            writer.newLine();
+        } else {
+            writer.write(feature.getDataFile().getName());
+            writer.newLine();
+        }
+        if (scanNumber != null) {
+            writer.write("SCANS=");
+            writer.write(String.valueOf(scanNumber));
+            writer.newLine();
+        }
     }
-  }
 
-  private void writeCorrelationSpectrum(BufferedWriter writer, Feature feature) throws IOException {
-    if (feature.getIsotopePattern() != null) {
-      writeSpectrum(writer, feature.getIsotopePattern().getDataPoints());
-    } else {
-      // write nothing
-      writer.write(String.valueOf(feature.getMZ()));
-      writer.write(' ');
-      writer.write("100.0");
-      writer.newLine();
-      writer.write("END IONS");
-      writer.newLine();
-      writer.newLine();
+    private void writeCorrelationSpectrum(BufferedWriter writer, Feature feature) throws IOException {
+        if (feature.getIsotopePattern() != null) {
+            writeSpectrum(writer, feature.getIsotopePattern().getDataPoints());
+        } else {
+            // write nothing
+            writer.write(String.valueOf(feature.getMZ()));
+            writer.write(' ');
+            writer.write("100.0");
+            writer.newLine();
+            writer.write("END IONS");
+            writer.newLine();
+            writer.newLine();
+        }
     }
-  }
 
-  private void writeSpectrum(BufferedWriter writer, DataPoint[] dps) throws IOException {
-    for (DataPoint dp : dps) {
-      writer.write(String.valueOf(dp.getMZ()));
-      writer.write(' ');
-      writer.write(String.valueOf(dp.getIntensity()));
-      writer.newLine();
+    private void writeSpectrum(BufferedWriter writer, DataPoint[] dps) throws IOException {
+        for (DataPoint dp : dps) {
+            writer.write(String.valueOf(dp.getMZ()));
+            writer.write(' ');
+            writer.write(String.valueOf(dp.getIntensity()));
+            if (DEBUG_MODE && dp instanceof MergeUtils.MergeDataPoint) {
+                writer.write(' ');
+                writer.write('#');
+                writer.write(((MergeUtils.MergeDataPoint) dp).getComment());
+            }
+            writer.newLine();
 
+        }
+        writer.write("END IONS");
+        writer.newLine();
+        writer.newLine();
     }
-    writer.write("END IONS");
-    writer.newLine();
-    writer.newLine();
-  }
 
-  private String escape(String name, String s) {
-    return name.replaceAll(s, "\\" + s);
-  }
 
-  private static enum MsType {
-    MS, MSMS, CORRELATED
-  }
+    private String escape(String name, String s) {
+        return name.replaceAll(s, "\\" + s);
+    }
 
+    private static enum MsType {
+        MS, MSMS, CORRELATED
+    }
 
 
 }

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/siriusexport/help/help.html
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/siriusexport/help/help.html
@@ -43,8 +43,7 @@
     <ul>
         <li> Information about <a href="../../gnpsexport/help/help.html" target="_blank">GNPS export</a>
         <li> If you use the SIRIUS export module, cite <a href="https://bmcbioinformatics.biomedcentral.com/articles/10.1186/1471-2105-11-395">MZmine2 paper</a>
-             and the following articles: <a href="http://www.pnas.org/content/112/41/12580.abstract">Dührkop et al., Proc Natl Acad Sci USA 112(41):12580-12585</a> and 
-             <a href="https://jcheminf.springeropen.com/articles/10.1186/s13321-016-0116-8">Boecker et al., Journal of Cheminformatics (2016) 8:5</a>
+             and the following article: <a href="http://dx.doi.org/10.1038/s41592-019-0344-8"> K. Dührkop, et al. “Sirius 4: a rapid tool for turning tandem mass spectra into metabolite structure information”, Nat methods, 2019.</a>
         <li> Sirius can be downloaded at the following address: <a href="https://bio.informatik.uni-jena.de/software/sirius/">https://bio.informatik.uni-jena.de/software/sirius/</a>
         <li> Sirius results can be mapped into <a href="http://gnps.ucsd.edu/">GNPS</a> molecular networks. <a href="https://bix-lab.ucsd.edu/display/Public/Mass+spectrometry+data+pre-processing+for+GNPS">See the documentation</a> here.
     </ul>


### PR DESCRIPTION
Hi,
I start implementing a merge functionality for MS/MS spectra. The current implementation contains three different merge modes:
- no merge (export all scans)
- merge only scans within the same raw data file
- merge scans across all raw data files (belonging to the same feature row in an aligned feature table)

Furthermore, merging involves the following steps:
- start with the MS/MS scan which has the best precursor (= low chimeric intensity, high precursor intensity, high MSMS TIC)
- iteratively merge surrounding MS/MS IF there cosine similarity is above a user given threshold (this should help in cases you have chimeric contaminations in some of your MSMS)
- several cleaning, outlier removal steps, merging of intensities and masses

The pull request affects the GNPSExport as well as the SIRIUS export