### PR TITLE
Removed error from msp parser

### DIFF
--- a/src/main/java/net/sf/mzmine/util/spectraldb/parser/NistMspParser.java
+++ b/src/main/java/net/sf/mzmine/util/spectraldb/parser/NistMspParser.java
@@ -91,7 +91,7 @@ public class NistMspParser extends SpectralDBParser {
               }
             }
           }
-          if (isData) {
+          if (l.isEmpty()) {
             // empty row after data
             // add entry and reset
             SpectralDBEntry entry =


### PR DESCRIPTION
Hi Tomas,
I found a bug in the msp DB parser. The parser was handling every data point pair as a DB Entry. Now every is fine again.
best wishes