### PR TITLE
Spectral sim: Error fix, cancel of all tasks, match only overlapping m/z

### DIFF
--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/spectraldbsearch/LocalSpectralDBSearchParameters.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/spectraldbsearch/LocalSpectralDBSearchParameters.java
@@ -56,7 +56,7 @@ public class LocalSpectralDBSearchParameters extends SimpleParameterSet {
           "Removes 13C isotope signals from mass lists", new MassListDeisotoperParameters(), true);
 
   public static final BooleanParameter cropSpectraToOverlap = new BooleanParameter(
-      "Crop spectra to overlap",
+      "Crop spectra to m/z overlap",
       "Crop query and library spectra to overlapping m/z range (+- spectra m/z tolerance). This is helptful if spectra were acquired with different fragmentation energies / methods.",
       true);
 

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/spectraldbsearch/LocalSpectralDBSearchParameters.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/spectraldbsearch/LocalSpectralDBSearchParameters.java
@@ -51,15 +51,16 @@ public class LocalSpectralDBSearchParameters extends SimpleParameterSet {
       "(GNPS json, MONA json, NIST msp, JCAMP-DX jdx) Name of file that contains information for peak identification");
 
   public static final OptionalModuleParameter<MassListDeisotoperParameters> deisotoping =
-      new OptionalModuleParameter<MassListDeisotoperParameters>("13C deisotoping",
+      new OptionalModuleParameter<>("13C deisotoping",
           "Removes 13C isotope signals from mass lists", new MassListDeisotoperParameters(), true);
 
   public static final IntegerParameter msLevel = new IntegerParameter("MS level",
       "Choose the MS level of the scans that should be compared with the database. Enter \"1\" for MS1 scans or \"2\" for MS/MS scans on MS level 2",
       2, 1, 1000);
 
-  public static final MZToleranceParameter mzTolerancePrecursor = new MZToleranceParameter(
-      "Precursor m/z tolerance", "Precursor m/z tolerance is used to filter library entries");
+  public static final MZToleranceParameter mzTolerancePrecursor =
+      new MZToleranceParameter("Precursor m/z tolerance",
+          "Precursor m/z tolerance is used to filter library entries", 0.001, 5);
 
   public static final MassListParameter massList =
       new MassListParameter("MassList", "MassList for either MS1 or MS/MS scans to match");
@@ -67,9 +68,10 @@ public class LocalSpectralDBSearchParameters extends SimpleParameterSet {
   public static final OptionalParameter<RTToleranceParameter> rtTolerance =
       new OptionalParameter<>(new RTToleranceParameter());
 
-  public static final MZToleranceParameter mzTolerance =
-      new MZToleranceParameter("Spectral m/z tolerance",
-          "Spectral m/z tolerance is used to match all signals in the query and library spectra");
+  public static final MZToleranceParameter mzTolerance = new MZToleranceParameter(
+      "Spectral m/z tolerance",
+      "Spectral m/z tolerance is used to match all signals in the query and library spectra (usually higher than precursor m/z tolerance)",
+      0.0015, 10);
 
   public static final DoubleParameter noiseLevel = new DoubleParameter("Minimum ion intensity",
       "Signals below this level will be filtered away from mass lists",

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/spectraldbsearch/LocalSpectralDBSearchParameters.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/spectraldbsearch/LocalSpectralDBSearchParameters.java
@@ -26,6 +26,7 @@ import net.sf.mzmine.modules.visualization.spectra.simplespectra.datapointproces
 import net.sf.mzmine.parameters.Parameter;
 import net.sf.mzmine.parameters.dialogs.ParameterSetupDialog;
 import net.sf.mzmine.parameters.impl.SimpleParameterSet;
+import net.sf.mzmine.parameters.parametertypes.BooleanParameter;
 import net.sf.mzmine.parameters.parametertypes.DoubleParameter;
 import net.sf.mzmine.parameters.parametertypes.IntegerComponent;
 import net.sf.mzmine.parameters.parametertypes.IntegerParameter;
@@ -53,6 +54,11 @@ public class LocalSpectralDBSearchParameters extends SimpleParameterSet {
   public static final OptionalModuleParameter<MassListDeisotoperParameters> deisotoping =
       new OptionalModuleParameter<>("13C deisotoping",
           "Removes 13C isotope signals from mass lists", new MassListDeisotoperParameters(), true);
+
+  public static final BooleanParameter cropSpectraToOverlap = new BooleanParameter(
+      "Crop spectra to overlap",
+      "Crop query and library spectra to overlapping m/z range (+- spectra m/z tolerance). This is helptful if spectra were acquired with different fragmentation energies / methods.",
+      true);
 
   public static final IntegerParameter msLevel = new IntegerParameter("MS level",
       "Choose the MS level of the scans that should be compared with the database. Enter \"1\" for MS1 scans or \"2\" for MS/MS scans on MS level 2",
@@ -86,9 +92,11 @@ public class LocalSpectralDBSearchParameters extends SimpleParameterSet {
           "Algorithm to calculate similarity and filter matches",
           SpectralSimilarityFunction.FUNCTIONS);
 
+
   public LocalSpectralDBSearchParameters() {
     super(new Parameter[] {peakLists, massList, dataBaseFile, msLevel, mzTolerancePrecursor,
-        noiseLevel, deisotoping, mzTolerance, rtTolerance, minMatch, similarityFunction});
+        noiseLevel, deisotoping, cropSpectraToOverlap, mzTolerance, rtTolerance, minMatch,
+        similarityFunction});
   }
 
   @Override

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/spectraldbsearch/LocalSpectralDBSearchTask.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/spectraldbsearch/LocalSpectralDBSearchTask.java
@@ -104,6 +104,10 @@ class LocalSpectralDBSearchTask extends AbstractTask {
             cancel();
           }
         }
+        // cancelled
+        if (isCanceled()) {
+          tasks.stream().forEach(AbstractTask::cancel);
+        }
       } else {
         setStatus(TaskStatus.ERROR);
         setErrorMessage("DB file was empty - or error while parsing " + dataBaseFile);
@@ -150,10 +154,8 @@ class LocalSpectralDBSearchTask extends AbstractTask {
     });
 
     // return tasks
-    if (parser.parse(this, dataBaseFile))
-      return tasks;
-    else
-      return new ArrayList<>();
+    parser.parse(this, dataBaseFile);
+    return tasks;
   }
 
 }

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/spectraldbsearch/PeakListSpectralMatchTask.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/spectraldbsearch/PeakListSpectralMatchTask.java
@@ -145,6 +145,11 @@ public class PeakListSpectralMatchTask extends AbstractTask {
   public void run() {
     setStatus(TaskStatus.PROCESSING);
     for (PeakListRow row : peakList.getRows()) {
+      if (isCanceled()) {
+        logger.info("Added " + count + " spectral library matches (before being cancelled)");
+        repaintWindow();
+        return;
+      }
 
       // check for MS1 or MSMS scan
       Scan scan;
@@ -193,12 +198,16 @@ public class PeakListSpectralMatchTask extends AbstractTask {
       logger.info("Added " + count + " spectral library matches");
 
     // Repaint the window to reflect the change in the peak list
-    Desktop desktop = MZmineCore.getDesktop();
-    if (!(desktop instanceof HeadLessDesktop))
-      desktop.getMainWindow().repaint();
+    repaintWindow();
 
     list = null;
     setStatus(TaskStatus.FINISHED);
+  }
+
+  private void repaintWindow() {
+    Desktop desktop = MZmineCore.getDesktop();
+    if (!(desktop instanceof HeadLessDesktop))
+      desktop.getMainWindow().repaint();
   }
 
   /**

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/spectraldbsearch/help/help.html
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/spectraldbsearch/help/help.html
@@ -34,6 +34,8 @@ Run on any feature list to match all rows against a local spectral library (form
 <dt>13C deisotoping </dt>
 	<dd>Deletes 13C isotope signals in the query and library mass spectra</dd>	
 	<dd>Monotonic shape: Especially, for small molecules. 13C isotope pattern with first signal as the most abundant</dd>	
+<dt>Crop spectra to m/z overlap </dt>
+	<dd>Only match signals that fall within the overlapping m/z range of both spectra (bounds are expanded by spectral m/z tolerance))</dd>	
 <dt>Spectral m/z tolerance </dt>
 	<dd>Tolerance to match signals in the two spectra (library and query) </dd>	
 <dt>Retention time tolerance</dt>

--- a/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectraIdentificationSpectralDatabaseParameters.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectraIdentificationSpectralDatabaseParameters.java
@@ -26,6 +26,7 @@ import net.sf.mzmine.modules.visualization.spectra.simplespectra.datapointproces
 import net.sf.mzmine.parameters.Parameter;
 import net.sf.mzmine.parameters.dialogs.ParameterSetupDialog;
 import net.sf.mzmine.parameters.impl.SimpleParameterSet;
+import net.sf.mzmine.parameters.parametertypes.BooleanParameter;
 import net.sf.mzmine.parameters.parametertypes.DoubleParameter;
 import net.sf.mzmine.parameters.parametertypes.IntegerParameter;
 import net.sf.mzmine.parameters.parametertypes.MassListParameter;
@@ -75,6 +76,11 @@ public class SpectraIdentificationSpectralDatabaseParameters extends SimpleParam
       new OptionalModuleParameter<>("13C deisotoping",
           "Removes 13C isotope signals from mass lists", new MassListDeisotoperParameters(), true);
 
+  public static final BooleanParameter cropSpectraToOverlap = new BooleanParameter(
+      "Crop spectra to overlap",
+      "Crop query and library spectra to overlapping m/z range (+- spectra m/z tolerance). This is helptful if spectra were acquired with different fragmentation energies / methods.",
+      true);
+
   public static final ModuleComboParameter<SpectralSimilarityFunction> similarityFunction =
       new ModuleComboParameter<>("Similarity",
           "Algorithm to calculate similarity and filter matches",
@@ -82,7 +88,7 @@ public class SpectraIdentificationSpectralDatabaseParameters extends SimpleParam
 
   public SpectraIdentificationSpectralDatabaseParameters() {
     super(new Parameter[] {massList, dataBaseFile, usePrecursorMZ, mzTolerancePrecursor, noiseLevel,
-        deisotoping, mzTolerance, minMatch, similarityFunction});
+        deisotoping, cropSpectraToOverlap, mzTolerance, minMatch, similarityFunction});
   }
 
 

--- a/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectraIdentificationSpectralDatabaseParameters.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectraIdentificationSpectralDatabaseParameters.java
@@ -77,7 +77,7 @@ public class SpectraIdentificationSpectralDatabaseParameters extends SimpleParam
           "Removes 13C isotope signals from mass lists", new MassListDeisotoperParameters(), true);
 
   public static final BooleanParameter cropSpectraToOverlap = new BooleanParameter(
-      "Crop spectra to overlap",
+      "Crop spectra to m/z overlap",
       "Crop query and library spectra to overlapping m/z range (+- spectra m/z tolerance). This is helptful if spectra were acquired with different fragmentation energies / methods.",
       true);
 

--- a/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectraIdentificationSpectralDatabaseParameters.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectraIdentificationSpectralDatabaseParameters.java
@@ -31,8 +31,8 @@ import net.sf.mzmine.parameters.parametertypes.IntegerParameter;
 import net.sf.mzmine.parameters.parametertypes.MassListParameter;
 import net.sf.mzmine.parameters.parametertypes.ModuleComboParameter;
 import net.sf.mzmine.parameters.parametertypes.OptionalParameter;
+import net.sf.mzmine.parameters.parametertypes.OptionalParameterComponent;
 import net.sf.mzmine.parameters.parametertypes.filenames.FileNameParameter;
-import net.sf.mzmine.parameters.parametertypes.submodules.OptionalModuleComponent;
 import net.sf.mzmine.parameters.parametertypes.submodules.OptionalModuleParameter;
 import net.sf.mzmine.parameters.parametertypes.tolerances.MZToleranceParameter;
 import net.sf.mzmine.util.ExitCode;
@@ -50,14 +50,18 @@ public class SpectraIdentificationSpectralDatabaseParameters extends SimpleParam
 
   public static final MassListParameter massList = new MassListParameter();
 
-  public static final MZToleranceParameter mzTolerance = new MZToleranceParameter();
+  public static final MZToleranceParameter mzTolerance = new MZToleranceParameter(
+      "Spectral m/z tolerance",
+      "Tolerance to match spectral signals in the query and library spectra (usually higher than precursor m/z tolerance (if used))",
+      0.0015, 10);
 
   public static final OptionalParameter<DoubleParameter> usePrecursorMZ =
       new OptionalParameter<>(new DoubleParameter("Use precursor m/z",
           "Use precursor m/z as a filter. Precursor m/z of library entry and this scan need to be within m/z tolerance. Entries without precursor m/z are skipped.",
           MZmineCore.getConfiguration().getMZFormat(), 0d));
-  public static final MZToleranceParameter mzTolerancePrecursor = new MZToleranceParameter(
-      "Precursor m/z tolerance", "Precursor m/z tolerance is used to filter library entries");
+  public static final MZToleranceParameter mzTolerancePrecursor =
+      new MZToleranceParameter("Precursor m/z tolerance",
+          "Precursor m/z tolerance is used to filter library entries", 0.001, 5);
 
   public static final DoubleParameter noiseLevel = new DoubleParameter("Minimum ion intensity",
       "Signals below this level will be filtered away from mass lists",
@@ -68,7 +72,7 @@ public class SpectraIdentificationSpectralDatabaseParameters extends SimpleParam
       20);
 
   public static final OptionalModuleParameter<MassListDeisotoperParameters> deisotoping =
-      new OptionalModuleParameter<MassListDeisotoperParameters>("13C deisotoping",
+      new OptionalModuleParameter<>("13C deisotoping",
           "Removes 13C isotope signals from mass lists", new MassListDeisotoperParameters(), true);
 
   public static final ModuleComboParameter<SpectralSimilarityFunction> similarityFunction =
@@ -90,8 +94,8 @@ public class SpectraIdentificationSpectralDatabaseParameters extends SimpleParam
     ParameterSetupDialog dialog = new ParameterSetupDialog(parent, valueCheckRequired, this);
 
     // only enable precursor mz tolerance if precursor mz is used
-    OptionalModuleComponent usePreComp =
-        (OptionalModuleComponent) dialog.getComponentForParameter(usePrecursorMZ);
+    OptionalParameterComponent usePreComp =
+        (OptionalParameterComponent) dialog.getComponentForParameter(usePrecursorMZ);
     JComponent mzTolPrecursor = dialog.getComponentForParameter(mzTolerancePrecursor);
     mzTolPrecursor.setEnabled(getParameter(usePrecursorMZ).getValue());
     usePreComp.addItemListener(e -> {

--- a/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectraIdentificationSpectralDatabaseTask.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectraIdentificationSpectralDatabaseTask.java
@@ -121,6 +121,10 @@ class SpectraIdentificationSpectralDatabaseTask extends AbstractTask {
             cancel();
           }
         }
+        // cancelled
+        if (isCanceled()) {
+          tasks.stream().forEach(AbstractTask::cancel);
+        }
       } else {
         setStatus(TaskStatus.ERROR);
         setErrorMessage("DB file was empty - or error while parsing " + dataBaseFile);
@@ -168,10 +172,8 @@ class SpectraIdentificationSpectralDatabaseTask extends AbstractTask {
     // return tasks
     try {
       // parse and create spectral matching tasks for batches of entries
-      if (parser.parse(this, dataBaseFile))
-        return tasks;
-      else
-        return new ArrayList<>();
+      parser.parse(this, dataBaseFile);
+      return tasks;
     } catch (UnsupportedFormatException | IOException e) {
       logger.log(Level.WARNING, "Library parsing error for file " + dataBaseFile.getAbsolutePath(),
           e);

--- a/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectralMatchTask.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectralMatchTask.java
@@ -178,6 +178,12 @@ public class SpectralMatchTask extends AbstractTask {
       totalSteps = list.size();
       matches = new ArrayList<>();
       for (SpectralDBEntry ident : list) {
+        if (isCanceled()) {
+          logger.info("Added " + count + " spectral library matches (before being cancelled)");
+          repaintWindow();
+          return;
+        }
+
         SpectraSimilarity sim = spectraDBMatch(spectraMassList, ident);
         if (sim != null) {
           count++;
@@ -206,12 +212,16 @@ public class SpectralMatchTask extends AbstractTask {
     }
 
     // Repaint the window to reflect the change in the peak list
-    Desktop desktop = MZmineCore.getDesktop();
-    if (!(desktop instanceof HeadLessDesktop))
-      desktop.getMainWindow().repaint();
+    repaintWindow();
 
     list = null;
     setStatus(TaskStatus.FINISHED);
+  }
+
+  private void repaintWindow() {
+    Desktop desktop = MZmineCore.getDesktop();
+    if (!(desktop instanceof HeadLessDesktop))
+      desktop.getMainWindow().repaint();
   }
 
   /**

--- a/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectralMatchTask.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectralMatchTask.java
@@ -110,11 +110,10 @@ public class SpectralMatchTask extends AbstractTask {
         .getValue();
     mzToleranceSpectra = parameters
         .getParameter(SpectraIdentificationSpectralDatabaseParameters.mzTolerance).getValue();
-    if (usePrecursorMZ)
-      mzTolerancePrecursor = parameters
-          .getParameter(SpectraIdentificationSpectralDatabaseParameters.mzTolerance).getValue();
-    else
-      mzTolerancePrecursor = null;
+    mzTolerancePrecursor = parameters
+        .getParameter(SpectraIdentificationSpectralDatabaseParameters.mzTolerancePrecursor)
+        .getValue();
+
     noiseLevel = parameters.getParameter(SpectraIdentificationSpectralDatabaseParameters.noiseLevel)
         .getValue();
 

--- a/src/main/java/net/sf/mzmine/parameters/parametertypes/OptionalParameterComponent.java
+++ b/src/main/java/net/sf/mzmine/parameters/parametertypes/OptionalParameterComponent.java
@@ -21,6 +21,7 @@ package net.sf.mzmine.parameters.parametertypes;
 import java.awt.FlowLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.ItemListener;
 import javax.swing.JCheckBox;
 import javax.swing.JComponent;
 import javax.swing.JPanel;
@@ -59,6 +60,7 @@ public class OptionalParameterComponent<EmbeddedComponent extends JComponent> ex
     embeddedComponent.setEnabled(selected);
   }
 
+  @Override
   public void actionPerformed(ActionEvent event) {
     Object src = event.getSource();
 
@@ -71,5 +73,9 @@ public class OptionalParameterComponent<EmbeddedComponent extends JComponent> ex
   @Override
   public void setToolTipText(String toolTip) {
     checkBox.setToolTipText(toolTip);
+  }
+
+  public void addItemListener(ItemListener il) {
+    checkBox.addItemListener(il);
   }
 }

--- a/src/main/java/net/sf/mzmine/parameters/parametertypes/tolerances/MZToleranceParameter.java
+++ b/src/main/java/net/sf/mzmine/parameters/parametertypes/tolerances/MZToleranceParameter.java
@@ -19,12 +19,10 @@
 package net.sf.mzmine.parameters.parametertypes.tolerances;
 
 import java.util.Collection;
-
-import net.sf.mzmine.parameters.UserParameter;
-
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
+import net.sf.mzmine.parameters.UserParameter;
 
 public class MZToleranceParameter implements UserParameter<MZTolerance, MZToleranceComponent> {
 
@@ -41,6 +39,12 @@ public class MZToleranceParameter implements UserParameter<MZTolerance, MZTolera
   public MZToleranceParameter(String name, String description) {
     this.name = name;
     this.description = description;
+  }
+
+  public MZToleranceParameter(String name, String description, double deltaMZ, double ppm) {
+    this.name = name;
+    this.description = description;
+    value = new MZTolerance(deltaMZ, ppm);
   }
 
   @Override

--- a/src/main/java/net/sf/mzmine/util/spectraldb/parser/AutoLibraryParser.java
+++ b/src/main/java/net/sf/mzmine/util/spectraldb/parser/AutoLibraryParser.java
@@ -48,9 +48,11 @@ public class AutoLibraryParser extends SpectralDBParser {
     if (json.accept(dataBaseFile)) {
       // test Gnps and MONA json parser
       SpectralDBParser[] parser =
-          new SpectralDBParser[] {new GnpsJsonParser(bufferEntries, processor),
-              new MonaJsonParser(bufferEntries, processor)};
+          new SpectralDBParser[] {new MonaJsonParser(bufferEntries, processor),
+              new GnpsJsonParser(bufferEntries, processor)};
       for (SpectralDBParser p : parser) {
+        if (mainTask.isCanceled())
+          return false;
         try {
           boolean state = p.parse(mainTask, dataBaseFile);
           if (state)
@@ -82,9 +84,11 @@ public class AutoLibraryParser extends SpectralDBParser {
       if (state)
         return state;
     }
-
-    throw (new UnsupportedFormatException(
-        "Format not supported: " + dataBaseFile.getAbsolutePath()));
+    if (mainTask.isCanceled())
+      return false;
+    else
+      throw (new UnsupportedFormatException(
+          "Format not supported: " + dataBaseFile.getAbsolutePath()));
   }
 
 }


### PR DESCRIPTION
Hey Tomas,

A first small PR. 

 - fixed error in single spectra matching task
 - If main task is cancelled - all tasks are
 - Option to limit the library matching to the overlapping m/z range only
    - query spectrum (200 - 1000 m/z) and library spectrum (50 - 800 m/z) --> they will only be matched within 200-800 m/z (with the specified m/z tolerance applied to both ends) 

Still working on some things for the library submission and results visualisation.

Cheers
Robin