### PR TITLE
Fix slow mass detection

### DIFF
--- a/src/main/java/net/sf/mzmine/datamodel/RawDataFile.java
+++ b/src/main/java/net/sf/mzmine/datamodel/RawDataFile.java
@@ -18,9 +18,11 @@
 
 package net.sf.mzmine.datamodel;
 
+import com.google.common.collect.Range;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import com.google.common.collect.Range;
+import java.util.List;
 
 public interface RawDataFile {
 
@@ -79,7 +81,7 @@ public interface RawDataFile {
 
   /**
    * Scan could be null if scanID is not contained in the raw data file
-   * 
+   *
    * @param scan Desired scan number
    * @return Desired scan
    */
@@ -105,5 +107,7 @@ public interface RawDataFile {
    * Close the file in case it is removed from the project
    */
   public void close();
+
+  public void notifyUpdatedMassLists(List<MassList> massList);
 
 }

--- a/src/main/java/net/sf/mzmine/datamodel/Scan.java
+++ b/src/main/java/net/sf/mzmine/datamodel/Scan.java
@@ -18,10 +18,10 @@
 
 package net.sf.mzmine.datamodel;
 
+import com.google.common.collect.Range;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-
-import com.google.common.collect.Range;
 
 /**
  * This class represent one spectrum of a raw data file.
@@ -94,5 +94,12 @@ public interface Scan extends MassSpectrum {
   public void addMassList(@Nonnull MassList massList);
 
   public void removeMassList(@Nonnull MassList massList);
+
+  /**
+    This will add a mass list, but won't trigger an update in the event queue.
+   You have to call RawDataFile#notifyUpdatedMassLists() to trigger the update afterwards
+   * @param massList
+   */
+  public MassList addMassListWithoutNotification(@Nonnull MassList massList);
 
 }

--- a/src/main/java/net/sf/mzmine/datamodel/impl/SimpleScan.java
+++ b/src/main/java/net/sf/mzmine/datamodel/impl/SimpleScan.java
@@ -18,20 +18,14 @@
 
 package net.sf.mzmine.datamodel.impl;
 
-import java.util.TreeSet;
-import java.util.Vector;
-
-import javax.annotation.Nonnull;
-
-import net.sf.mzmine.datamodel.DataPoint;
-import net.sf.mzmine.datamodel.MassList;
-import net.sf.mzmine.datamodel.MassSpectrumType;
-import net.sf.mzmine.datamodel.PolarityType;
-import net.sf.mzmine.datamodel.RawDataFile;
-import net.sf.mzmine.datamodel.Scan;
-import net.sf.mzmine.util.scans.ScanUtils;
 import com.google.common.collect.Range;
 import com.google.common.primitives.Ints;
+import net.sf.mzmine.datamodel.*;
+import net.sf.mzmine.util.scans.ScanUtils;
+
+import javax.annotation.Nonnull;
+import java.util.TreeSet;
+import java.util.Vector;
 
 /**
  * Simple implementation of the Scan interface.
@@ -311,6 +305,11 @@ public class SimpleScan implements Scan {
 
   @Override
   public synchronized void addMassList(@Nonnull MassList massList) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public MassList addMassListWithoutNotification(MassList massList) {
     throw new UnsupportedOperationException();
   }
 

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/mascot/data/PeptideScan.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/mascot/data/PeptideScan.java
@@ -18,23 +18,17 @@
 
 package net.sf.mzmine.modules.peaklistmethods.identification.mascot.data;
 
-import java.util.Arrays;
-import java.util.TreeSet;
-import java.util.Vector;
-
-import javax.annotation.Nonnull;
-
-import net.sf.mzmine.datamodel.DataPoint;
-import net.sf.mzmine.datamodel.MassList;
-import net.sf.mzmine.datamodel.MassSpectrumType;
-import net.sf.mzmine.datamodel.PolarityType;
-import net.sf.mzmine.datamodel.RawDataFile;
-import net.sf.mzmine.datamodel.Scan;
+import com.google.common.collect.Range;
+import com.google.common.primitives.Ints;
+import net.sf.mzmine.datamodel.*;
 import net.sf.mzmine.util.PeptideSorter;
 import net.sf.mzmine.util.SortingDirection;
 import net.sf.mzmine.util.scans.ScanUtils;
-import com.google.common.collect.Range;
-import com.google.common.primitives.Ints;
+
+import javax.annotation.Nonnull;
+import java.util.Arrays;
+import java.util.TreeSet;
+import java.util.Vector;
 
 public class PeptideScan implements Scan {
 
@@ -384,6 +378,11 @@ public class PeptideScan implements Scan {
   @Override
   public MassList getMassList(@Nonnull String name) {
     // TODO Auto-generated method stub
+    return null;
+  }
+
+  @Override
+  public MassList addMassListWithoutNotification(MassList massList) {
     return null;
   }
 

--- a/src/main/java/net/sf/mzmine/modules/rawdatamethods/peakpicking/massdetection/MassDetectionTask.java
+++ b/src/main/java/net/sf/mzmine/modules/rawdatamethods/peakpicking/massdetection/MassDetectionTask.java
@@ -19,15 +19,13 @@
 package net.sf.mzmine.modules.rawdatamethods.peakpicking.massdetection;
 
 import net.sf.mzmine.datamodel.DataPoint;
+import net.sf.mzmine.datamodel.MassList;
 import net.sf.mzmine.datamodel.RawDataFile;
 import net.sf.mzmine.datamodel.Scan;
 import net.sf.mzmine.datamodel.impl.SimpleMassList;
 import net.sf.mzmine.modules.MZmineProcessingStep;
-import net.sf.mzmine.modules.rawdatamethods.peakpicking.massdetection.centroid.CentroidMassDetector;
-import net.sf.mzmine.modules.rawdatamethods.peakpicking.massdetection.centroid.CentroidMassDetectorParameters;
 import net.sf.mzmine.parameters.ParameterSet;
 import net.sf.mzmine.parameters.parametertypes.selectors.ScanSelection;
-import net.sf.mzmine.project.impl.StorableScan;
 import net.sf.mzmine.taskcontrol.AbstractTask;
 import net.sf.mzmine.taskcontrol.TaskStatus;
 import ucar.ma2.ArrayDouble;
@@ -40,10 +38,7 @@ import ucar.nc2.Variable;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.FloatBuffer;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Logger;
 
@@ -117,15 +112,6 @@ public class MassDetectionTask extends AbstractTask {
    * @see Runnable#run()
    */
   public void run() {
-    if (!(massDetector.getModule() instanceof CentroidMassDetector) || this.saveToCDF) {
-      runSlow();
-    } else {
-      runFast();
-    }
-  }
-
-
-  public void runSlow() {
     int indexOfPeriod = dataFile.getName().indexOf(".");
 
     // String massOutLocation =
@@ -160,7 +146,7 @@ public class MassDetectionTask extends AbstractTask {
 
       final Scan scans[] = scanSelection.getMatchingScans(dataFile);
       totalScans = scans.length;
-
+      final List<MassList> massLists = new ArrayList<>();
       // Process scans one by one
       for (Scan scan : scans) {
 
@@ -173,28 +159,31 @@ public class MassDetectionTask extends AbstractTask {
         SimpleMassList newMassList = new SimpleMassList(name, scan, mzPeaks);
 
         // Add new mass list to the scan
-        scan.addMassList(newMassList);
+        massLists.add(scan.addMassListWithoutNotification(newMassList));
 
-        curTotalIntensity = 0;
-        for (int a = 0; a < mzPeaks.length; a++) {
-          DataPoint curMzPeak = mzPeaks[a];
-          allMZ.add(curMzPeak.getMZ());
-          allIntensities.add(curMzPeak.getIntensity());
+        if (this.saveToCDF) {
 
-          curTotalIntensity += curMzPeak.getIntensity();
+          curTotalIntensity = 0;
+          for (int a = 0; a < mzPeaks.length; a++) {
+            DataPoint curMzPeak = mzPeaks[a];
+            allMZ.add(curMzPeak.getMZ());
+            allIntensities.add(curMzPeak.getIntensity());
+
+            curTotalIntensity += curMzPeak.getIntensity();
+          }
+
+          scanAcquisitionTime.add(scan.getRetentionTime());
+          pointsInScans.add(0);
+          startIndex.add(mzPeaks.length + lastPointCount);
+          totalIntensity.add(curTotalIntensity);
+
+
+          lastPointCount = mzPeaks.length + lastPointCount;
         }
-
-        scanAcquisitionTime.add(scan.getRetentionTime());
-        pointsInScans.add(0);
-        startIndex.add(mzPeaks.length + lastPointCount);
-        totalIntensity.add(curTotalIntensity);
-
-
-        lastPointCount = mzPeaks.length + lastPointCount;
 
         processedScans++;
       }
-
+      dataFile.notifyUpdatedMassLists(massLists);
       setStatus(TaskStatus.FINISHED);
 
       logger.info("Finished mass detector on " + dataFile);
@@ -313,47 +302,5 @@ public class MassDetectionTask extends AbstractTask {
       }
     }
 
-  }
-
-  /**
-   * Temporary hack to speed up mass detection with centroid module and not storing peaks on disc.
-   * This hack will be removed with the next MZMine module.
-   */
-  public void runFast() {
-    int indexOfPeriod = dataFile.getName().indexOf(".");
-      setStatus(TaskStatus.PROCESSING);
-      logger.info("Started mass detector on " + dataFile + ". Use the faster version of mass detection algorithm.");
-
-      final Scan scans[] = scanSelection.getMatchingScans(dataFile);
-      totalScans = scans.length;
-      final double noiseLevel = massDetector.getParameterSet().getParameter(CentroidMassDetectorParameters.noiseLevel).getValue();
-      // Process scans one by one
-      for (Scan scan : scans) {
-        if (scan instanceof StorableScan) {
-          FloatBuffer floatBuffer = ((StorableScan) scan).readDataPointsAsFloatBuffer();
-          final ByteBuffer buffer = ByteBuffer.allocate(floatBuffer.limit()*4);
-          while (floatBuffer.hasRemaining()) {
-            float mz = floatBuffer.get();
-            float intens = floatBuffer.get();
-            if (intens >= noiseLevel) {
-              buffer.putFloat(mz);
-              buffer.putFloat(intens);
-            }
-          }
-          buffer.flip();
-          ((StorableScan) scan).addMassList(name, buffer);
-        } else {
-          scan.addMassList(new SimpleMassList(name, scan, Arrays.stream(scan.getDataPoints()).filter(x -> x.getIntensity() >= noiseLevel).toArray(DataPoint[]::new)));
-        }
-
-
-        if (isCanceled())
-          return;
-        processedScans++;
-      }
-
-      setStatus(TaskStatus.FINISHED);
-
-      logger.info("Finished mass detector on " + dataFile);
   }
 }

--- a/src/main/java/net/sf/mzmine/modules/rawdatamethods/peakpicking/massdetection/MassDetectionTask.java
+++ b/src/main/java/net/sf/mzmine/modules/rawdatamethods/peakpicking/massdetection/MassDetectionTask.java
@@ -340,7 +340,7 @@ public class MassDetectionTask extends AbstractTask {
               buffer.putFloat(intens);
             }
           }
-          buffer.rewind();
+          buffer.flip();
           ((StorableScan) scan).addMassList(name, buffer);
         } else {
           scan.addMassList(new SimpleMassList(name, scan, Arrays.stream(scan.getDataPoints()).filter(x -> x.getIntensity() >= noiseLevel).toArray(DataPoint[]::new)));

--- a/src/main/java/net/sf/mzmine/project/impl/RawDataFileImpl.java
+++ b/src/main/java/net/sf/mzmine/project/impl/RawDataFileImpl.java
@@ -397,7 +397,7 @@ public class RawDataFileImpl implements RawDataFile, RawDataFileWriter {
 
     dataPointsFile.seek(currentOffset);
     dataPointsFile.read(buffer.array(), 0, numOfBytes);
-
+    buffer.limit(numOfBytes);
     FloatBuffer floatBuffer = buffer.asFloatBuffer();
     return floatBuffer;
   }

--- a/src/main/java/net/sf/mzmine/project/impl/RawDataFileImpl.java
+++ b/src/main/java/net/sf/mzmine/project/impl/RawDataFileImpl.java
@@ -351,58 +351,6 @@ public class RawDataFileImpl implements RawDataFile, RawDataFileWriter {
 
   }
 
-
-  public synchronized int storeDataPoints(ByteBuffer peakBuffer) throws IOException {
-
-    if (dataPointsFile == null) {
-      File newFile = RawDataFileImpl.createNewDataPointsFile();
-      openDataPointsFile(newFile);
-    }
-
-    final long currentOffset = dataPointsFile.length();
-
-    final int currentID;
-    if (!dataPointsOffsets.isEmpty())
-      currentID = dataPointsOffsets.lastKey() + 1;
-    else
-      currentID = 1;
-    final int ndatapoints = peakBuffer.limit()/8;
-    dataPointsFile.seek(currentOffset);
-    dataPointsFile.write(peakBuffer.array(), 0, peakBuffer.limit());
-
-    dataPointsOffsets.put(currentID, currentOffset);
-    dataPointsLengths.put(currentID, ndatapoints);
-
-    return currentID;
-
-  }
-
-
-  public synchronized FloatBuffer readDataPointsAsFloatBuffer(int ID) throws IOException {
-
-    final Long currentOffset = dataPointsOffsets.get(ID);
-    final Integer numOfDataPoints = dataPointsLengths.get(ID);
-
-    if ((currentOffset == null) || (numOfDataPoints == null)) {
-      throw new IllegalArgumentException("Unknown storage ID " + ID);
-    }
-
-    final int numOfBytes = numOfDataPoints * 2 * 4;
-
-    if (buffer.capacity() < numOfBytes) {
-      buffer = ByteBuffer.allocate(numOfBytes * 2);
-    } else {
-      buffer.clear();
-    }
-
-    dataPointsFile.seek(currentOffset);
-    dataPointsFile.read(buffer.array(), 0, numOfBytes);
-    buffer.limit(numOfBytes);
-    FloatBuffer floatBuffer = buffer.asFloatBuffer();
-    return floatBuffer;
-  }
-
-
   public synchronized DataPoint[] readDataPoints(int ID) throws IOException {
 
     final Long currentOffset = dataPointsOffsets.get(ID);

--- a/src/main/java/net/sf/mzmine/project/impl/StorableScan.java
+++ b/src/main/java/net/sf/mzmine/project/impl/StorableScan.java
@@ -352,30 +352,7 @@ public class StorableScan implements Scan {
 
   @Override
   public synchronized void addMassList(final @Nonnull MassList massList) {
-
-    // Remove all mass lists with same name, if there are any
-    MassList currentMassLists[] = massLists.toArray(new MassList[0]);
-    for (MassList ml : currentMassLists) {
-      if (ml.getName().equals(massList.getName()))
-        removeMassList(ml);
-    }
-
-    StorableMassList storedMassList;
-    if (massList instanceof StorableMassList) {
-      storedMassList = (StorableMassList) massList;
-    } else {
-      DataPoint massListDataPoints[] = massList.getDataPoints();
-      try {
-        int mlStorageID = rawDataFile.storeDataPoints(massListDataPoints);
-        storedMassList = new StorableMassList(rawDataFile, mlStorageID, massList.getName(), this);
-      } catch (IOException e) {
-        logger.severe("Could not write data to temporary file " + e.toString());
-        return;
-      }
-    }
-
-    // Add the new mass list
-    massLists.add(storedMassList);
+    MassList storedMassList = addMassListWithoutNotification(massList);
 
     // Add the mass list to the tree model
     MZmineProjectImpl project =
@@ -433,6 +410,35 @@ public class StorableScan implements Scan {
 
     }
 
+  }
+
+  @Override
+  public MassList addMassListWithoutNotification(@Nonnull MassList massList) {
+    // Remove all mass lists with same name, if there are any
+    MassList currentMassLists[] = massLists.toArray(new MassList[0]);
+    for (MassList ml : currentMassLists) {
+      if (ml.getName().equals(massList.getName()))
+        removeMassList(ml);
+    }
+
+    StorableMassList storedMassList;
+    if (massList instanceof StorableMassList) {
+      storedMassList = (StorableMassList) massList;
+    } else {
+      DataPoint massListDataPoints[] = massList.getDataPoints();
+      try {
+        int mlStorageID = rawDataFile.storeDataPoints(massListDataPoints);
+        storedMassList = new StorableMassList(rawDataFile, mlStorageID, massList.getName(), this);
+      } catch (IOException e) {
+        logger.severe("Could not write data to temporary file " + e.toString());
+        return null;
+      }
+    }
+
+    // Add the new mass list
+    massLists.add(storedMassList);
+
+    return storedMassList;
   }
 
   @Override

--- a/src/main/java/net/sf/mzmine/project/impl/StorableScan.java
+++ b/src/main/java/net/sf/mzmine/project/impl/StorableScan.java
@@ -27,7 +27,6 @@ import net.sf.mzmine.util.scans.ScanUtils;
 import javax.annotation.Nonnull;
 import javax.swing.*;
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -308,46 +307,6 @@ public class StorableScan implements Scan {
   @Override
   public String toString() {
     return ScanUtils.scanToString(this, false);
-  }
-
-
-  public synchronized void addMassList(final String massListName, ByteBuffer buffer) {
-    try {
-      int id = rawDataFile.storeDataPoints(buffer);
-      StorableMassList storedMassList = new StorableMassList(rawDataFile, id, massListName, this);
-
-      // Add the new mass list
-      massLists.add(storedMassList);
-
-      // Add the mass list to the tree model
-      MZmineProjectImpl project =
-              (MZmineProjectImpl) MZmineCore.getProjectManager().getCurrentProject();
-
-      // Check if we are adding to the current project
-      if (Arrays.asList(project.getDataFiles()).contains(rawDataFile)) {
-        final RawDataTreeModel treeModel = project.getRawDataTreeModel();
-        final MassList newMassList = storedMassList;
-        Runnable swingCode = new Runnable() {
-          @Override
-          public void run() {
-            treeModel.addObject(newMassList);
-          }
-        };
-
-        try {
-          if (SwingUtilities.isEventDispatchThread())
-            swingCode.run();
-          else
-            SwingUtilities.invokeAndWait(swingCode);
-        } catch (Exception e) {
-          e.printStackTrace();
-        }
-
-      }
-    } catch (IOException e) {
-      logger.severe("Could not write data to temporary file " + e.toString());
-      return;
-    }
   }
 
   @Override


### PR DESCRIPTION
Hi,

can you roll back my last pull request about the faster mass detection?

I found out that the DataPoint structure is not the problem. In fact, when parsing the MzXML file, all spectra are converted into this format anyways. 

The real problem is that you add a new SWING event to the event queue every time you add a new mass list (which is done for every spectrum). So if you have ten thousands of spectra in a file, MZmine is busy for hours just updating the event queue.

I add a new fix which just delays the update until all scans of a raw data file are processed. The advantage of this fix: it does not introduce any strange hack. It has only very small changes in the core API. It is much cleaner than before. And it is super fast - reducing the time for mass detection from hours to seconds.