### PR TITLE
Peaklist spectra matching

### DIFF
--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/spectraldbsearch/LocalSpectralDBSearchModule.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/spectraldbsearch/LocalSpectralDBSearchModule.java
@@ -30,9 +30,9 @@ import net.sf.mzmine.util.ExitCode;
 
 public class LocalSpectralDBSearchModule implements MZmineProcessingModule {
 
-  public static final String MODULE_NAME = "Local MS/MS database search (JSON)";
+  public static final String MODULE_NAME = "Spectra database search";
   private static final String MODULE_DESCRIPTION =
-      "This method searches all peaklist rows with a fragmentation scan against a local MS/MS spectral database.";
+      "This method searches all peaklist rows against a local spectral database.";
 
   @Override
   public @Nonnull String getName() {
@@ -49,8 +49,8 @@ public class LocalSpectralDBSearchModule implements MZmineProcessingModule {
   public ExitCode runModule(@Nonnull MZmineProject project, @Nonnull ParameterSet parameters,
       @Nonnull Collection<Task> tasks) {
 
-    PeakList peakLists[] = parameters.getParameter(LocalSpectralDBSearchParameters.peakLists).getValue()
-        .getMatchingPeakLists();
+    PeakList peakLists[] = parameters.getParameter(LocalSpectralDBSearchParameters.peakLists)
+        .getValue().getMatchingPeakLists();
 
     for (PeakList peakList : peakLists) {
       Task newTask = new LocalSpectralDBSearchTask(peakList, parameters);

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/spectraldbsearch/LocalSpectralDBSearchParameters.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/spectraldbsearch/LocalSpectralDBSearchParameters.java
@@ -39,33 +39,35 @@ public class LocalSpectralDBSearchParameters extends SimpleParameterSet {
   public static final PeakListsParameter peakLists = new PeakListsParameter();
 
   public static final FileNameParameter dataBaseFile = new FileNameParameter("Database file",
-      "(GNPS json, MONA json, NIST msp) Name of file that contains information for peak identification");
+      "(GNPS json, MONA json, NIST msp, JCAMP-DX jdx) Name of file that contains information for peak identification");
+
+  public static final IntegerParameter msLevel = new IntegerParameter("MS level",
+      "Choose the MS level of the scans that should be compared with the database. Enter \"1\" for MS1 scans or \"2\" for MS/MS scans on MS level 2");
 
   public static final MassListParameter massList =
-      new MassListParameter("MassList (MS2)", "MassList for MS/MS scans to match");
+      new MassListParameter("MassList", "MassList for either MS1 or MS/MS scans to match");
 
   public static final OptionalParameter<RTToleranceParameter> rtTolerance =
       new OptionalParameter<>(new RTToleranceParameter());
 
   public static final MZToleranceParameter mzTolerance = new MZToleranceParameter();
 
-  public static final DoubleParameter noiseLevelMS2 =
-      new DoubleParameter("Minimum MS2 ion intensity",
-          "Signals below this level will be filtered away from MS2 mass lists",
-          MZmineCore.getConfiguration().getIntensityFormat(), 0d);
+  public static final DoubleParameter noiseLevel = new DoubleParameter("Minimum ion intensity",
+      "Signals below this level will be filtered away from mass lists",
+      MZmineCore.getConfiguration().getIntensityFormat(), 0d);
 
   public static final DoubleParameter minCosine = new DoubleParameter("Minimum  cos similarity",
-      "Minimum cosine similarity. (All MS2 signals in the masslist against the spectral library entry. "
+      "Minimum cosine similarity. (All signals in the masslist against the spectral library entry. "
           + "Considers only signals which were found in both the masslist and the library entry)",
       new DecimalFormat("0.000"), 0.7);
 
   public static final IntegerParameter minMatch = new IntegerParameter("Minimum  matched signals",
-      "Minimum number of matched signals in MS2 masslist and spectral library entry (within mz tolerance)",
+      "Minimum number of matched signals in masslist and spectral library entry (within mz tolerance)",
       4);
 
   public LocalSpectralDBSearchParameters() {
-    super(new Parameter[] {peakLists, massList, dataBaseFile, mzTolerance, rtTolerance,
-        noiseLevelMS2, minCosine, minMatch});
+    super(new Parameter[] {peakLists, massList, dataBaseFile, msLevel, mzTolerance, rtTolerance,
+        noiseLevel, minCosine, minMatch});
   }
 
 }

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/spectraldbsearch/help/help.html
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/spectraldbsearch/help/help.html
@@ -11,27 +11,32 @@
 
 <h2>Description</h2>
 <p>
-Run on any feature list to match all rows agains a local spectral library (formats: MoNA json, NIST msp, GNPS json (internal library submission format)).
+Run on any feature list to match all rows against a local spectral library (formats: MoNA json, NIST msp, GNPS json (internal library submission format), JCAMP-DX jdx).
 </p>
 
 
 <h4>Method parameters</h4>
 <dl>
+<dt>Peaklist</dt>
+	<dd>Select any peaklist</dd>
 <dt>Masslist</dt>
-	<dd>Masslist of the MS2 scans</dd>
+	<dd>Masslist of scans</dd>
 <dt>Spectral database file</dt>
 	<dd>json/msp from MoNA (MassBank of North America)</dd>
 	<dd>msp NIST format</dd>
-	<dd>json GNPS (format from the spectral DB submission module)</dd>
+	<dd>JCAMP-DX jdx</dd>
+<dd>json GNPS (format from the spectral DB submission module)</dd>
+	<dt>MS level</dt>
+	<dd>Set MS level to "1" to compare MS1 spectra (e.g. GC-EI-MS data) or set it to "2" or higher for MS/MS scans</dd>
 <dt>Retention time tolerance</dt>
 	<dd>Optional: Only used if the DB entry has a retention time</dd>
 <dt>Noise level</dt>
-	<dd>An additional noise level for MS2 masslists (masslists are typically already thresholded)</dd>
+	<dd>An additional noise level for masslists (masslists are typically already thresholded)</dd>
 <dt>Min cos similarity</dt>
 	<dd>Minimum cosine similarity between fragmentation scan and spectral DB entry. Considers only 
 	signals which were found in both spectra.</dd>
 <dt>Minimum matched signals</dt>
-	<dd>Minimum number of signals within m/z tolerance in an MS2 masslist and the spectral library entry</dd>
+	<dd>Minimum number of signals within m/z tolerance in a masslist and the spectral library entry</dd>
 <dt></dt>
 	<dd></dd>
 </dl>

--- a/src/main/java/net/sf/mzmine/util/spectraldb/entry/SpectralDBPeakIdentity.java
+++ b/src/main/java/net/sf/mzmine/util/spectraldb/entry/SpectralDBPeakIdentity.java
@@ -33,10 +33,11 @@ public class SpectralDBPeakIdentity extends SimplePeakIdentity {
       String method) {
     super(
         MessageFormat.format("{0} as {3} ({1}) {2} cos={4}",
-            entry.getField(DBEntryField.NAME).orElse("NONAME"), entry.getPrecursorMZ(),
-            entry.getField(DBEntryField.FORMULA).orElse(""),
-            entry.getField(DBEntryField.IONTYPE).orElse("N/A"),
-            COS_FORM.format(similarity.getCosine())),
+            entry.getField(DBEntryField.NAME).orElse("NONAME"), // Name
+            entry.getField(DBEntryField.MZ).orElse(""), // precursor m/z
+            entry.getField(DBEntryField.FORMULA).orElse(""), // molevular formula
+            entry.getField(DBEntryField.IONTYPE).orElse(""), // Ion type
+            COS_FORM.format(similarity.getCosine())), // cosine similarity
         entry.getField(DBEntryField.FORMULA).orElse("").toString(), method, "", "");
     this.entry = entry;
     this.similarity = similarity;


### PR DESCRIPTION
Hi Tomas,
I made some small changes to the MS/MS spectra matching module for peaklists. I have implemented an MS level parameter. Now the module can be used for MS1 scans as well (GC-EI-MS).
@robinschmid pls check if I have cracked your module with this change. Also pls check if I have again changed the rawDataImpl file you have changed earlier. I had a liitle GitHub trouble today :-P