### PR TITLE
Spectral matching

### DIFF
--- a/src/main/java/net/sf/mzmine/main/MZmineModulesList.java
+++ b/src/main/java/net/sf/mzmine/main/MZmineModulesList.java
@@ -119,6 +119,7 @@ import net.sf.mzmine.modules.visualization.productionfilter.ProductIonFilterVisu
 import net.sf.mzmine.modules.visualization.scatterplot.ScatterPlotVisualizerModule;
 import net.sf.mzmine.modules.visualization.spectra.msms.MsMsVisualizerModule;
 import net.sf.mzmine.modules.visualization.spectra.simplespectra.SpectraVisualizerModule;
+import net.sf.mzmine.modules.visualization.spectra.simplespectra.spectraidentification.spectraldatabase.SpectraIdentificationSpectralDatabaseModule;
 import net.sf.mzmine.modules.visualization.threed.ThreeDVisualizerModule;
 import net.sf.mzmine.modules.visualization.tic.TICVisualizerModule;
 import net.sf.mzmine.modules.visualization.twod.TwoDVisualizerModule;
@@ -132,7 +133,6 @@ public class MZmineModulesList {
   public static final Class<?> MODULES[] = new Class<?>[] {
 
       // Project methods
-
       ProjectLoadModule.class, ProjectSaveModule.class, ProjectSaveAsModule.class,
       ProjectCloseModule.class,
 
@@ -202,7 +202,10 @@ public class MZmineModulesList {
 
       // Tools
       MzRangeMassCalculatorModule.class, MzRangeFormulaCalculatorModule.class,
-      IsotopePatternPreviewModule.class, MsMsSpectraMergeModule.class
+      IsotopePatternPreviewModule.class, MsMsSpectraMergeModule.class,
+
+      // all other regular MZmineRunnableModule (not MZmineProcessingModule) NOT LISTED IN MENU
+      SpectraIdentificationSpectralDatabaseModule.class
 
   };
 }

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/spectraldbsearch/LocalSpectralDBSearchTask.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/spectraldbsearch/LocalSpectralDBSearchTask.java
@@ -36,6 +36,7 @@ import net.sf.mzmine.taskcontrol.TaskStatus;
 import net.sf.mzmine.util.spectraldb.entry.SpectralDBEntry;
 import net.sf.mzmine.util.spectraldb.parser.AutoLibraryParser;
 import net.sf.mzmine.util.spectraldb.parser.LibraryEntryProcessor;
+import net.sf.mzmine.util.spectraldb.parser.UnsupportedFormatException;
 
 class LocalSpectralDBSearchTask extends AbstractTask {
 
@@ -133,7 +134,8 @@ class LocalSpectralDBSearchTask extends AbstractTask {
    * @param dataBaseFile
    * @return
    */
-  private List<PeakListSpectralMatchTask> parseFile(File dataBaseFile) throws IOException {
+  private List<PeakListSpectralMatchTask> parseFile(File dataBaseFile)
+      throws UnsupportedFormatException, IOException {
     //
     List<PeakListSpectralMatchTask> tasks = new ArrayList<>();
     AutoLibraryParser parser = new AutoLibraryParser(1000, new LibraryEntryProcessor() {

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/spectraldbsearch/PeakListSpectralMatchTask.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/spectraldbsearch/PeakListSpectralMatchTask.java
@@ -159,7 +159,8 @@ public class PeakListSpectralMatchTask extends AbstractTask {
         // next row
         finishedRows++;
       }
-      logger.info("Added " + count + " spectral library matches");
+      if (count > 0)
+        logger.info("Added " + count + " spectral library matches");
     } catch (Exception e) {
     }
     // Repaint the window to reflect the change in the peak list

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/spectraldbsearch/PeakListSpectralMatchTask.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/spectraldbsearch/PeakListSpectralMatchTask.java
@@ -184,8 +184,9 @@ public class PeakListSpectralMatchTask extends AbstractTask {
       // precursor mz
       Boolean precursorMzTol = false;
       if (msLevel >= 2) {
-        precursorMzTol =
-            mzTolerance.checkWithinTolerance(ident.getPrecursorMZ(), row.getAverageMZ());
+        if (ident.getPrecursorMZ() != null)
+          precursorMzTol =
+              mzTolerance.checkWithinTolerance(ident.getPrecursorMZ(), row.getAverageMZ());
       }
       if (msLevel == 1 || precursorMzTol) {
         try {

--- a/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectraIdentificationResultsWindow.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectraIdentificationResultsWindow.java
@@ -87,6 +87,12 @@ public class SpectraIdentificationResultsWindow extends JFrame {
     pnGrid.setBackground(Color.WHITE);
     pnGrid.setAutoscrolls(false);
 
+    // add label (is replaced later
+    JLabel noMatchesFound = new JLabel("Sorry, no matches found!", SwingConstants.CENTER);
+    noMatchesFound.setFont(headerFont);
+    noMatchesFound.setForeground(Color.RED);
+    pnGrid.add(noMatchesFound, BorderLayout.CENTER);
+
     // Add the Windows menu
     JMenuBar menuBar = new JMenuBar();
     menuBar.add(new WindowsMenu());
@@ -478,10 +484,6 @@ public class SpectraIdentificationResultsWindow extends JFrame {
    */
   public void sortTotalMatches() {
     if (totalMatches.isEmpty()) {
-      JLabel noMatchesFound = new JLabel("Sorry, no matches found!", SwingConstants.CENTER);
-      noMatchesFound.setFont(headerFont);
-      noMatchesFound.setForeground(Color.RED);
-      pnGrid.add(noMatchesFound, BorderLayout.CENTER);
       return;
     }
 

--- a/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectraIdentificationResultsWindow.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectraIdentificationResultsWindow.java
@@ -18,7 +18,6 @@
 
 package net.sf.mzmine.modules.visualization.spectra.simplespectra.spectraidentification.spectraldatabase;
 
-import static java.util.stream.Collectors.toMap;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
@@ -26,9 +25,9 @@ import java.awt.Font;
 import java.awt.GridLayout;
 import java.awt.LayoutManager;
 import java.text.DecimalFormat;
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import javax.swing.BorderFactory;
@@ -43,6 +42,7 @@ import javax.swing.JScrollPane;
 import javax.swing.JSplitPane;
 import javax.swing.JTable;
 import javax.swing.SwingConstants;
+import javax.swing.SwingUtilities;
 import org.jfree.chart.axis.NumberAxis;
 import org.jfree.chart.plot.CombinedDomainXYPlot;
 import org.jfree.chart.plot.XYPlot;
@@ -55,7 +55,7 @@ import net.sf.mzmine.modules.visualization.spectra.multimsms.pseudospectra.Pseud
 import net.sf.mzmine.taskcontrol.impl.TaskControllerImpl;
 import net.sf.mzmine.util.components.ComponentCellRenderer;
 import net.sf.mzmine.util.spectraldb.entry.DBEntryField;
-import net.sf.mzmine.util.spectraldb.entry.SpectralDBEntry;
+import net.sf.mzmine.util.spectraldb.entry.SpectralDBPeakIdentity;
 
 public class SpectraIdentificationResultsWindow extends JFrame {
   /**
@@ -71,9 +71,10 @@ public class SpectraIdentificationResultsWindow extends JFrame {
   private Font headerFont = new Font("Dialog", Font.BOLD, 16);
   private static final DecimalFormat COS_FORM = new DecimalFormat("0.000");
   private JScrollPane scrollPane;
-  private Map<SpectralDBEntry, Double> totalMatches;
+  private List<SpectralDBPeakIdentity> totalMatches;
+  private Map<SpectralDBPeakIdentity, JPanel> matchPanels;
 
-  public SpectraIdentificationResultsWindow(Scan scan) {
+  public SpectraIdentificationResultsWindow() {
     setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
     setSize(new Dimension(1200, 800));
     getContentPane().setLayout(new BorderLayout());
@@ -82,6 +83,7 @@ public class SpectraIdentificationResultsWindow extends JFrame {
     pnGrid = new JPanel();
     // any number of rows
     pnGrid.setLayout(new GridLayout(0, 1, 0, 25));
+
     pnGrid.setBackground(Color.WHITE);
     pnGrid.setAutoscrolls(false);
 
@@ -112,7 +114,8 @@ public class SpectraIdentificationResultsWindow extends JFrame {
     scrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
     scrollPane.setViewportView(pnGrid);
 
-    totalMatches = new HashMap<SpectralDBEntry, Double>();
+    totalMatches = new ArrayList<>();
+    matchPanels = new HashMap<>();
 
     setVisible(true);
     setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
@@ -120,14 +123,14 @@ public class SpectraIdentificationResultsWindow extends JFrame {
     repaint();
   }
 
-  public boolean setScanAndShow(Scan scan, SpectralDBEntry ident, Double simScore) {
-    pnGrid.add(addSpectra(scan, ident, simScore));
-    pnGrid.revalidate();
-    pnGrid.repaint();
-    return true;
-  }
-
-  private JPanel addSpectra(Scan scan, SpectralDBEntry ident, Double simScore) {
+  /**
+   * Creates a new panel for the library match
+   * 
+   * @param scan
+   * @param hit
+   * @return
+   */
+  private JPanel createPanel(Scan scan, SpectralDBPeakIdentity hit) {
     JPanel panel = new JPanel(new BorderLayout());
 
     JSplitPane spectrumPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT);
@@ -150,17 +153,19 @@ public class SpectraIdentificationResultsWindow extends JFrame {
     panelTitle.setPreferredSize(new Dimension(250, 75));
     panelTitle.setMinimumSize(new Dimension(250, 75));
     panelTitle.setMaximumSize(new Dimension(250, 75));
-    String name = (String) ident.getField(DBEntryField.NAME).orElse("N/A");
+    String name = (String) hit.getEntry().getField(DBEntryField.NAME).orElse("N/A");
     JLabel title = new JLabel();
     if (name.length() >= 20) {
       title = new JLabel(name.substring(0, 19) + "...");
     } else {
       title = new JLabel(name);
     }
-    title.setToolTipText((String) ident.getField(DBEntryField.NAME).orElse("N/A"));
+    title.setToolTipText((String) hit.getEntry().getField(DBEntryField.NAME).orElse("N/A"));
     title.setFont(headerFont);
     title.setForeground(Color.WHITE);
     panelTitle.add(title);
+
+    double simScore = hit.getSimilarity().getCosine();
 
     // score result
     JPanel panelScore = new JPanel();
@@ -195,68 +200,80 @@ public class SpectraIdentificationResultsWindow extends JFrame {
         "This section shows all the compound information listed in the used database");
     compoundInfo.setFont(headerFont);
     panelCompounds.add(compoundInfo);
-    JLabel synonym = new JLabel("Synonym: " + ident.getField(DBEntryField.SYNONYM).orElse("N/A"));
-    synonym.setText("Synonym: " + ident.getField(DBEntryField.SYNONYM).orElse("N/A"));
-    if (ident.getField(DBEntryField.SYNONYM).orElse("N/A") != "N/A")
+    JLabel synonym =
+        new JLabel("Synonym: " + hit.getEntry().getField(DBEntryField.SYNONYM).orElse("N/A"));
+    synonym.setText("Synonym: " + hit.getEntry().getField(DBEntryField.SYNONYM).orElse("N/A"));
+    if (hit.getEntry().getField(DBEntryField.SYNONYM).orElse("N/A") != "N/A")
       panelCompounds.add(synonym);
-    JLabel formula = new JLabel("Formula: " + ident.getField(DBEntryField.FORMULA).orElse("N/A"));
-    formula.setToolTipText("Formula: " + ident.getField(DBEntryField.FORMULA).orElse("N/A"));
-    if (ident.getField(DBEntryField.FORMULA).orElse("N/A") != "N/A")
+    JLabel formula =
+        new JLabel("Formula: " + hit.getEntry().getField(DBEntryField.FORMULA).orElse("N/A"));
+    formula
+        .setToolTipText("Formula: " + hit.getEntry().getField(DBEntryField.FORMULA).orElse("N/A"));
+    if (hit.getEntry().getField(DBEntryField.FORMULA).orElse("N/A") != "N/A")
       panelCompounds.add(formula);
-    JLabel molarWeight =
-        new JLabel("Molar Weight: " + ident.getField(DBEntryField.MOLWEIGHT).orElse("N/A"));
-    molarWeight
-        .setToolTipText("Molar Weight: " + ident.getField(DBEntryField.MOLWEIGHT).orElse("N/A"));
-    if (ident.getField(DBEntryField.MOLWEIGHT).orElse("N/A") != "N/A")
+    JLabel molarWeight = new JLabel(
+        "Molar Weight: " + hit.getEntry().getField(DBEntryField.MOLWEIGHT).orElse("N/A"));
+    molarWeight.setToolTipText(
+        "Molar Weight: " + hit.getEntry().getField(DBEntryField.MOLWEIGHT).orElse("N/A"));
+    if (hit.getEntry().getField(DBEntryField.MOLWEIGHT).orElse("N/A") != "N/A")
       panelCompounds.add(molarWeight);
     JLabel exactMass =
-        new JLabel("Exact mass: " + ident.getField(DBEntryField.EXACT_MASS).orElse("N/A"));
-    exactMass
-        .setToolTipText("Exact mass: " + ident.getField(DBEntryField.EXACT_MASS).orElse("N/A"));
-    if (ident.getField(DBEntryField.EXACT_MASS).orElse("N/A") != "N/A")
+        new JLabel("Exact mass: " + hit.getEntry().getField(DBEntryField.EXACT_MASS).orElse("N/A"));
+    exactMass.setToolTipText(
+        "Exact mass: " + hit.getEntry().getField(DBEntryField.EXACT_MASS).orElse("N/A"));
+    if (hit.getEntry().getField(DBEntryField.EXACT_MASS).orElse("N/A") != "N/A")
       panelCompounds.add(exactMass);
-    JLabel ionType = new JLabel("Ion type: " + ident.getField(DBEntryField.IONTYPE).orElse("N/A"));
-    ionType.setToolTipText("Ion type: " + ident.getField(DBEntryField.IONTYPE).orElse("N/A"));
-    if (ident.getField(DBEntryField.IONTYPE).orElse("N/A") != "N/A")
+    JLabel ionType =
+        new JLabel("Ion type: " + hit.getEntry().getField(DBEntryField.IONTYPE).orElse("N/A"));
+    ionType
+        .setToolTipText("Ion type: " + hit.getEntry().getField(DBEntryField.IONTYPE).orElse("N/A"));
+    if (hit.getEntry().getField(DBEntryField.IONTYPE).orElse("N/A") != "N/A")
       panelCompounds.add(ionType);
-    JLabel rt = new JLabel("Retention time: " + ident.getField(DBEntryField.RT).orElse("N/A"));
-    rt.setToolTipText("Retention time: " + ident.getField(DBEntryField.RT).orElse("N/A"));
-    if (ident.getField(DBEntryField.RT).orElse("N/A") != "N/A")
+    JLabel rt =
+        new JLabel("Retention time: " + hit.getEntry().getField(DBEntryField.RT).orElse("N/A"));
+    rt.setToolTipText("Retention time: " + hit.getEntry().getField(DBEntryField.RT).orElse("N/A"));
+    if (hit.getEntry().getField(DBEntryField.RT).orElse("N/A") != "N/A")
       panelCompounds.add(rt);
-    JLabel mz = new JLabel("m/z: " + ident.getField(DBEntryField.MZ).orElse("N/A"));
-    mz.setToolTipText("m/z: " + ident.getField(DBEntryField.MZ).orElse("N/A"));
-    if (ident.getField(DBEntryField.MZ).orElse("N/A") != "N/A")
+    JLabel mz = new JLabel("m/z: " + hit.getEntry().getField(DBEntryField.MZ).orElse("N/A"));
+    mz.setToolTipText("m/z: " + hit.getEntry().getField(DBEntryField.MZ).orElse("N/A"));
+    if (hit.getEntry().getField(DBEntryField.MZ).orElse("N/A") != "N/A")
       panelCompounds.add(mz);
-    JLabel charge = new JLabel("Charge: " + ident.getField(DBEntryField.CHARGE).orElse("N/A"));
-    charge.setToolTipText("Charge: " + ident.getField(DBEntryField.CHARGE).orElse("N/A"));
-    if (ident.getField(DBEntryField.CHARGE).orElse("N/A") != "N/A")
+    JLabel charge =
+        new JLabel("Charge: " + hit.getEntry().getField(DBEntryField.CHARGE).orElse("N/A"));
+    charge.setToolTipText("Charge: " + hit.getEntry().getField(DBEntryField.CHARGE).orElse("N/A"));
+    if (hit.getEntry().getField(DBEntryField.CHARGE).orElse("N/A") != "N/A")
       panelCompounds.add(charge);
-    JLabel ionMode = new JLabel("Ion mode: " + ident.getField(DBEntryField.ION_MODE).orElse("N/A"));
-    ionMode.setToolTipText("Ion mode: " + ident.getField(DBEntryField.ION_MODE).orElse("N/A"));
-    if (ident.getField(DBEntryField.ION_MODE).orElse("N/A") != "N/A")
+    JLabel ionMode =
+        new JLabel("Ion mode: " + hit.getEntry().getField(DBEntryField.ION_MODE).orElse("N/A"));
+    ionMode.setToolTipText(
+        "Ion mode: " + hit.getEntry().getField(DBEntryField.ION_MODE).orElse("N/A"));
+    if (hit.getEntry().getField(DBEntryField.ION_MODE).orElse("N/A") != "N/A")
       panelCompounds.add(ionMode);
-    JLabel inchi = new JLabel("INCHI: " + ident.getField(DBEntryField.INCHI).orElse("N/A"));
-    inchi.setToolTipText("INCHI: " + ident.getField(DBEntryField.INCHI).orElse("N/A"));
-    if (ident.getField(DBEntryField.INCHI).orElse("N/A") != "N/A")
+    JLabel inchi =
+        new JLabel("INCHI: " + hit.getEntry().getField(DBEntryField.INCHI).orElse("N/A"));
+    inchi.setToolTipText("INCHI: " + hit.getEntry().getField(DBEntryField.INCHI).orElse("N/A"));
+    if (hit.getEntry().getField(DBEntryField.INCHI).orElse("N/A") != "N/A")
       panelCompounds.add(inchi);
     JLabel inchiKey =
-        new JLabel("INCHI Key: " + ident.getField(DBEntryField.INCHIKEY).orElse("N/A"));
-    inchiKey.setToolTipText("INCHI Key: " + ident.getField(DBEntryField.INCHIKEY).orElse("N/A"));
-    if (ident.getField(DBEntryField.INCHI).orElse("N/A") != "N/A")
+        new JLabel("INCHI Key: " + hit.getEntry().getField(DBEntryField.INCHIKEY).orElse("N/A"));
+    inchiKey.setToolTipText(
+        "INCHI Key: " + hit.getEntry().getField(DBEntryField.INCHIKEY).orElse("N/A"));
+    if (hit.getEntry().getField(DBEntryField.INCHI).orElse("N/A") != "N/A")
       panelCompounds.add(inchiKey);
-    JLabel smiles = new JLabel("SMILES: " + ident.getField(DBEntryField.SMILES).orElse("N/A"));
-    smiles.setToolTipText("SMILES: " + ident.getField(DBEntryField.SMILES).orElse("N/A"));
-    if (ident.getField(DBEntryField.SMILES).orElse("N/A") != "N/A")
+    JLabel smiles =
+        new JLabel("SMILES: " + hit.getEntry().getField(DBEntryField.SMILES).orElse("N/A"));
+    smiles.setToolTipText("SMILES: " + hit.getEntry().getField(DBEntryField.SMILES).orElse("N/A"));
+    if (hit.getEntry().getField(DBEntryField.SMILES).orElse("N/A") != "N/A")
       panelCompounds.add(smiles);
-    JLabel cas = new JLabel("CAS: " + ident.getField(DBEntryField.CAS).orElse("N/A"));
-    cas.setToolTipText("CAS: " + ident.getField(DBEntryField.CAS).orElse("N/A"));
-    if (ident.getField(DBEntryField.CAS).orElse("N/A") != "N/A")
+    JLabel cas = new JLabel("CAS: " + hit.getEntry().getField(DBEntryField.CAS).orElse("N/A"));
+    cas.setToolTipText("CAS: " + hit.getEntry().getField(DBEntryField.CAS).orElse("N/A"));
+    if (hit.getEntry().getField(DBEntryField.CAS).orElse("N/A") != "N/A")
       panelCompounds.add(cas);
-    JLabel numberPeaks =
-        new JLabel("Number of peaks: " + ident.getField(DBEntryField.NUM_PEAKS).orElse("N/A"));
-    numberPeaks
-        .setToolTipText("Number of peaks: " + ident.getField(DBEntryField.NUM_PEAKS).orElse("N/A"));
-    if (ident.getField(DBEntryField.NUM_PEAKS).orElse("N/A") != "N/A")
+    JLabel numberPeaks = new JLabel(
+        "Number of peaks: " + hit.getEntry().getField(DBEntryField.NUM_PEAKS).orElse("N/A"));
+    numberPeaks.setToolTipText(
+        "Number of peaks: " + hit.getEntry().getField(DBEntryField.NUM_PEAKS).orElse("N/A"));
+    if (hit.getEntry().getField(DBEntryField.NUM_PEAKS).orElse("N/A") != "N/A")
       panelCompounds.add(numberPeaks);
 
     // instrument info
@@ -268,49 +285,52 @@ public class SpectraIdentificationResultsWindow extends JFrame {
     instrumentInfo.setToolTipText(
         "This section shows all the instrument information listed in the used database");
     JLabel instrumentType = new JLabel(
-        "Instrument type: " + ident.getField(DBEntryField.INSTRUMENT_TYPE).orElse("N/A"));
+        "Instrument type: " + hit.getEntry().getField(DBEntryField.INSTRUMENT_TYPE).orElse("N/A"));
     instrumentType.setToolTipText(
-        "Instrument type: " + ident.getField(DBEntryField.INSTRUMENT_TYPE).orElse("N/A"));
-    if (ident.getField(DBEntryField.INSTRUMENT_TYPE).orElse("N/A") != "N/A")
+        "Instrument type: " + hit.getEntry().getField(DBEntryField.INSTRUMENT_TYPE).orElse("N/A"));
+    if (hit.getEntry().getField(DBEntryField.INSTRUMENT_TYPE).orElse("N/A") != "N/A")
       panelInstrument.add(instrumentType);
     JLabel instrument =
-        new JLabel("Instrument: " + ident.getField(DBEntryField.INSTRUMENT).orElse("N/A"));
-    instrument
-        .setToolTipText("Instrument: " + ident.getField(DBEntryField.INSTRUMENT).orElse("N/A"));
-    if (ident.getField(DBEntryField.INSTRUMENT).orElse("N/A") != "N/A")
+        new JLabel("Instrument: " + hit.getEntry().getField(DBEntryField.INSTRUMENT).orElse("N/A"));
+    instrument.setToolTipText(
+        "Instrument: " + hit.getEntry().getField(DBEntryField.INSTRUMENT).orElse("N/A"));
+    if (hit.getEntry().getField(DBEntryField.INSTRUMENT).orElse("N/A") != "N/A")
       panelInstrument.add(instrument);
     JLabel ionSource =
-        new JLabel("Ion source: " + ident.getField(DBEntryField.ION_SOURCE).orElse("N/A"));
-    ionSource
-        .setToolTipText("Ion source: " + ident.getField(DBEntryField.ION_SOURCE).orElse("N/A"));
-    if (ident.getField(DBEntryField.ION_SOURCE).orElse("N/A") != "N/A")
+        new JLabel("Ion source: " + hit.getEntry().getField(DBEntryField.ION_SOURCE).orElse("N/A"));
+    ionSource.setToolTipText(
+        "Ion source: " + hit.getEntry().getField(DBEntryField.ION_SOURCE).orElse("N/A"));
+    if (hit.getEntry().getField(DBEntryField.ION_SOURCE).orElse("N/A") != "N/A")
       panelInstrument.add(ionSource);
     JLabel resolution =
-        new JLabel("Resolution: " + ident.getField(DBEntryField.RESOLUTION).orElse("N/A"));
-    resolution
-        .setToolTipText("Resolution: " + ident.getField(DBEntryField.RESOLUTION).orElse("N/A"));
-    if (ident.getField(DBEntryField.RESOLUTION).orElse("N/A") != "N/A")
+        new JLabel("Resolution: " + hit.getEntry().getField(DBEntryField.RESOLUTION).orElse("N/A"));
+    resolution.setToolTipText(
+        "Resolution: " + hit.getEntry().getField(DBEntryField.RESOLUTION).orElse("N/A"));
+    if (hit.getEntry().getField(DBEntryField.RESOLUTION).orElse("N/A") != "N/A")
       panelInstrument.add(resolution);
-    JLabel msLevel = new JLabel("MS level: " + ident.getField(DBEntryField.MS_LEVEL).orElse("N/A"));
-    msLevel.setToolTipText("MS level: " + ident.getField(DBEntryField.MS_LEVEL).orElse("N/A"));
-    if (ident.getField(DBEntryField.MS_LEVEL).orElse("N/A") != "N/A")
+    JLabel msLevel =
+        new JLabel("MS level: " + hit.getEntry().getField(DBEntryField.MS_LEVEL).orElse("N/A"));
+    msLevel.setToolTipText(
+        "MS level: " + hit.getEntry().getField(DBEntryField.MS_LEVEL).orElse("N/A"));
+    if (hit.getEntry().getField(DBEntryField.MS_LEVEL).orElse("N/A") != "N/A")
       panelInstrument.add(msLevel);
-    JLabel collision = new JLabel(
-        "Collision energy: " + ident.getField(DBEntryField.COLLISION_ENERGY).orElse("N/A"));
+    JLabel collision = new JLabel("Collision energy: "
+        + hit.getEntry().getField(DBEntryField.COLLISION_ENERGY).orElse("N/A"));
     collision.setToolTipText(
-        "Collision enery: " + ident.getField(DBEntryField.COLLISION_ENERGY).orElse("N/A"));
-    if (ident.getField(DBEntryField.COLLISION_ENERGY).orElse("N/A") != "N/A")
+        "Collision enery: " + hit.getEntry().getField(DBEntryField.COLLISION_ENERGY).orElse("N/A"));
+    if (hit.getEntry().getField(DBEntryField.COLLISION_ENERGY).orElse("N/A") != "N/A")
       panelInstrument.add(collision);
-    JLabel acquisition =
-        new JLabel("Acquisition: " + ident.getField(DBEntryField.ACQUISITION).orElse("N/A"));
-    acquisition
-        .setToolTipText("Acquisition: " + ident.getField(DBEntryField.ACQUISITION).orElse("N/A"));
-    if (ident.getField(DBEntryField.ACQUISITION).orElse("N/A") != "N/A")
+    JLabel acquisition = new JLabel(
+        "Acquisition: " + hit.getEntry().getField(DBEntryField.ACQUISITION).orElse("N/A"));
+    acquisition.setToolTipText(
+        "Acquisition: " + hit.getEntry().getField(DBEntryField.ACQUISITION).orElse("N/A"));
+    if (hit.getEntry().getField(DBEntryField.ACQUISITION).orElse("N/A") != "N/A")
       panelInstrument.add(acquisition);
     JLabel software =
-        new JLabel("Software: " + ident.getField(DBEntryField.SOFTWARE).orElse("N/A"));
-    software.setToolTipText("Software: " + ident.getField(DBEntryField.SOFTWARE).orElse("N/A"));
-    if (ident.getField(DBEntryField.SOFTWARE).orElse("N/A") != "N/A")
+        new JLabel("Software: " + hit.getEntry().getField(DBEntryField.SOFTWARE).orElse("N/A"));
+    software.setToolTipText(
+        "Software: " + hit.getEntry().getField(DBEntryField.SOFTWARE).orElse("N/A"));
+    if (hit.getEntry().getField(DBEntryField.SOFTWARE).orElse("N/A") != "N/A")
       panelInstrument.add(software);
 
     boxCompoundAndInstrument.add(panelCompounds, BorderLayout.WEST);
@@ -326,22 +346,27 @@ public class SpectraIdentificationResultsWindow extends JFrame {
         .setToolTipText("This section shows links to other databases of the matched compound");
     databaseLinks.setFont(headerFont);
     panelDB.add(databaseLinks);
-    JLabel pubmed = new JLabel("PUBMED: " + ident.getField(DBEntryField.PUBMED).orElse("N/A"));
-    pubmed.setToolTipText("PUBMED: " + ident.getField(DBEntryField.PUBMED).orElse("N/A"));
-    if (ident.getField(DBEntryField.PUBMED).orElse("N/A") != "N/A")
+    JLabel pubmed =
+        new JLabel("PUBMED: " + hit.getEntry().getField(DBEntryField.PUBMED).orElse("N/A"));
+    pubmed.setToolTipText("PUBMED: " + hit.getEntry().getField(DBEntryField.PUBMED).orElse("N/A"));
+    if (hit.getEntry().getField(DBEntryField.PUBMED).orElse("N/A") != "N/A")
       panelDB.add(pubmed);
-    JLabel pubchem = new JLabel("PUBCHEM: " + ident.getField(DBEntryField.PUBCHEM).orElse("N/A"));
-    pubchem.setToolTipText("PUBCHEM: " + ident.getField(DBEntryField.PUBCHEM).orElse("N/A"));
-    if (ident.getField(DBEntryField.PUBCHEM).orElse("N/A") != "N/A")
+    JLabel pubchem =
+        new JLabel("PUBCHEM: " + hit.getEntry().getField(DBEntryField.PUBCHEM).orElse("N/A"));
+    pubchem
+        .setToolTipText("PUBCHEM: " + hit.getEntry().getField(DBEntryField.PUBCHEM).orElse("N/A"));
+    if (hit.getEntry().getField(DBEntryField.PUBCHEM).orElse("N/A") != "N/A")
       panelDB.add(pubchem);
-    JLabel mona = new JLabel("MONA ID: " + ident.getField(DBEntryField.MONA_ID).orElse("N/A"));
-    mona.setToolTipText("MONA ID: " + ident.getField(DBEntryField.MONA_ID).orElse("N/A"));
-    if (ident.getField(DBEntryField.MONA_ID).orElse("N/A") != "N/A")
+    JLabel mona =
+        new JLabel("MONA ID: " + hit.getEntry().getField(DBEntryField.MONA_ID).orElse("N/A"));
+    mona.setToolTipText("MONA ID: " + hit.getEntry().getField(DBEntryField.MONA_ID).orElse("N/A"));
+    if (hit.getEntry().getField(DBEntryField.MONA_ID).orElse("N/A") != "N/A")
       panelDB.add(mona);
     JLabel spider =
-        new JLabel("Chemspider: " + ident.getField(DBEntryField.CHEMSPIDER).orElse("N/A"));
-    spider.setToolTipText("Chemspider: " + ident.getField(DBEntryField.CHEMSPIDER).orElse("N/A"));
-    if (ident.getField(DBEntryField.CHEMSPIDER).orElse("N/A") != "N/A")
+        new JLabel("Chemspider: " + hit.getEntry().getField(DBEntryField.CHEMSPIDER).orElse("N/A"));
+    spider.setToolTipText(
+        "Chemspider: " + hit.getEntry().getField(DBEntryField.CHEMSPIDER).orElse("N/A"));
+    if (hit.getEntry().getField(DBEntryField.CHEMSPIDER).orElse("N/A") != "N/A")
       panelDB.add(spider);
 
     // // Other info
@@ -352,25 +377,28 @@ public class SpectraIdentificationResultsWindow extends JFrame {
     otherInfo.setFont(headerFont);
     panelOther.add(otherInfo);
     JLabel investigator = new JLabel("Prinziple investigator: "
-        + ident.getField(DBEntryField.PRINZIPLE_INVESTIGATOR).orElse("N/A"));
+        + hit.getEntry().getField(DBEntryField.PRINZIPLE_INVESTIGATOR).orElse("N/A"));
     investigator.setToolTipText("Prinziple investigator: "
-        + ident.getField(DBEntryField.PRINZIPLE_INVESTIGATOR).orElse("N/A"));
-    if (ident.getField(DBEntryField.PRINZIPLE_INVESTIGATOR).orElse("N/A") != "N/A")
+        + hit.getEntry().getField(DBEntryField.PRINZIPLE_INVESTIGATOR).orElse("N/A"));
+    if (hit.getEntry().getField(DBEntryField.PRINZIPLE_INVESTIGATOR).orElse("N/A") != "N/A")
       panelOther.add(investigator);
-    JLabel collector =
-        new JLabel("Data collector: " + ident.getField(DBEntryField.DATA_COLLECTOR).orElse("N/A"));
+    JLabel collector = new JLabel(
+        "Data collector: " + hit.getEntry().getField(DBEntryField.DATA_COLLECTOR).orElse("N/A"));
     collector.setToolTipText(
-        "Data collector: " + ident.getField(DBEntryField.DATA_COLLECTOR).orElse("N/A"));
-    if (ident.getField(DBEntryField.DATA_COLLECTOR).orElse("N/A") != "N/A")
+        "Data collector: " + hit.getEntry().getField(DBEntryField.DATA_COLLECTOR).orElse("N/A"));
+    if (hit.getEntry().getField(DBEntryField.DATA_COLLECTOR).orElse("N/A") != "N/A")
       panelOther.add(collector);
     JLabel entry =
-        new JLabel("DB entry ID: " + ident.getField(DBEntryField.ENTRY_ID).orElse("N/A"));
-    entry.setToolTipText("DB entry ID: " + ident.getField(DBEntryField.ENTRY_ID).orElse("N/A"));
-    if (ident.getField(DBEntryField.ENTRY_ID).orElse("N/A") != "N/A")
+        new JLabel("DB entry ID: " + hit.getEntry().getField(DBEntryField.ENTRY_ID).orElse("N/A"));
+    entry.setToolTipText(
+        "DB entry ID: " + hit.getEntry().getField(DBEntryField.ENTRY_ID).orElse("N/A"));
+    if (hit.getEntry().getField(DBEntryField.ENTRY_ID).orElse("N/A") != "N/A")
       panelOther.add(entry);
-    JLabel comment = new JLabel("Comment: " + ident.getField(DBEntryField.COMMENT).orElse("N/A"));
-    comment.setToolTipText("Comment: " + ident.getField(DBEntryField.COMMENT).orElse("N/A"));
-    if (ident.getField(DBEntryField.COMMENT).orElse("N/A") != "N/A")
+    JLabel comment =
+        new JLabel("Comment: " + hit.getEntry().getField(DBEntryField.COMMENT).orElse("N/A"));
+    comment
+        .setToolTipText("Comment: " + hit.getEntry().getField(DBEntryField.COMMENT).orElse("N/A"));
+    if (hit.getEntry().getField(DBEntryField.COMMENT).orElse("N/A") != "N/A")
       panelOther.add(comment);
 
     boxDBAndOther.add(panelDB, BorderLayout.WEST);
@@ -379,7 +407,7 @@ public class SpectraIdentificationResultsWindow extends JFrame {
 
     // get mirror spectra window
     MirrorScanWindow mirrorWindow = new MirrorScanWindow();
-    mirrorWindow.setScans(scan, ident);
+    mirrorWindow.setScans(scan, hit.getEntry());
 
     // get spectra plot
     EChartPanel spectraPlots = mirrorWindow.getMirrorSpecrumPlot();
@@ -408,26 +436,86 @@ public class SpectraIdentificationResultsWindow extends JFrame {
     return panel;
   }
 
-  public synchronized void addMatches(Scan scan, Map<SpectralDBEntry, Double> matches) {
-    for (Map.Entry<SpectralDBEntry, Double> match : matches.entrySet()) {
-      // add matches of task to total matches
-      totalMatches.put(match.getKey(), match.getValue());
-      setScanAndShow(scan, match.getKey(), match.getValue());
+  /**
+   * Add a new match and sort the view
+   * 
+   * @param scan
+   * @param match
+   */
+  public synchronized void addMatches(Scan scan, SpectralDBPeakIdentity match) {
+    if (!totalMatches.contains(match)) {
+      // add
+      totalMatches.add(match);
+      matchPanels.put(match, createPanel(scan, match));
+
+      // sort and show
+      sortTotalMatches();
     }
   }
 
-  public void sortTotalMatches(Scan scan) {
-    pnGrid.removeAll();
-    getContentPane().remove(0);
-    Map<SpectralDBEntry, Double> sorted = totalMatches.entrySet().stream()
-        .sorted(Collections.reverseOrder(Map.Entry.comparingByValue()))
-        .collect(toMap(e -> e.getKey(), e -> e.getValue(), (e1, e2) -> e2, LinkedHashMap::new));
-    if (totalMatches.size() == 0) {
+  /**
+   * add all matches and sort the view
+   * 
+   * @param scan
+   * @param matches
+   */
+  public synchronized void addMatches(Scan scan, List<SpectralDBPeakIdentity> matches) {
+    // add all
+    for (SpectralDBPeakIdentity match : matches) {
+      if (!totalMatches.contains(match)) {
+        // add
+        totalMatches.add(match);
+        matchPanels.put(match, createPanel(scan, match));
+      }
+    }
+    // sort and show
+    sortTotalMatches();
+  }
+
+  /**
+   * Sort all matches and renew panels
+   * 
+   */
+  public void sortTotalMatches() {
+    if (totalMatches.isEmpty()) {
       JLabel noMatchesFound = new JLabel("Sorry, no matches found!", SwingConstants.CENTER);
       noMatchesFound.setFont(headerFont);
       noMatchesFound.setForeground(Color.RED);
       pnGrid.add(noMatchesFound, BorderLayout.CENTER);
+      return;
     }
-    addMatches(scan, sorted);
+
+    // reversed sorting (highest cosine first
+    totalMatches.sort((SpectralDBPeakIdentity a, SpectralDBPeakIdentity b) -> Double
+        .compare(b.getSimilarity().getCosine(), a.getSimilarity().getCosine()));
+
+    // renew layout and show
+    renewLayout();
+  }
+
+  /**
+   * Add a spectral library hit
+   * 
+   * @param ident
+   * @param simScore
+   */
+  public void renewLayout() {
+    SwingUtilities.invokeLater(() -> {
+      // any number of rows
+      JPanel pnGrid = new JPanel(new GridLayout(0, 1, 0, 25));
+      pnGrid.setBackground(Color.WHITE);
+      pnGrid.setAutoscrolls(false);
+      // add all panel in order
+      for (SpectralDBPeakIdentity match : totalMatches) {
+        JPanel pn = matchPanels.get(match);
+        if (pn != null)
+          pnGrid.add(pn);
+      }
+      // show
+      scrollPane.setViewportView(pnGrid);
+      scrollPane.revalidate();
+      scrollPane.repaint();
+      this.pnGrid = pnGrid;
+    });
   }
 }

--- a/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectraIdentificationSpectralDatabaseModule.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectraIdentificationSpectralDatabaseModule.java
@@ -24,7 +24,7 @@ import net.sf.mzmine.datamodel.MZmineProject;
 import net.sf.mzmine.datamodel.Scan;
 import net.sf.mzmine.main.MZmineCore;
 import net.sf.mzmine.modules.MZmineModuleCategory;
-import net.sf.mzmine.modules.MZmineProcessingModule;
+import net.sf.mzmine.modules.MZmineRunnableModule;
 import net.sf.mzmine.modules.visualization.spectra.simplespectra.SpectraPlot;
 import net.sf.mzmine.parameters.ParameterSet;
 import net.sf.mzmine.taskcontrol.Task;
@@ -35,7 +35,7 @@ import net.sf.mzmine.util.ExitCode;
  * 
  * @author Ansgar Korf (ansgar.korf@uni-muenster.de)
  */
-public class SpectraIdentificationSpectralDatabaseModule implements MZmineProcessingModule {
+public class SpectraIdentificationSpectralDatabaseModule implements MZmineRunnableModule {
 
   public static final String MODULE_NAME = "Local spectral database search for single spectra";
   private static final String MODULE_DESCRIPTION =
@@ -68,7 +68,8 @@ public class SpectraIdentificationSpectralDatabaseModule implements MZmineProces
       final SpectraPlot spectraPlot) {
 
     final SpectraIdentificationSpectralDatabaseParameters parameters =
-        new SpectraIdentificationSpectralDatabaseParameters();
+        (SpectraIdentificationSpectralDatabaseParameters) MZmineCore.getConfiguration()
+            .getModuleParameters(SpectraIdentificationSpectralDatabaseModule.class);
 
     // Run task.
     if (parameters.showSetupDialog(scan, MZmineCore.getDesktop().getMainWindow(),

--- a/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectraIdentificationSpectralDatabaseModule.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectraIdentificationSpectralDatabaseModule.java
@@ -67,10 +67,12 @@ public class SpectraIdentificationSpectralDatabaseModule implements MZmineProces
   public static void showSpectraIdentificationDialog(final Scan scan,
       final SpectraPlot spectraPlot) {
 
-    final ParameterSet parameters = new SpectraIdentificationSpectralDatabaseParameters();
+    final SpectraIdentificationSpectralDatabaseParameters parameters =
+        new SpectraIdentificationSpectralDatabaseParameters();
 
     // Run task.
-    if (parameters.showSetupDialog(MZmineCore.getDesktop().getMainWindow(), true) == ExitCode.OK) {
+    if (parameters.showSetupDialog(scan, MZmineCore.getDesktop().getMainWindow(),
+        true) == ExitCode.OK) {
 
       MZmineCore.getTaskController().addTask(new SpectraIdentificationSpectralDatabaseTask(
           parameters.cloneParameterSet(), scan, spectraPlot));

--- a/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectraIdentificationSpectralDatabaseParameters.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectraIdentificationSpectralDatabaseParameters.java
@@ -18,15 +18,19 @@
 
 package net.sf.mzmine.modules.visualization.spectra.simplespectra.spectraidentification.spectraldatabase;
 
+import java.awt.Window;
 import java.text.DecimalFormat;
+import net.sf.mzmine.datamodel.Scan;
 import net.sf.mzmine.main.MZmineCore;
 import net.sf.mzmine.parameters.Parameter;
 import net.sf.mzmine.parameters.impl.SimpleParameterSet;
 import net.sf.mzmine.parameters.parametertypes.DoubleParameter;
 import net.sf.mzmine.parameters.parametertypes.IntegerParameter;
 import net.sf.mzmine.parameters.parametertypes.MassListParameter;
+import net.sf.mzmine.parameters.parametertypes.OptionalParameter;
 import net.sf.mzmine.parameters.parametertypes.filenames.FileNameParameter;
 import net.sf.mzmine.parameters.parametertypes.tolerances.MZToleranceParameter;
+import net.sf.mzmine.util.ExitCode;
 
 /**
  * Module to compare single spectra with spectral databases
@@ -42,6 +46,11 @@ public class SpectraIdentificationSpectralDatabaseParameters extends SimpleParam
 
   public static final MZToleranceParameter mzTolerance = new MZToleranceParameter();
 
+  public static final OptionalParameter<DoubleParameter> usePrecursorMZ =
+      new OptionalParameter<>(new DoubleParameter("Use precursor m/z",
+          "Use precursor m/z as a filter. Precursor m/z of library entry and this scan need to be within m/z tolerance. Entries without precursor m/z are skipped.",
+          MZmineCore.getConfiguration().getMZFormat(), 0d));
+
   public static final DoubleParameter noiseLevel = new DoubleParameter("Minimum ion intensity",
       "Signals below this level will be filtered away from mass lists",
       MZmineCore.getConfiguration().getIntensityFormat(), 0d);
@@ -56,7 +65,19 @@ public class SpectraIdentificationSpectralDatabaseParameters extends SimpleParam
       20);
 
   public SpectraIdentificationSpectralDatabaseParameters() {
-    super(new Parameter[] {dataBaseFile, massList, mzTolerance, noiseLevel, minCosine, minMatch});
+    super(new Parameter[] {dataBaseFile, massList, mzTolerance, usePrecursorMZ, noiseLevel,
+        minCosine, minMatch});
   }
 
+
+  public ExitCode showSetupDialog(Scan scan, Window parent, boolean valueCheckRequired) {
+    // set precursor mz to parameter if MS2 scan
+    // otherwise leave the value to the one specified before
+    if (scan.getPrecursorMZ() != 0)
+      this.getParameter(usePrecursorMZ).getEmbeddedParameter().setValue(scan.getPrecursorMZ());
+    else
+      this.getParameter(usePrecursorMZ).setValue(false);
+
+    return super.showSetupDialog(parent, valueCheckRequired);
+  }
 }

--- a/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectraIdentificationSpectralDatabaseTask.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectraIdentificationSpectralDatabaseTask.java
@@ -98,7 +98,7 @@ class SpectraIdentificationSpectralDatabaseTask extends AbstractTask {
     int count = 0;
 
     // add result frame
-    resultWindow = new SpectraIdentificationResultsWindow(currentScan);
+    resultWindow = new SpectraIdentificationResultsWindow();
     resultWindow.setVisible(true);
 
     try {
@@ -133,7 +133,6 @@ class SpectraIdentificationSpectralDatabaseTask extends AbstractTask {
       setErrorMessage(e.toString());
     }
     logger.info("Added " + count + " spectral library matches");
-    resultWindow.sortTotalMatches(currentScan);
     resultWindow.setTitle("Matched " + count + " compunds for scan#" + currentScan.getScanNumber());
     resultWindow.revalidate();
     resultWindow.repaint();

--- a/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectraIdentificationSpectralDatabaseTask.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectraIdentificationSpectralDatabaseTask.java
@@ -35,6 +35,7 @@ import net.sf.mzmine.taskcontrol.TaskStatus;
 import net.sf.mzmine.util.spectraldb.entry.SpectralDBEntry;
 import net.sf.mzmine.util.spectraldb.parser.AutoLibraryParser;
 import net.sf.mzmine.util.spectraldb.parser.LibraryEntryProcessor;
+import net.sf.mzmine.util.spectraldb.parser.UnsupportedFormatException;
 
 /**
  * Task to compare single spectra with spectral databases
@@ -172,7 +173,7 @@ class SpectraIdentificationSpectralDatabaseTask extends AbstractTask {
         return tasks;
       else
         return new ArrayList<>();
-    } catch (IOException e) {
+    } catch (UnsupportedFormatException | IOException e) {
       logger.log(Level.WARNING, "Library parsing error for file " + dataBaseFile.getAbsolutePath(),
           e);
       return new ArrayList<>();

--- a/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectralMatchTask.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectralMatchTask.java
@@ -210,10 +210,16 @@ public class SpectralMatchTask extends AbstractTask {
         }
 
         String compoundName = match.getKey().getField(DBEntryField.NAME).toString();
+        String shortName = compoundName;
+        // TODO remove or specify more - special naming format?
+        int start = compoundName.indexOf("[");
+        int end = compoundName.indexOf("]");
+        if (start != -1 && start + 1 < compoundName.length() && end != -1
+            && end < compoundName.length())
+          shortName = compoundName.substring(start + 1, end);
+
         DataPointsDataSet detectedCompoundsDataset = new DataPointsDataSet(
-            compoundName.substring(compoundName.indexOf("[") + 1, compoundName.indexOf("]")) + " "
-                + "Score: " + COS_FORM.format(match.getValue()),
-            dataset);
+            shortName + " " + "Score: " + COS_FORM.format(match.getValue()), dataset);
         spectraPlot.addDataSet(detectedCompoundsDataset,
             new Color((int) (Math.random() * 0x1000000)), true);
 

--- a/src/main/java/net/sf/mzmine/util/spectraldb/entry/DBEntryField.java
+++ b/src/main/java/net/sf/mzmine/util/spectraldb/entry/DBEntryField.java
@@ -116,6 +116,7 @@ public enum DBEntryField {
    */
   public static DBEntryField forGnpsJasonID(String key) {
     for (DBEntryField f : values()) {
+      // equalsIgnoreCase is more robust against changes in library consistency
       if (f.getGnpsJsonID().equalsIgnoreCase(key))
         return f;
     }
@@ -201,6 +202,7 @@ public enum DBEntryField {
    */
   public static DBEntryField forMspID(String key) {
     for (DBEntryField f : values()) {
+      // equalsIgnoreCase is more robust against changes in library consistency
       if (f.getNistMspID().equalsIgnoreCase(key))
         return f;
     }
@@ -287,6 +289,7 @@ public enum DBEntryField {
    */
   public static DBEntryField forMgfID(String key) {
     for (DBEntryField f : values()) {
+      // equalsIgnoreCase is more robust against changes in library consistency
       if (f.getMgfID().equalsIgnoreCase(key))
         return f;
     }
@@ -372,6 +375,7 @@ public enum DBEntryField {
    */
   public static DBEntryField forJdxID(String key) {
     for (DBEntryField f : values()) {
+      // equalsIgnoreCase is more robust against changes in library consistency
       if (f.getJdxID().equalsIgnoreCase(key))
         return f;
     }

--- a/src/main/java/net/sf/mzmine/util/spectraldb/entry/DBEntryField.java
+++ b/src/main/java/net/sf/mzmine/util/spectraldb/entry/DBEntryField.java
@@ -250,7 +250,7 @@ public enum DBEntryField {
       case MZ:
         return "PEPMASS";
       case NAME:
-        return "Name";
+        return "NAME";
       case PRINZIPLE_INVESTIGATOR:
         return "PI";
       case PUBMED:

--- a/src/main/java/net/sf/mzmine/util/spectraldb/entry/DBEntryField.java
+++ b/src/main/java/net/sf/mzmine/util/spectraldb/entry/DBEntryField.java
@@ -116,7 +116,7 @@ public enum DBEntryField {
    */
   public static DBEntryField forGnpsJasonID(String key) {
     for (DBEntryField f : values()) {
-      if (f.getGnpsJsonID().equals(key))
+      if (f.getGnpsJsonID().equalsIgnoreCase(key))
         return f;
     }
     return null;
@@ -201,7 +201,7 @@ public enum DBEntryField {
    */
   public static DBEntryField forMspID(String key) {
     for (DBEntryField f : values()) {
-      if (f.getNistMspID().equals(key))
+      if (f.getNistMspID().equalsIgnoreCase(key))
         return f;
     }
     return null;
@@ -287,7 +287,7 @@ public enum DBEntryField {
    */
   public static DBEntryField forMgfID(String key) {
     for (DBEntryField f : values()) {
-      if (f.getMgfID().equals(key))
+      if (f.getMgfID().equalsIgnoreCase(key))
         return f;
     }
     return null;
@@ -372,7 +372,7 @@ public enum DBEntryField {
    */
   public static DBEntryField forJdxID(String key) {
     for (DBEntryField f : values()) {
-      if (f.getJdxID().equals(key))
+      if (f.getJdxID().equalsIgnoreCase(key))
         return f;
     }
     return null;

--- a/src/main/java/net/sf/mzmine/util/spectraldb/entry/DBEntryField.java
+++ b/src/main/java/net/sf/mzmine/util/spectraldb/entry/DBEntryField.java
@@ -209,6 +209,92 @@ public enum DBEntryField {
 
   /**
    *
+   * @return The mgf format (used by GNPS)
+   */
+  public String getMgfID() {
+    switch (this) {
+      case ENTRY_ID:
+        return "SPECTRUMID";
+      case ACQUISITION:
+        return "";
+      case SOFTWARE:
+        return "";
+      case CAS:
+        return "";
+      case CHARGE:
+        return "CHARGE";
+      case COLLISION_ENERGY:
+        return "";
+      case COMMENT:
+        return "ORGANISM";
+      case DATA_COLLECTOR:
+        return "DATACOLLECTOR";
+      case EXACT_MASS:
+        return "ExactMass";
+      case FORMULA:
+        return "Formula";
+      case INCHI:
+        return "INCHI";
+      case INCHIKEY:
+        return "INCHIAUX";
+      case INSTRUMENT:
+        return "SOURCE_INSTRUMENT";
+      case INSTRUMENT_TYPE:
+        return "Instrument_type";
+      case IONTYPE:
+        return "Precursor_type";
+      case ION_MODE:
+        return "IONMODE"; // Positive Negative
+      case ION_SOURCE:
+        return "";
+      case MZ:
+        return "PEPMASS";
+      case NAME:
+        return "Name";
+      case PRINZIPLE_INVESTIGATOR:
+        return "PI";
+      case PUBMED:
+        return "PUBMED";
+      case RT:
+        return "";
+      case SMILES:
+        return "SMILES";
+      case MS_LEVEL:
+        return "MSLEVEL";
+      case PUBCHEM:
+        return "";
+      case CHEMSPIDER:
+        return "";
+      case MONA_ID:
+        return "";
+      case NUM_PEAKS:
+        return "";
+      case RESOLUTION:
+      case SYNONYM:
+      case MOLWEIGHT:
+        return "";
+      // SUBMITUSER
+      // LIBRARYQUALITY
+    }
+    return "";
+  }
+
+  /**
+   * DBENtryField for mgf (GNPS) key
+   * 
+   * @param key
+   * @return
+   */
+  public static DBEntryField forMgfID(String key) {
+    for (DBEntryField f : values()) {
+      if (f.getMgfID().equals(key))
+        return f;
+    }
+    return null;
+  }
+
+  /**
+   *
    * @return The JCAMP-DX format key or an empty String
    */
   public String getJdxID() {

--- a/src/main/java/net/sf/mzmine/util/spectraldb/parser/GnpsMgfParser.java
+++ b/src/main/java/net/sf/mzmine/util/spectraldb/parser/GnpsMgfParser.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2006-2018 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package net.sf.mzmine.util.spectraldb.parser;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import net.sf.mzmine.datamodel.DataPoint;
+import net.sf.mzmine.datamodel.impl.SimpleDataPoint;
+import net.sf.mzmine.taskcontrol.AbstractTask;
+import net.sf.mzmine.util.spectraldb.entry.DBEntryField;
+import net.sf.mzmine.util.spectraldb.entry.SpectralDBEntry;
+
+/**
+ * Main format for library entries in GNPS
+ * 
+ * @author Robin Schmid
+ *
+ */
+public class GnpsMgfParser extends SpectralDBParser {
+
+  public GnpsMgfParser(int bufferEntries, LibraryEntryProcessor processor) {
+    super(bufferEntries, processor);
+  }
+
+  private static Logger logger = Logger.getLogger(GnpsMgfParser.class.getName());
+
+  private enum State {
+    WAIT_FOR_META, META, DATA;
+  }
+
+  @Override
+  public boolean parse(AbstractTask mainTask, File dataBaseFile) throws IOException {
+    logger.info("Parsing mgf spectral library " + dataBaseFile.getAbsolutePath());
+
+    // BEGIN IONS
+    // meta data
+    // SCANS=1 .... n (the scan ID; could be used to put all spectra of the same entry together)
+    // data
+    // END IONS
+
+    int correct = 0;
+    State state = State.WAIT_FOR_META;
+    Map<DBEntryField, Object> fields = new EnumMap<>(DBEntryField.class);
+    List<DataPoint> dps = new ArrayList<>();
+    int sep = -1;
+    // create db
+    try (BufferedReader br = new BufferedReader(new FileReader(dataBaseFile))) {
+      for (String l; (l = br.readLine()) != null;) {
+        // main task was canceled?
+        if (mainTask != null && mainTask.isCanceled()) {
+          return false;
+        }
+        try {
+          if (l.length() > 1) {
+            // meta data start?
+            if (state.equals(State.WAIT_FOR_META)) {
+              if (l.equalsIgnoreCase("BEGIN IONS")) {
+                fields = new EnumMap<>(fields);
+                dps.clear();
+                state = State.META;
+              }
+            } else {
+              if (l.equalsIgnoreCase("END IONS")) {
+                // add entry and reset
+                if (fields.size() > 1 && dps.size() > 1) {
+                  SpectralDBEntry entry =
+                      new SpectralDBEntry(fields, dps.toArray(new DataPoint[dps.size()]));
+                  // add and push
+                  addLibraryEntry(entry);
+                  correct++;
+                }
+                state = State.WAIT_FOR_META;
+              } else if (l.toLowerCase().startsWith("scans")) {
+                // belongs to the previously created entry and is another spectrum
+
+                // data starts
+                state = State.DATA;
+              } else {
+                switch (state) {
+                  case WAIT_FOR_META:
+                    // wait for next entry
+                    break;
+                  case DATA:
+                    String[] data = l.split("\t");
+                    dps.add(new SimpleDataPoint(Double.parseDouble(data[0]),
+                        Double.parseDouble(data[1])));
+                    break;
+                  case META:
+                    sep = l.indexOf('=');
+                    if (sep != -1 && sep < l.length() - 1) {
+                      DBEntryField field = DBEntryField.forMgfID(l.substring(0, sep));
+                      if (field != null) {
+                        String content = l.substring(sep + 1, l.length());
+                        if (!content.isEmpty()) {
+                          try {
+                            Object value = field.convertValue(content);
+                            fields.put(field, value);
+                          } catch (Exception e) {
+                            logger.log(Level.WARNING, "Cannot convert value type of " + content
+                                + " to " + field.getObjectClass().toString(), e);
+                          }
+                        }
+                      }
+                    }
+                    break;
+                }
+              }
+            }
+          }
+        } catch (Exception ex) {
+          logger.log(Level.WARNING, "Error for entry", ex);
+          state = State.WAIT_FOR_META;
+        }
+      }
+      // finish and process all entries
+      finish();
+      return true;
+    }
+  }
+
+}

--- a/src/main/java/net/sf/mzmine/util/spectraldb/parser/GnpsMgfParser.java
+++ b/src/main/java/net/sf/mzmine/util/spectraldb/parser/GnpsMgfParser.java
@@ -118,6 +118,18 @@ public class GnpsMgfParser extends SpectralDBParser {
                         if (!content.isEmpty()) {
                           try {
                             Object value = field.convertValue(content);
+
+                            // name
+                            if (field.equals(DBEntryField.NAME)) {
+                              String name = ((String) value);
+                              int lastSpace = name.lastIndexOf(' ');
+                              if (lastSpace != -1 && lastSpace < name.length() - 2) {
+                                String adductCandidate = name.substring(lastSpace + 1);
+                                
+                                check for valid adduct with the adduct parser from export - use as adduct
+                              }
+                            }
+
                             fields.put(field, value);
                           } catch (Exception e) {
                             logger.log(Level.WARNING, "Cannot convert value type of " + content

--- a/src/main/java/net/sf/mzmine/util/spectraldb/parser/GnpsMgfParser.java
+++ b/src/main/java/net/sf/mzmine/util/spectraldb/parser/GnpsMgfParser.java
@@ -30,6 +30,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import net.sf.mzmine.datamodel.DataPoint;
 import net.sf.mzmine.datamodel.impl.SimpleDataPoint;
+import net.sf.mzmine.modules.peaklistmethods.io.spectraldbsubmit.AdductParser;
 import net.sf.mzmine.taskcontrol.AbstractTask;
 import net.sf.mzmine.util.spectraldb.entry.DBEntryField;
 import net.sf.mzmine.util.spectraldb.entry.SpectralDBEntry;
@@ -125,8 +126,11 @@ public class GnpsMgfParser extends SpectralDBParser {
                               int lastSpace = name.lastIndexOf(' ');
                               if (lastSpace != -1 && lastSpace < name.length() - 2) {
                                 String adductCandidate = name.substring(lastSpace + 1);
-                                
-                                check for valid adduct with the adduct parser from export - use as adduct
+                                // check for valid adduct with the adduct parser from export
+                                // use as adduct
+                                String adduct = AdductParser.parse(adductCandidate);
+                                if (adduct != null && !adduct.isEmpty())
+                                  fields.put(DBEntryField.IONTYPE, adduct);
                               }
                             }
 

--- a/src/main/java/net/sf/mzmine/util/spectraldb/parser/SpectralDBParser.java
+++ b/src/main/java/net/sf/mzmine/util/spectraldb/parser/SpectralDBParser.java
@@ -50,7 +50,8 @@ public abstract class SpectralDBParser {
    * @return the list or an empty list if something went wrong (e.g., wrong format)
    * @throws IOException
    */
-  public abstract boolean parse(AbstractTask mainTask, File dataBaseFile) throws IOException;
+  public abstract boolean parse(AbstractTask mainTask, File dataBaseFile)
+      throws UnsupportedFormatException, IOException;
 
   /**
    * Add DB entry and push every 1000 entries

--- a/src/main/java/net/sf/mzmine/util/spectraldb/parser/UnsupportedFormatException.java
+++ b/src/main/java/net/sf/mzmine/util/spectraldb/parser/UnsupportedFormatException.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2006-2018 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package net.sf.mzmine.util.spectraldb.parser;
+
+public class UnsupportedFormatException extends Exception {
+  private static final long serialVersionUID = 1L;
+
+  public UnsupportedFormatException() {
+    super();
+  }
+
+  public UnsupportedFormatException(String message, Throwable cause, boolean enableSuppression,
+      boolean writableStackTrace) {
+    super(message, cause, enableSuppression, writableStackTrace);
+    // TODO Auto-generated constructor stub
+  }
+
+  public UnsupportedFormatException(String message, Throwable cause) {
+    super(message, cause);
+    // TODO Auto-generated constructor stub
+  }
+
+  public UnsupportedFormatException(String message) {
+    super(message);
+    // TODO Auto-generated constructor stub
+  }
+
+  public UnsupportedFormatException(Throwable cause) {
+    super(cause);
+    // TODO Auto-generated constructor stub
+  }
+
+
+}

--- a/src/main/java/net/sf/mzmine/util/spectraldb/parser/UnsupportedFormatException.java
+++ b/src/main/java/net/sf/mzmine/util/spectraldb/parser/UnsupportedFormatException.java
@@ -28,22 +28,18 @@ public class UnsupportedFormatException extends Exception {
   public UnsupportedFormatException(String message, Throwable cause, boolean enableSuppression,
       boolean writableStackTrace) {
     super(message, cause, enableSuppression, writableStackTrace);
-    // TODO Auto-generated constructor stub
   }
 
   public UnsupportedFormatException(String message, Throwable cause) {
     super(message, cause);
-    // TODO Auto-generated constructor stub
   }
 
   public UnsupportedFormatException(String message) {
     super(message);
-    // TODO Auto-generated constructor stub
   }
 
   public UnsupportedFormatException(Throwable cause) {
     super(cause);
-    // TODO Auto-generated constructor stub
   }
 
 


### PR DESCRIPTION
Hey Tomas,
Hey Ansgar,

@Annexhc please check out my second commit 604b3bb . I think you have been very specific here with the compound name formatting.

- mgf database parser (e.g., GNPS)
- refixed the NIST msp format parser and added some comments/refactored into methods
- Key are now checked with equalsIgnoreCase (to be more flexible)
- Added optional double parameter for precursor m/z in single spectrum local spectral library search
- ResultsWindow is now directly sorted after new entries are added
- Replaced the show DB results option in peaklist visualizer: Mirror chart ---> replaced by ResultsWindow


I have tested the whole thing with different libraries and single spectrum / full peaklist

Cheers
Robin