### PR TITLE
Faster mass detection

### DIFF
--- a/src/main/java/net/sf/mzmine/modules/rawdatamethods/peakpicking/massdetection/MassDetectionTask.java
+++ b/src/main/java/net/sf/mzmine/modules/rawdatamethods/peakpicking/massdetection/MassDetectionTask.java
@@ -315,10 +315,14 @@ public class MassDetectionTask extends AbstractTask {
 
   }
 
+  /**
+   * Temporary hack to speed up mass detection with centroid module and not storing peaks on disc.
+   * This hack will be removed with the next MZMine module.
+   */
   public void runFast() {
     int indexOfPeriod = dataFile.getName().indexOf(".");
       setStatus(TaskStatus.PROCESSING);
-      logger.info("Started FAST mass detector on " + dataFile);
+      logger.info("Started mass detector on " + dataFile + ". Use the faster version of mass detection algorithm.");
 
       final Scan scans[] = scanSelection.getMatchingScans(dataFile);
       totalScans = scans.length;

--- a/src/main/java/net/sf/mzmine/modules/rawdatamethods/peakpicking/massdetection/centroid/CentroidMassDetector.java
+++ b/src/main/java/net/sf/mzmine/modules/rawdatamethods/peakpicking/massdetection/centroid/CentroidMassDetector.java
@@ -18,15 +18,19 @@
 
 package net.sf.mzmine.modules.rawdatamethods.peakpicking.massdetection.centroid;
 
-import java.util.ArrayList;
-
-import javax.annotation.Nonnull;
-
 import net.sf.mzmine.datamodel.DataPoint;
 import net.sf.mzmine.datamodel.Scan;
 import net.sf.mzmine.modules.rawdatamethods.peakpicking.massdetection.MassDetector;
 import net.sf.mzmine.parameters.ParameterSet;
 
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+
+/**
+ * Remove peaks below the given noise level.
+ * Note that the module is bypassed in the MassDetectionTask to speed up noise removal. Thus, changes within
+ * this module will have no effect in some cases. This is just a temporary hack to speed up noise removal in MZMine2.
+ */
 public class CentroidMassDetector implements MassDetector {
 
   public DataPoint[] getMassValues(Scan scan, ParameterSet parameters) {


### PR DESCRIPTION
Speed up Mass Detection (Centroid) with MZMine2 by bypassing the Centroid Mass Detector and remove low intense noise peaks directly.

This fix is intended to be a temporary solution until MZMine adopts the more efficient data model from MSDK.