### PR TITLE
Bugfix for #570

### DIFF
--- a/src/main/java/net/sf/mzmine/modules/masslistmethods/ADAPchromatogrambuilder/ADAPChromatogramBuilderTask.java
+++ b/src/main/java/net/sf/mzmine/modules/masslistmethods/ADAPchromatogrambuilder/ADAPChromatogramBuilderTask.java
@@ -258,7 +258,7 @@ public class ADAPChromatogramBuilderTask extends AbstractTask {
         return;
       }
 
-      if (mzPeak == null) {
+      if (mzPeak == null || Double.isNaN(mzPeak.getMZ()) || Double.isNaN(mzPeak.getIntensity())) {
         // System.out.println("null Peak");
         continue;
       }

--- a/src/main/java/net/sf/mzmine/modules/rawdatamethods/peakpicking/massdetection/exactmass/ExactMassDetector.java
+++ b/src/main/java/net/sf/mzmine/modules/rawdatamethods/peakpicking/massdetection/exactmass/ExactMassDetector.java
@@ -181,10 +181,16 @@ public class ExactMassDetector implements MassDetector {
         // We calculate the slope with formula m = Y1 - Y2 / X1 - X2
         double mLeft = (leftY1 - leftY2) / (leftX1 - leftX2);
 
-        // We calculate the desired point (at half intensity) with the
-        // linear equation
-        // X = X1 + [(Y - Y1) / m ], where Y = half of total intensity
-        xLeft = leftX1 + (((halfIntensity) - leftY1) / mLeft);
+        if (mLeft == 0.0) {
+          // If slope is zero, we calculate the desired point as the middle point
+          xLeft = (leftX1 + leftX2) / 2;
+        }
+        else {
+          // We calculate the desired point (at half intensity) with the
+          // linear equation
+          // X = X1 + [(Y - Y1) / m ], where Y = half of total intensity
+          xLeft = leftX1 + (((halfIntensity) - leftY1) / mLeft);
+        }
         continue;
       }
 
@@ -206,10 +212,16 @@ public class ExactMassDetector implements MassDetector {
         // We calculate the slope with formula m = Y1 - Y2 / X1 - X2
         double mRight = (rightY1 - rightY2) / (rightX1 - rightX2);
 
-        // We calculate the desired point (at half intensity) with the
-        // linear equation
-        // X = X1 + [(Y - Y1) / m ], where Y = half of total intensity
-        xRight = rightX1 + (((halfIntensity) - rightY1) / mRight);
+        if (mRight == 0.0) {
+          // If slope is zero, we calculate the desired point as the middle point
+          xRight = (rightX1 + rightX2) / 2;
+        }
+        else {
+          // We calculate the desired point (at half intensity) with the
+          // linear equation
+          // X = X1 + [(Y - Y1) / m ], where Y = half of total intensity
+          xRight = rightX1 + (((halfIntensity) - rightY1) / mRight);
+        }
         break;
       }
     }


### PR DESCRIPTION
Hi Tomas,

@glerny is right in his description of this bug:
> I believe it is more a problem with the mzML files (converted from TIF to mzML with MSConvert) before or after the MassDetection step (exact mass with a threshold at 1,000) as the same parameters work with other files. I assume the NaN values result from one of those two steps and this case is not taken into account by the ADAP algorithms. I just test it using a threshold at 10,000 for the MassDetection (exact mass with a threshold at 10,000) and in this case, the ADAP algorithms work, so I definitely believe that during the centroidisation some errors occur that generate NaN values that bugged the ADAP algorithms (the chromatogram builder work through).

I have added a check for NaN values in ADAPChromatogramBuilder.