### PR TITLE
Fix nio.buffer.clear for jdk>8

### DIFF
--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/spectraldbsearch/LocalSpectralDBSearchModule.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/spectraldbsearch/LocalSpectralDBSearchModule.java
@@ -30,9 +30,9 @@ import net.sf.mzmine.util.ExitCode;
 
 public class LocalSpectralDBSearchModule implements MZmineProcessingModule {
 
-  public static final String MODULE_NAME = "Local MS/MS database search (JSON)";
+  public static final String MODULE_NAME = "Local MS/MS database search";
   private static final String MODULE_DESCRIPTION =
-      "This method searches all peaklist rows with a fragmentation scan against a local MS/MS spectral database.";
+      "This method searches all peaklist rows with a fragmentation scan against a local MS/MS spectral database and supports different DB file formats, e.g., NIST .msp, MoNA .json, GNPS .json, ...).";
 
   @Override
   public @Nonnull String getName() {
@@ -49,8 +49,8 @@ public class LocalSpectralDBSearchModule implements MZmineProcessingModule {
   public ExitCode runModule(@Nonnull MZmineProject project, @Nonnull ParameterSet parameters,
       @Nonnull Collection<Task> tasks) {
 
-    PeakList peakLists[] = parameters.getParameter(LocalSpectralDBSearchParameters.peakLists).getValue()
-        .getMatchingPeakLists();
+    PeakList peakLists[] = parameters.getParameter(LocalSpectralDBSearchParameters.peakLists)
+        .getValue().getMatchingPeakLists();
 
     for (PeakList peakList : peakLists) {
       Task newTask = new LocalSpectralDBSearchTask(peakList, parameters);

--- a/src/main/java/net/sf/mzmine/project/impl/RawDataFileImpl.java
+++ b/src/main/java/net/sf/mzmine/project/impl/RawDataFileImpl.java
@@ -21,6 +21,7 @@ package net.sf.mzmine.project.impl;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
 import java.nio.channels.FileChannel;
@@ -34,13 +35,10 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-
 import com.google.common.collect.Range;
 import com.google.common.primitives.Ints;
-
 import net.sf.mzmine.datamodel.DataPoint;
 import net.sf.mzmine.datamodel.MassList;
 import net.sf.mzmine.datamodel.RawDataFile;
@@ -346,7 +344,9 @@ public class RawDataFileImpl implements RawDataFile, RawDataFileWriter {
     if (buffer.capacity() < numOfBytes) {
       buffer = ByteBuffer.allocate(numOfBytes * 2);
     } else {
-      buffer.clear();
+      // JDK 9 breaks compatibility with JRE8: need to cast
+      // https://stackoverflow.com/questions/48693695/java-nio-buffer-not-loading-clear-method-on-runtime
+      ((Buffer) buffer).clear();
     }
 
     FloatBuffer floatBuffer = buffer.asFloatBuffer();
@@ -379,7 +379,9 @@ public class RawDataFileImpl implements RawDataFile, RawDataFileWriter {
     if (buffer.capacity() < numOfBytes) {
       buffer = ByteBuffer.allocate(numOfBytes * 2);
     } else {
-      buffer.clear();
+      // JDK 9 breaks compatibility with JRE8: need to cast
+      // https://stackoverflow.com/questions/48693695/java-nio-buffer-not-loading-clear-method-on-runtime
+      ((Buffer) buffer).clear();
     }
 
     dataPointsFile.seek(currentOffset);


### PR DESCRIPTION
Hey Tomas,

I have fixed this error before but I have added some comments this time. It got changed back in the last PR of Kai. 

When building with jdk>8 and running with JRE8 buffer.clear will throw a NoSuchMethodException. The fix is tested.

The other change is just a renaming of the MS/MS database search.

Cheers
Robin