### PR TITLE
Spectral match results changes

### DIFF
--- a/src/main/java/net/sf/mzmine/chartbasics/listener/AxisRangeChangedListener.java
+++ b/src/main/java/net/sf/mzmine/chartbasics/listener/AxisRangeChangedListener.java
@@ -18,6 +18,7 @@
 
 package net.sf.mzmine.chartbasics.listener;
 
+import javax.annotation.Nullable;
 import org.jfree.chart.axis.ValueAxis;
 import org.jfree.chart.event.AxisChangeEvent;
 import org.jfree.chart.event.AxisChangeListener;
@@ -30,7 +31,7 @@ public abstract class AxisRangeChangedListener implements AxisChangeListener {
   private Range lastRange = null;
   private ChartViewWrapper chart;
 
-  public AxisRangeChangedListener(ChartViewWrapper cp) {
+  public AxisRangeChangedListener(@Nullable ChartViewWrapper cp) {
     chart = cp;
   }
 
@@ -49,10 +50,11 @@ public abstract class AxisRangeChangedListener implements AxisChangeListener {
   /**
    * only if axis range has changed
    * 
+   * @param chart (null if no chart was defined when this listener was created)
    * @param axis
    * @param lastR
    * @param newR
    */
-  public abstract void axisRangeChanged(ChartViewWrapper chart, ValueAxis axis, Range lastR,
-      Range newR);
+  public abstract void axisRangeChanged(@Nullable ChartViewWrapper chart, ValueAxis axis,
+      Range lastR, Range newR);
 }

--- a/src/main/java/net/sf/mzmine/framework/CustomTextPane.java
+++ b/src/main/java/net/sf/mzmine/framework/CustomTextPane.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2006-2018 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package net.sf.mzmine.framework;
+
+import java.awt.Container;
+import javax.swing.JTextPane;
+import javax.swing.SwingUtilities;
+import javax.swing.text.AbstractDocument;
+import javax.swing.text.BoxView;
+import javax.swing.text.ComponentView;
+import javax.swing.text.Element;
+import javax.swing.text.IconView;
+import javax.swing.text.LabelView;
+import javax.swing.text.ParagraphView;
+import javax.swing.text.StyleConstants;
+import javax.swing.text.StyledEditorKit;
+import javax.swing.text.View;
+import javax.swing.text.ViewFactory;
+
+public class CustomTextPane extends JTextPane {
+  private boolean lineWrap;
+
+  public CustomTextPane(final boolean lineWrap) {
+    this.lineWrap = lineWrap;
+
+    if (lineWrap)
+      setEditorKit(new WrapEditorKit());
+  }
+
+  @Override
+  public boolean getScrollableTracksViewportWidth() {
+    if (lineWrap)
+      return super.getScrollableTracksViewportWidth();
+    else {
+      Container parent = SwingUtilities.getUnwrappedParent(this);
+      return parent == null || getUI().getPreferredSize(this).width <= parent.getSize().width;
+    }
+  }
+
+  private class WrapEditorKit extends StyledEditorKit {
+    private final ViewFactory defaultFactory = new WrapColumnFactory();
+
+    @Override
+    public ViewFactory getViewFactory() {
+      return defaultFactory;
+    }
+  }
+
+  private class WrapColumnFactory implements ViewFactory {
+    @Override
+    public View create(final Element element) {
+      final String kind = element.getName();
+      if (kind != null) {
+        switch (kind) {
+          case AbstractDocument.ContentElementName:
+            return new WrapLabelView(element);
+          case AbstractDocument.ParagraphElementName:
+            return new ParagraphView(element);
+          case AbstractDocument.SectionElementName:
+            return new BoxView(element, View.Y_AXIS);
+          case StyleConstants.ComponentElementName:
+            return new ComponentView(element);
+          case StyleConstants.IconElementName:
+            return new IconView(element);
+        }
+      }
+
+      // Default to text display.
+      return new LabelView(element);
+    }
+  }
+
+  private class WrapLabelView extends LabelView {
+    public WrapLabelView(final Element element) {
+      super(element);
+    }
+
+    @Override
+    public float getMinimumSpan(final int axis) {
+      switch (axis) {
+        case View.X_AXIS:
+          return 0;
+        case View.Y_AXIS:
+          return super.getMinimumSpan(axis);
+        default:
+          throw new IllegalArgumentException("Invalid axis: " + axis);
+      }
+    }
+  }
+}

--- a/src/main/java/net/sf/mzmine/framework/ScrollablePanel.java
+++ b/src/main/java/net/sf/mzmine/framework/ScrollablePanel.java
@@ -1,0 +1,326 @@
+/*
+ * Copyright 2006-2018 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package net.sf.mzmine.framework;
+
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.LayoutManager;
+import java.awt.Rectangle;
+import javax.swing.JPanel;
+import javax.swing.JViewport;
+import javax.swing.Scrollable;
+import javax.swing.SwingConstants;
+
+/**
+ * A panel that implements the Scrollable interface. This class allows you to customize the
+ * scrollable features by using newly provided setter methods so you don't have to extend this class
+ * every time.
+ *
+ * Scrollable amounts can be specifed as a percentage of the viewport size or as an actual pixel
+ * value. The amount can be changed for both unit and block scrolling for both horizontal and
+ * vertical scrollbars.
+ *
+ * The Scrollable interface only provides a boolean value for determining whether or not the
+ * viewport size (width or height) should be used by the scrollpane when determining if scrollbars
+ * should be made visible. This class supports the concept of dynamically changing this value based
+ * on the size of the viewport. In this case the viewport size will only be used when it is larger
+ * than the panels size. This has the effect of ensuring the viewport is always full as components
+ * added to the panel will be size to fill the area available, based on the rules of the applicable
+ * layout manager of course.
+ */
+public class ScrollablePanel extends JPanel implements Scrollable, SwingConstants {
+  public enum ScrollableSizeHint {
+    NONE, FIT, STRETCH;
+  }
+
+  public enum IncrementType {
+    PERCENT, PIXELS;
+  }
+
+  private ScrollableSizeHint scrollableHeight = ScrollableSizeHint.NONE;
+  private ScrollableSizeHint scrollableWidth = ScrollableSizeHint.NONE;
+
+  private IncrementInfo horizontalBlock;
+  private IncrementInfo horizontalUnit;
+  private IncrementInfo verticalBlock;
+  private IncrementInfo verticalUnit;
+
+  /**
+   * Default constructor that uses a FlowLayout
+   */
+  public ScrollablePanel() {
+    this(new FlowLayout());
+  }
+
+  /**
+   * Constuctor for specifying the LayoutManager of the panel.
+   *
+   * @param layout the LayountManger for the panel
+   */
+  public ScrollablePanel(LayoutManager layout) {
+    super(layout);
+
+    IncrementInfo block = new IncrementInfo(IncrementType.PERCENT, 100);
+    IncrementInfo unit = new IncrementInfo(IncrementType.PERCENT, 10);
+
+    setScrollableBlockIncrement(HORIZONTAL, block);
+    setScrollableBlockIncrement(VERTICAL, block);
+    setScrollableUnitIncrement(HORIZONTAL, unit);
+    setScrollableUnitIncrement(VERTICAL, unit);
+  }
+
+  /**
+   * Get the height ScrollableSizeHint enum
+   *
+   * @return the ScrollableSizeHint enum for the height
+   */
+  public ScrollableSizeHint getScrollableHeight() {
+    return scrollableHeight;
+  }
+
+  /**
+   * Set the ScrollableSizeHint enum for the height. The enum is used to determine the boolean value
+   * that is returned by the getScrollableTracksViewportHeight() method. The valid values are:
+   *
+   * ScrollableSizeHint.NONE - return "false", which causes the height of the panel to be used when
+   * laying out the children ScrollableSizeHint.FIT - return "true", which causes the height of the
+   * viewport to be used when laying out the children ScrollableSizeHint.STRETCH - return "true"
+   * when the viewport height is greater than the height of the panel, "false" otherwise.
+   *
+   * @param scrollableHeight as represented by the ScrollableSizeHint enum.
+   */
+  public void setScrollableHeight(ScrollableSizeHint scrollableHeight) {
+    this.scrollableHeight = scrollableHeight;
+    revalidate();
+  }
+
+  /**
+   * Get the width ScrollableSizeHint enum
+   *
+   * @return the ScrollableSizeHint enum for the width
+   */
+  public ScrollableSizeHint getScrollableWidth() {
+    return scrollableWidth;
+  }
+
+  /**
+   * Set the ScrollableSizeHint enum for the width. The enum is used to determine the boolean value
+   * that is returned by the getScrollableTracksViewportWidth() method. The valid values are:
+   *
+   * ScrollableSizeHint.NONE - return "false", which causes the width of the panel to be used when
+   * laying out the children ScrollableSizeHint.FIT - return "true", which causes the width of the
+   * viewport to be used when laying out the children ScrollableSizeHint.STRETCH - return "true"
+   * when the viewport width is greater than the width of the panel, "false" otherwise.
+   *
+   * @param scrollableWidth as represented by the ScrollableSizeHint enum.
+   */
+  public void setScrollableWidth(ScrollableSizeHint scrollableWidth) {
+    this.scrollableWidth = scrollableWidth;
+    revalidate();
+  }
+
+  /**
+   * Get the block IncrementInfo for the specified orientation
+   *
+   * @return the block IncrementInfo for the specified orientation
+   */
+  public IncrementInfo getScrollableBlockIncrement(int orientation) {
+    return orientation == SwingConstants.HORIZONTAL ? horizontalBlock : verticalBlock;
+  }
+
+  /**
+   * Specify the information needed to do block scrolling.
+   *
+   * @param orientation specify the scrolling orientation. Must be either: SwingContants.HORIZONTAL
+   *        or SwingContants.VERTICAL.
+   * @paran type specify how the amount parameter in the calculation of the scrollable amount. Valid
+   *        values are: IncrementType.PERCENT - treat the amount as a % of the viewport size
+   *        IncrementType.PIXEL - treat the amount as the scrollable amount
+   * @param amount a value used with the IncrementType to determine the scrollable amount
+   */
+  public void setScrollableBlockIncrement(int orientation, IncrementType type, int amount) {
+    IncrementInfo info = new IncrementInfo(type, amount);
+    setScrollableBlockIncrement(orientation, info);
+  }
+
+  /**
+   * Specify the information needed to do block scrolling.
+   *
+   * @param orientation specify the scrolling orientation. Must be either: SwingContants.HORIZONTAL
+   *        or SwingContants.VERTICAL.
+   * @param info An IncrementInfo object containing information of how to calculate the scrollable
+   *        amount.
+   */
+  public void setScrollableBlockIncrement(int orientation, IncrementInfo info) {
+    switch (orientation) {
+      case SwingConstants.HORIZONTAL:
+        horizontalBlock = info;
+        break;
+      case SwingConstants.VERTICAL:
+        verticalBlock = info;
+        break;
+      default:
+        throw new IllegalArgumentException("Invalid orientation: " + orientation);
+    }
+  }
+
+  /**
+   * Get the unit IncrementInfo for the specified orientation
+   *
+   * @return the unit IncrementInfo for the specified orientation
+   */
+  public IncrementInfo getScrollableUnitIncrement(int orientation) {
+    return orientation == SwingConstants.HORIZONTAL ? horizontalUnit : verticalUnit;
+  }
+
+  /**
+   * Specify the information needed to do unit scrolling.
+   *
+   * @param orientation specify the scrolling orientation. Must be either: SwingContants.HORIZONTAL
+   *        or SwingContants.VERTICAL.
+   * @paran type specify how the amount parameter in the calculation of the scrollable amount. Valid
+   *        values are: IncrementType.PERCENT - treat the amount as a % of the viewport size
+   *        IncrementType.PIXEL - treat the amount as the scrollable amount
+   * @param amount a value used with the IncrementType to determine the scrollable amount
+   */
+  public void setScrollableUnitIncrement(int orientation, IncrementType type, int amount) {
+    IncrementInfo info = new IncrementInfo(type, amount);
+    setScrollableUnitIncrement(orientation, info);
+  }
+
+  /**
+   * Specify the information needed to do unit scrolling.
+   *
+   * @param orientation specify the scrolling orientation. Must be either: SwingContants.HORIZONTAL
+   *        or SwingContants.VERTICAL.
+   * @param info An IncrementInfo object containing information of how to calculate the scrollable
+   *        amount.
+   */
+  public void setScrollableUnitIncrement(int orientation, IncrementInfo info) {
+    switch (orientation) {
+      case SwingConstants.HORIZONTAL:
+        horizontalUnit = info;
+        break;
+      case SwingConstants.VERTICAL:
+        verticalUnit = info;
+        break;
+      default:
+        throw new IllegalArgumentException("Invalid orientation: " + orientation);
+    }
+  }
+
+  // Implement Scrollable interface
+
+  @Override
+  public Dimension getPreferredScrollableViewportSize() {
+    return getPreferredSize();
+  }
+
+  @Override
+  public int getScrollableUnitIncrement(Rectangle visible, int orientation, int direction) {
+    switch (orientation) {
+      case SwingConstants.HORIZONTAL:
+        return getScrollableIncrement(horizontalUnit, visible.width);
+      case SwingConstants.VERTICAL:
+        return getScrollableIncrement(verticalUnit, visible.height);
+      default:
+        throw new IllegalArgumentException("Invalid orientation: " + orientation);
+    }
+  }
+
+  @Override
+  public int getScrollableBlockIncrement(Rectangle visible, int orientation, int direction) {
+    switch (orientation) {
+      case SwingConstants.HORIZONTAL:
+        return getScrollableIncrement(horizontalBlock, visible.width);
+      case SwingConstants.VERTICAL:
+        return getScrollableIncrement(verticalBlock, visible.height);
+      default:
+        throw new IllegalArgumentException("Invalid orientation: " + orientation);
+    }
+  }
+
+  protected int getScrollableIncrement(IncrementInfo info, int distance) {
+    if (info.getIncrement() == IncrementType.PIXELS)
+      return info.getAmount();
+    else
+      return distance * info.getAmount() / 100;
+  }
+
+  @Override
+  public boolean getScrollableTracksViewportWidth() {
+    if (scrollableWidth == ScrollableSizeHint.NONE)
+      return false;
+
+    if (scrollableWidth == ScrollableSizeHint.FIT)
+      return true;
+
+    // STRETCH sizing, use the greater of the panel or viewport width
+
+    if (getParent() instanceof JViewport) {
+      return (((JViewport) getParent()).getWidth() > getPreferredSize().width);
+    }
+
+    return false;
+  }
+
+  @Override
+  public boolean getScrollableTracksViewportHeight() {
+    if (scrollableHeight == ScrollableSizeHint.NONE)
+      return false;
+
+    if (scrollableHeight == ScrollableSizeHint.FIT)
+      return true;
+
+    // STRETCH sizing, use the greater of the panel or viewport height
+
+
+    if (getParent() instanceof JViewport) {
+      return (((JViewport) getParent()).getHeight() > getPreferredSize().height);
+    }
+
+    return false;
+  }
+
+  /**
+   * Helper class to hold the information required to calculate the scroll amount.
+   */
+  static class IncrementInfo {
+    private IncrementType type;
+    private int amount;
+
+    public IncrementInfo(IncrementType type, int amount) {
+      this.type = type;
+      this.amount = amount;
+    }
+
+    public IncrementType getIncrement() {
+      return type;
+    }
+
+    public int getAmount() {
+      return amount;
+    }
+
+    @Override
+    public String toString() {
+      return "ScrollablePanel[" + type + ", " + amount + "]";
+    }
+  }
+}

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/spectraldbsearch/LocalSpectralDBSearchTask.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/spectraldbsearch/LocalSpectralDBSearchTask.java
@@ -142,7 +142,7 @@ class LocalSpectralDBSearchTask extends AbstractTask {
       throws UnsupportedFormatException, IOException {
     //
     List<PeakListSpectralMatchTask> tasks = new ArrayList<>();
-    AutoLibraryParser parser = new AutoLibraryParser(1000, new LibraryEntryProcessor() {
+    AutoLibraryParser parser = new AutoLibraryParser(100, new LibraryEntryProcessor() {
       @Override
       public void processNextEntries(List<SpectralDBEntry> list, int alreadyProcessed) {
         // start last task

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/spectraldbsubmit/formats/GnpsJsonGenerator.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/spectraldbsubmit/formats/GnpsJsonGenerator.java
@@ -75,7 +75,7 @@ public class GnpsJsonGenerator {
 
     String adduct = param.getParameter(LibrarySubmitIonParameters.ADDUCT).getValue();
     if (adduct != null && !adduct.trim().isEmpty())
-      json.add(DBEntryField.IONTYPE.getGnpsJsonID(), adduct);
+      json.add(DBEntryField.ION_TYPE.getGnpsJsonID(), adduct);
 
     if (exportRT) {
       Double rt =

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/spectraldbsubmit/formats/MSPEntryGenerator.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/spectraldbsubmit/formats/MSPEntryGenerator.java
@@ -89,7 +89,7 @@ public class MSPEntryGenerator {
 
     String adduct = param.getParameter(LibrarySubmitIonParameters.ADDUCT).getValue();
     if (adduct != null && !adduct.trim().isEmpty())
-      s.append(DBEntryField.IONTYPE.getNistMspID() + def
+      s.append(DBEntryField.ION_TYPE.getNistMspID() + def
           + param.getParameter(LibrarySubmitIonParameters.ADDUCT).getValue() + br);
 
     if (exportRT) {

--- a/src/main/java/net/sf/mzmine/modules/visualization/molstructure/Structure2DComponent.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/molstructure/Structure2DComponent.java
@@ -27,9 +27,7 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
-
 import javax.swing.JComponent;
-
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.geometry.GeometryUtil;
 import org.openscience.cdk.interfaces.IAtomContainer;
@@ -50,6 +48,8 @@ import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
 public class Structure2DComponent extends JComponent {
 
   private static final long serialVersionUID = 1L;
+
+  public static final Font FONT = new Font("Verdana", Font.PLAIN, 14);
 
   private AtomContainerRenderer renderer;
   private IAtomContainer molecule;
@@ -93,6 +93,10 @@ public class Structure2DComponent extends JComponent {
   }
 
   public Structure2DComponent(IAtomContainer container) throws CDKException {
+    this(container, FONT);
+  }
+
+  public Structure2DComponent(IAtomContainer container, Font font) throws CDKException {
     molecule = container;
 
     // Suppress the hydrogens
@@ -106,7 +110,6 @@ public class Structure2DComponent extends JComponent {
     }
 
     // Generators make the image elements
-    Font font = new Font("Verdana", Font.PLAIN, 14);
     List<IGenerator<IAtomContainer>> generators = new ArrayList<IGenerator<IAtomContainer>>();
     generators.add(new BasicSceneGenerator());
     generators.add(new StandardGenerator(font));

--- a/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/datapointprocessing/isotopes/MassListDeisotoper.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/datapointprocessing/isotopes/MassListDeisotoper.java
@@ -158,7 +158,7 @@ public class MassListDeisotoper {
 
         DataPoint candidatePeak = sortedPeaks[ind];
 
-        if (candidatePeak == null)
+        if (candidatePeak == null || Double.compare(candidatePeak.getIntensity(), 0) == 0)
           continue;
 
         // Get properties of the candidate peak

--- a/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectraIdentificationResultsWindow.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectraIdentificationResultsWindow.java
@@ -20,46 +20,24 @@ package net.sf.mzmine.modules.visualization.spectra.simplespectra.spectraidentif
 
 import java.awt.BorderLayout;
 import java.awt.Color;
-import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.GridLayout;
-import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Level;
+import java.util.Objects;
 import java.util.logging.Logger;
-import javax.swing.BorderFactory;
-import javax.swing.Box;
-import javax.swing.BoxLayout;
-import javax.swing.JComponent;
+import javax.swing.JCheckBoxMenuItem;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JMenuBar;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
-import javax.swing.ScrollPaneConstants;
 import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
-import org.openscience.cdk.DefaultChemObjectBuilder;
-import org.openscience.cdk.exception.CDKException;
-import org.openscience.cdk.exception.InvalidSmilesException;
-import org.openscience.cdk.inchi.InChIGeneratorFactory;
-import org.openscience.cdk.inchi.InChIToStructure;
-import org.openscience.cdk.interfaces.IAtomContainer;
-import org.openscience.cdk.smiles.SmilesParser;
-import net.miginfocom.swing.MigLayout;
 import net.sf.mzmine.desktop.impl.WindowsMenu;
-import net.sf.mzmine.framework.CustomTextPane;
-import net.sf.mzmine.framework.ScrollablePanel;
-import net.sf.mzmine.modules.visualization.molstructure.Structure2DComponent;
-import net.sf.mzmine.modules.visualization.spectra.simplespectra.mirrorspectra.MirrorScanWindow;
-import net.sf.mzmine.util.ColorScaleUtil;
-import net.sf.mzmine.util.components.MultiLineLabel;
-import net.sf.mzmine.util.spectraldb.entry.DBEntryField;
-import net.sf.mzmine.util.spectraldb.entry.SpectralDBEntry;
 import net.sf.mzmine.util.spectraldb.entry.SpectralDBPeakIdentity;
 
 /**
@@ -69,26 +47,14 @@ import net.sf.mzmine.util.spectraldb.entry.SpectralDBPeakIdentity;
  */
 public class SpectraIdentificationResultsWindow extends JFrame {
   private final Logger logger = Logger.getLogger(this.getClass().getName());
-  private static final long serialVersionUID = 1L;
-  public static final int META_WIDTH = 500;
-  public static final int ENTRY_HEIGHT = 500;
 
-  // colors
-  public static final double MIN_COS_COLOR_VALUE = 0.5;
-  public static final double MAX_COS_COLOR_VALUE = 1.0;
-  // min color is a darker red
-  // max color is a darker green
-  public static final Color MAX_COS_COLOR = new Color(0x388E3C);
-  public static final Color MIN_COS_COLOR = new Color(0xE30B0B);
-
-  private JPanel pnGrid;
-  private Font titleFont = new Font("Dialog", Font.BOLD, 18);
-  private Font scoreFont = new Font("Dialog", Font.BOLD, 30);
   private Font headerFont = new Font("Dialog", Font.BOLD, 16);
-  private static final DecimalFormat COS_FORM = new DecimalFormat("0.000");
+  private JPanel pnGrid;
   private JScrollPane scrollPane;
   private List<SpectralDBPeakIdentity> totalMatches;
-  private Map<SpectralDBPeakIdentity, JPanel> matchPanels;
+  private Map<SpectralDBPeakIdentity, SpectralMatchPanel> matchPanels;
+  // couple y zoom (if one is changed - change the other in a mirror plot)
+  private boolean isCouplingZoomY;
 
   public SpectraIdentificationResultsWindow() {
     setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
@@ -98,7 +64,7 @@ public class SpectraIdentificationResultsWindow extends JFrame {
 
     pnGrid = new JPanel();
     // any number of rows
-    pnGrid.setLayout(new GridLayout(0, 1, 0, 25));
+    pnGrid.setLayout(new GridLayout(0, 1, 0, 0));
 
     pnGrid.setBackground(Color.WHITE);
     pnGrid.setAutoscrolls(false);
@@ -112,6 +78,10 @@ public class SpectraIdentificationResultsWindow extends JFrame {
     // Add the Windows menu
     JMenuBar menuBar = new JMenuBar();
     menuBar.add(new WindowsMenu());
+    JCheckBoxMenuItem cbCoupleZoomY = new JCheckBoxMenuItem("Couple y-zoom");
+    cbCoupleZoomY.setSelected(true);
+    cbCoupleZoomY.addItemListener(e -> setCoupleZoomY(cbCoupleZoomY.isSelected()));
+    menuBar.add(cbCoupleZoomY);
     setJMenuBar(menuBar);
 
     scrollPane = new JScrollPane(pnGrid);
@@ -122,6 +92,7 @@ public class SpectraIdentificationResultsWindow extends JFrame {
 
     totalMatches = new ArrayList<>();
     matchPanels = new HashMap<>();
+    setCoupleZoomY(true);
 
     setVisible(true);
     setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
@@ -129,184 +100,13 @@ public class SpectraIdentificationResultsWindow extends JFrame {
     repaint();
   }
 
-  /**
-   * Creates a new panel for the library match
-   * 
-   * @param scan
-   * @param hit
-   * @return
-   */
-  private JPanel createPanel(SpectralDBPeakIdentity hit) {
-    JPanel panel = new JPanel(new BorderLayout());
+  public void setCoupleZoomY(boolean selected) {
+    isCouplingZoomY = selected;
 
-    JPanel spectrumPanel = new JPanel(new BorderLayout());
-
-    // set meta data from identity
-    JPanel metaDataPanel = new JPanel();
-    metaDataPanel.setLayout(new BoxLayout(metaDataPanel, BoxLayout.Y_AXIS));
-
-    metaDataPanel.setBackground(Color.WHITE);
-
-    // add title
-    MigLayout l = new MigLayout("aligny center, wrap, insets 0 10 0 30", "[grow][]", "[grow]");
-    JPanel boxTitlePanel = new JPanel();
-    boxTitlePanel.setLayout(l);
-
-
-    double simScore = hit.getSimilarity().getScore();
-    Color gradientCol = ColorScaleUtil.getColor(MIN_COS_COLOR, MAX_COS_COLOR, MIN_COS_COLOR_VALUE,
-        MAX_COS_COLOR_VALUE, simScore);
-    boxTitlePanel.setBackground(gradientCol);
-    Box boxTitle = Box.createHorizontalBox();
-    // boxTitle.add(Box.createHorizontalGlue());
-
-    JPanel panelTitle = new JPanel(new GridLayout(1, 1));
-    panelTitle.setBackground(gradientCol);
-    String name = hit.getEntry().getField(DBEntryField.NAME).orElse("N/A").toString();
-    CustomTextPane title = new CustomTextPane(true);
-    title.setEditable(false);
-    title.setFont(headerFont);
-    title.setText(name);
-    title.setBackground(gradientCol);
-    title.setForeground(Color.WHITE);
-    panelTitle.add(title);
-
-    // score result
-    JPanel panelScore = new JPanel();
-    panelScore.setLayout(new BoxLayout(panelScore, BoxLayout.Y_AXIS));
-    JLabel score = new JLabel(COS_FORM.format(simScore));
-    score.setToolTipText("Cosine similarity of raw data scan (top, blue) and database scan: "
-        + COS_FORM.format(simScore));
-    score.setFont(scoreFont);
-    score.setForeground(Color.WHITE);
-    panelScore.setBackground(gradientCol);
-    panelScore.add(score);
-    boxTitlePanel.add(panelScore, "cell 1 0");
-    boxTitlePanel.add(panelTitle, "cell 0 0, growx, center");
-    boxTitle.add(boxTitlePanel);
-
-    // structure preview
-    IAtomContainer molecule;
-    JPanel preview2DPanel = new JPanel(new BorderLayout());
-    preview2DPanel.setPreferredSize(new Dimension(META_WIDTH, 150));
-    preview2DPanel.setMinimumSize(new Dimension(META_WIDTH, 150));
-    preview2DPanel.setMaximumSize(new Dimension(META_WIDTH, 150));
-    JComponent newComponent = null;
-
-    String inchiString = hit.getEntry().getField(DBEntryField.INCHI).orElse("N/A").toString();
-    String smilesString = hit.getEntry().getField(DBEntryField.SMILES).orElse("N/A").toString();
-
-    // check for INCHI
-    if (inchiString != "N/A") {
-      molecule = parseInChi(hit);
+    synchronized (matchPanels) {
+      matchPanels.values().stream().filter(Objects::nonNull)
+          .forEach(pn -> pn.setCoupleZoomY(selected));
     }
-    // check for smiles
-    else if (smilesString != "N/A") {
-      molecule = parseSmiles(hit);
-    } else
-      molecule = null;
-
-    // try to draw the component
-    if (molecule != null) {
-      try {
-        newComponent = new Structure2DComponent(molecule);
-      } catch (Exception e) {
-        String errorMessage = "Could not load 2D structure\n" + "Exception: ";
-        logger.log(Level.WARNING, errorMessage, e);
-        newComponent = new MultiLineLabel(errorMessage);
-      }
-      preview2DPanel.add(newComponent, BorderLayout.CENTER);
-      preview2DPanel.revalidate();
-
-      metaDataPanel.add(preview2DPanel);
-    }
-
-    // information on compound
-    JPanel panelCompounds =
-        extractMetaData("Compound information", hit.getEntry(), DBEntryField.COMPOUND_FIELDS);
-
-    // instrument info
-    JPanel panelInstrument =
-        extractMetaData("Instrument information", hit.getEntry(), DBEntryField.INSTRUMENT_FIELDS);
-
-    JPanel g1 = new JPanel(new GridLayout(1, 2, 4, 0));
-    g1.setBackground(Color.WHITE);
-    g1.add(panelCompounds);
-    g1.add(panelInstrument);
-    metaDataPanel.add(g1);
-
-    // database links
-    JPanel panelDB =
-        extractMetaData("Database links", hit.getEntry(), DBEntryField.DATABASE_FIELDS);
-
-    // // Other info
-    JPanel panelOther =
-        extractMetaData("Other information", hit.getEntry(), DBEntryField.OTHER_FIELDS);
-
-    JPanel g2 = new JPanel(new GridLayout(1, 2, 4, 0));
-    g2.setBackground(Color.WHITE);
-    g2.add(panelDB);
-    g2.add(panelOther);
-    metaDataPanel.add(g2);
-
-    // get mirror spectra window
-    MirrorScanWindow mirrorWindow = new MirrorScanWindow();
-    mirrorWindow.setScans(hit);
-
-    // fixed width panel
-    ScrollablePanel pn = new ScrollablePanel(new BorderLayout());
-    pn.setScrollableWidth(ScrollablePanel.ScrollableSizeHint.FIT);
-    pn.setScrollableHeight(ScrollablePanel.ScrollableSizeHint.STRETCH);
-    pn.add(metaDataPanel);
-
-
-    JScrollPane metaDataPanelScrollPane =
-        new JScrollPane(pn, ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED,
-            ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
-
-    spectrumPanel.add(mirrorWindow.getMirrorSpecrumPlot());
-
-    metaDataPanelScrollPane.setPreferredSize(new Dimension(META_WIDTH + 20, ENTRY_HEIGHT));
-    panel.setPreferredSize(new Dimension(0, ENTRY_HEIGHT));
-
-    panel.add(boxTitle, BorderLayout.NORTH);
-    panel.add(spectrumPanel, BorderLayout.CENTER);
-    panel.add(metaDataPanelScrollPane, BorderLayout.EAST);
-    panel.setBorder(BorderFactory.createLineBorder(Color.BLACK));
-
-    metaDataPanelScrollPane.revalidate();
-    pn.revalidate();
-    panel.revalidate();
-    panel.repaint();
-    return panel;
-  }
-
-  private JPanel extractMetaData(String title, SpectralDBEntry entry, DBEntryField[] other) {
-    JPanel panelOther = new JPanel();
-    panelOther.setLayout(new BoxLayout(panelOther, BoxLayout.Y_AXIS));
-    panelOther.setBackground(Color.WHITE);
-    panelOther.setAlignmentY(Component.TOP_ALIGNMENT);
-    panelOther.setAlignmentX(Component.TOP_ALIGNMENT);
-
-    for (DBEntryField db : other) {
-      Object o = entry.getField(db).orElse("N/A");
-      if (!o.equals("N/A")) {
-        CustomTextPane textPane = new CustomTextPane(true);
-        textPane.setText(db.toString() + ": " + o.toString());
-        panelOther.add(textPane);
-      }
-    }
-
-    JLabel otherInfo = new JLabel(title);
-    otherInfo.setFont(headerFont);
-    JPanel pn = new JPanel(new BorderLayout());
-    pn.setBackground(Color.WHITE);
-    pn.add(otherInfo, BorderLayout.NORTH);
-    pn.add(panelOther, BorderLayout.CENTER);
-    JPanel pn1 = new JPanel(new BorderLayout());
-    pn1.add(pn, BorderLayout.NORTH);
-    pn1.setBackground(Color.WHITE);
-    return pn1;
   }
 
   /**
@@ -319,7 +119,9 @@ public class SpectraIdentificationResultsWindow extends JFrame {
     if (!totalMatches.contains(match)) {
       // add
       totalMatches.add(match);
-      matchPanels.put(match, createPanel(match));
+      SpectralMatchPanel pn = new SpectralMatchPanel(match);
+      pn.setCoupleZoomY(isCouplingZoomY);
+      matchPanels.put(match, pn);
 
       // sort and show
       sortTotalMatches();
@@ -338,7 +140,9 @@ public class SpectraIdentificationResultsWindow extends JFrame {
       if (!totalMatches.contains(match)) {
         // add
         totalMatches.add(match);
-        matchPanels.put(match, createPanel(match));
+        SpectralMatchPanel pn = new SpectralMatchPanel(match);
+        pn.setCoupleZoomY(isCouplingZoomY);
+        matchPanels.put(match, pn);
       }
     }
     // sort and show
@@ -372,7 +176,7 @@ public class SpectraIdentificationResultsWindow extends JFrame {
   public void renewLayout() {
     SwingUtilities.invokeLater(() -> {
       // any number of rows
-      JPanel pnGrid = new JPanel(new GridLayout(0, 1, 0, 25));
+      JPanel pnGrid = new JPanel(new GridLayout(0, 1, 0, 5));
       pnGrid.setBackground(Color.WHITE);
       pnGrid.setAutoscrolls(false);
       // add all panel in order
@@ -392,43 +196,4 @@ public class SpectraIdentificationResultsWindow extends JFrame {
       this.pnGrid = pnGrid;
     });
   }
-
-  private IAtomContainer parseInChi(SpectralDBPeakIdentity hit) {
-    String inchiString = hit.getEntry().getField(DBEntryField.INCHI).orElse("N/A").toString();
-    InChIGeneratorFactory factory;
-    IAtomContainer molecule;
-    if (inchiString != "N/A") {
-      try {
-        factory = InChIGeneratorFactory.getInstance();
-        // Get InChIToStructure
-        InChIToStructure inchiToStructure =
-            factory.getInChIToStructure(inchiString, DefaultChemObjectBuilder.getInstance());
-        molecule = inchiToStructure.getAtomContainer();
-        return molecule;
-      } catch (CDKException e) {
-        String errorMessage = "Could not load 2D structure\n" + "Exception: ";
-        logger.log(Level.WARNING, errorMessage, e);
-        return null;
-      }
-    } else
-      return null;
-  }
-
-  private IAtomContainer parseSmiles(SpectralDBPeakIdentity hit) {
-    SmilesParser smilesParser = new SmilesParser(DefaultChemObjectBuilder.getInstance());
-    String smilesString = hit.getEntry().getField(DBEntryField.SMILES).orElse("N/A").toString();
-    IAtomContainer molecule;
-    if (smilesString != "N/A") {
-      try {
-        molecule = smilesParser.parseSmiles(smilesString);
-        return molecule;
-      } catch (InvalidSmilesException e1) {
-        String errorMessage = "Could not load 2D structure\n" + "Exception: ";
-        logger.log(Level.WARNING, errorMessage, e1);
-        return null;
-      }
-    } else
-      return null;
-  }
-
 }

--- a/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectraIdentificationResultsWindow.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectraIdentificationResultsWindow.java
@@ -83,7 +83,7 @@ public class SpectraIdentificationResultsWindow extends JFrame {
 
   private JPanel pnGrid;
   private Font titleFont = new Font("Dialog", Font.BOLD, 18);
-  private Font scoreFont = new Font("Dialog", Font.BOLD, 36);
+  private Font scoreFont = new Font("Dialog", Font.BOLD, 30);
   private Font headerFont = new Font("Dialog", Font.BOLD, 16);
   private static final DecimalFormat COS_FORM = new DecimalFormat("0.000");
   private JScrollPane scrollPane;
@@ -148,7 +148,7 @@ public class SpectraIdentificationResultsWindow extends JFrame {
     metaDataPanel.setBackground(Color.WHITE);
 
     // add title
-    MigLayout l = new MigLayout("aligny center, wrap", "[grow][]", "[grow]");
+    MigLayout l = new MigLayout("aligny center, wrap, insets 0 10 0 30", "[grow][]", "[grow]");
     JPanel boxTitlePanel = new JPanel();
     boxTitlePanel.setLayout(l);
 
@@ -182,7 +182,7 @@ public class SpectraIdentificationResultsWindow extends JFrame {
     panelScore.setBackground(gradientCol);
     panelScore.add(score);
     boxTitlePanel.add(panelScore, "cell 1 0");
-    boxTitlePanel.add(panelTitle, "cell 0 0, grow");
+    boxTitlePanel.add(panelTitle, "cell 0 0, growx, center");
     boxTitle.add(boxTitlePanel);
 
     // structure preview
@@ -268,7 +268,6 @@ public class SpectraIdentificationResultsWindow extends JFrame {
 
     metaDataPanelScrollPane.setPreferredSize(new Dimension(META_WIDTH + 20, ENTRY_HEIGHT));
     panel.setPreferredSize(new Dimension(0, ENTRY_HEIGHT));
-    boxTitle.setPreferredSize(new Dimension(META_WIDTH, 45));
 
     panel.add(boxTitle, BorderLayout.NORTH);
     panel.add(spectrumPanel, BorderLayout.CENTER);
@@ -301,6 +300,7 @@ public class SpectraIdentificationResultsWindow extends JFrame {
     JLabel otherInfo = new JLabel(title);
     otherInfo.setFont(headerFont);
     JPanel pn = new JPanel(new BorderLayout());
+    pn.setBackground(Color.WHITE);
     pn.add(otherInfo, BorderLayout.NORTH);
     pn.add(panelOther, BorderLayout.CENTER);
     JPanel pn1 = new JPanel(new BorderLayout());
@@ -385,6 +385,7 @@ public class SpectraIdentificationResultsWindow extends JFrame {
       }
       // show
       scrollPane.setViewportView(pnGrid);
+      scrollPane.getVerticalScrollBar().setUnitIncrement(75);
       pnGrid.revalidate();
       scrollPane.revalidate();
       scrollPane.repaint();

--- a/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectraIdentificationResultsWindow.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectraIdentificationResultsWindow.java
@@ -354,9 +354,10 @@ public class SpectraIdentificationResultsWindow extends JFrame {
     }
 
     // reversed sorting (highest cosine first
-    totalMatches.sort((SpectralDBPeakIdentity a, SpectralDBPeakIdentity b) -> Double
-        .compare(b.getSimilarity().getScore(), a.getSimilarity().getScore()));
-
+    synchronized (totalMatches) {
+      totalMatches.sort((SpectralDBPeakIdentity a, SpectralDBPeakIdentity b) -> Double
+          .compare(b.getSimilarity().getScore(), a.getSimilarity().getScore()));
+    }
     // renew layout and show
     renewLayout();
   }
@@ -374,10 +375,12 @@ public class SpectraIdentificationResultsWindow extends JFrame {
       pnGrid.setBackground(Color.WHITE);
       pnGrid.setAutoscrolls(false);
       // add all panel in order
-      for (SpectralDBPeakIdentity match : totalMatches) {
-        JPanel pn = matchPanels.get(match);
-        if (pn != null)
-          pnGrid.add(pn);
+      synchronized (totalMatches) {
+        for (SpectralDBPeakIdentity match : totalMatches) {
+          JPanel pn = matchPanels.get(match);
+          if (pn != null)
+            pnGrid.add(pn);
+        }
       }
       // show
       scrollPane.setViewportView(pnGrid);

--- a/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectraIdentificationResultsWindow.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectraIdentificationResultsWindow.java
@@ -50,6 +50,7 @@ import org.openscience.cdk.inchi.InChIGeneratorFactory;
 import org.openscience.cdk.inchi.InChIToStructure;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.smiles.SmilesParser;
+import net.miginfocom.swing.MigLayout;
 import net.sf.mzmine.desktop.impl.WindowsMenu;
 import net.sf.mzmine.framework.CustomTextPane;
 import net.sf.mzmine.framework.ScrollablePanel;
@@ -147,7 +148,10 @@ public class SpectraIdentificationResultsWindow extends JFrame {
     metaDataPanel.setBackground(Color.WHITE);
 
     // add title
-    JPanel boxTitlePanel = new JPanel(new BorderLayout());
+    MigLayout l = new MigLayout("aligny center, wrap", "[grow][]", "[grow]");
+    JPanel boxTitlePanel = new JPanel();
+    boxTitlePanel.setLayout(l);
+
 
     double simScore = hit.getSimilarity().getScore();
     Color gradientCol = ColorScaleUtil.getColor(MIN_COS_COLOR, MAX_COS_COLOR, MIN_COS_COLOR_VALUE,
@@ -173,18 +177,12 @@ public class SpectraIdentificationResultsWindow extends JFrame {
     JLabel score = new JLabel(COS_FORM.format(simScore));
     score.setToolTipText("Cosine similarity of raw data scan (top, blue) and database scan: "
         + COS_FORM.format(simScore));
-    JLabel scoreLabel = new JLabel("Cosine similarity");
-    scoreLabel.setToolTipText("Cosine similarity of raw data scan (top, blue) and database scan: "
-        + COS_FORM.format(simScore));
     score.setFont(scoreFont);
     score.setForeground(Color.WHITE);
-    scoreLabel.setFont(titleFont);
-    scoreLabel.setForeground(Color.WHITE);
     panelScore.setBackground(gradientCol);
     panelScore.add(score);
-    panelScore.add(scoreLabel);
-    boxTitlePanel.add(panelScore, BorderLayout.EAST);
-    boxTitlePanel.add(panelTitle, BorderLayout.WEST);
+    boxTitlePanel.add(panelScore, "cell 1 0");
+    boxTitlePanel.add(panelTitle, "cell 0 0, grow");
     boxTitle.add(boxTitlePanel);
 
     // structure preview

--- a/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectraIdentificationResultsWindow.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectraIdentificationResultsWindow.java
@@ -51,6 +51,7 @@ import org.openscience.cdk.inchi.InChIToStructure;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.smiles.SmilesParser;
 import net.sf.mzmine.desktop.impl.WindowsMenu;
+import net.sf.mzmine.framework.CustomTextPane;
 import net.sf.mzmine.framework.ScrollablePanel;
 import net.sf.mzmine.modules.visualization.molstructure.Structure2DComponent;
 import net.sf.mzmine.modules.visualization.spectra.simplespectra.mirrorspectra.MirrorScanWindow;
@@ -153,13 +154,15 @@ public class SpectraIdentificationResultsWindow extends JFrame {
         MAX_COS_COLOR_VALUE, simScore);
     boxTitlePanel.setBackground(gradientCol);
     Box boxTitle = Box.createHorizontalBox();
-    boxTitle.add(Box.createHorizontalGlue());
+    // boxTitle.add(Box.createHorizontalGlue());
 
-    JPanel panelTitle = new JPanel(new BorderLayout());
+    JPanel panelTitle = new JPanel(new GridLayout(1, 1));
     panelTitle.setBackground(gradientCol);
     String name = hit.getEntry().getField(DBEntryField.NAME).orElse("N/A").toString();
-    JLabel title = new JLabel(name);
+    CustomTextPane title = new CustomTextPane(true);
+    title.setEditable(false);
     title.setFont(headerFont);
+    title.setText(name);
     title.setBackground(gradientCol);
     title.setForeground(Color.WHITE);
     panelTitle.add(title);
@@ -180,8 +183,8 @@ public class SpectraIdentificationResultsWindow extends JFrame {
     panelScore.setBackground(gradientCol);
     panelScore.add(score);
     panelScore.add(scoreLabel);
-    boxTitlePanel.add(panelTitle, BorderLayout.WEST);
     boxTitlePanel.add(panelScore, BorderLayout.EAST);
+    boxTitlePanel.add(panelTitle, BorderLayout.WEST);
     boxTitle.add(boxTitlePanel);
 
     // structure preview
@@ -261,7 +264,7 @@ public class SpectraIdentificationResultsWindow extends JFrame {
 
     JScrollPane metaDataPanelScrollPane =
         new JScrollPane(pn, ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED,
-            ScrollPaneConstants.HORIZONTAL_SCROLLBAR_AS_NEEDED);
+            ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
 
     spectrumPanel.add(mirrorWindow.getMirrorSpecrumPlot());
 
@@ -291,9 +294,9 @@ public class SpectraIdentificationResultsWindow extends JFrame {
     for (DBEntryField db : other) {
       Object o = entry.getField(db).orElse("N/A");
       if (!o.equals("N/A")) {
-        SpectralIdentificationSpectralDatabaseTextPane pane =
-            new SpectralIdentificationSpectralDatabaseTextPane(db.toString() + ": " + o.toString());
-        panelOther.add(pane);
+        CustomTextPane textPane = new CustomTextPane(true);
+        textPane.setText(db.toString() + ": " + o.toString());
+        panelOther.add(textPane);
       }
     }
 

--- a/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectraIdentificationResultsWindow.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectraIdentificationResultsWindow.java
@@ -20,12 +20,10 @@ package net.sf.mzmine.modules.visualization.spectra.simplespectra.spectraidentif
 
 import java.awt.BorderLayout;
 import java.awt.Color;
+import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Font;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
 import java.awt.GridLayout;
-import java.awt.Insets;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -59,6 +57,7 @@ import net.sf.mzmine.modules.visualization.spectra.simplespectra.mirrorspectra.M
 import net.sf.mzmine.util.ColorScaleUtil;
 import net.sf.mzmine.util.components.MultiLineLabel;
 import net.sf.mzmine.util.spectraldb.entry.DBEntryField;
+import net.sf.mzmine.util.spectraldb.entry.SpectralDBEntry;
 import net.sf.mzmine.util.spectraldb.entry.SpectralDBPeakIdentity;
 
 /**
@@ -141,8 +140,8 @@ public class SpectraIdentificationResultsWindow extends JFrame {
     JPanel spectrumPanel = new JPanel(new BorderLayout());
 
     // set meta data from identity
-    JPanel metaDataPanel = new JPanel(new GridBagLayout());
-    GridBagConstraints constraintsMetaDataPanel = new GridBagConstraints();
+    JPanel metaDataPanel = new JPanel();
+    metaDataPanel.setLayout(new BoxLayout(metaDataPanel, BoxLayout.Y_AXIS));
 
     metaDataPanel.setBackground(Color.WHITE);
 
@@ -218,239 +217,36 @@ public class SpectraIdentificationResultsWindow extends JFrame {
       preview2DPanel.add(newComponent, BorderLayout.CENTER);
       preview2DPanel.revalidate();
 
-      constraintsMetaDataPanel.anchor = GridBagConstraints.PAGE_START;
-      constraintsMetaDataPanel.fill = GridBagConstraints.BOTH;
-      constraintsMetaDataPanel.weightx = 1;
-      constraintsMetaDataPanel.weighty = 1;
-      constraintsMetaDataPanel.gridx = 0;
-      constraintsMetaDataPanel.gridy = 0;
-      constraintsMetaDataPanel.gridwidth = 2;
-      metaDataPanel.add(preview2DPanel, constraintsMetaDataPanel);
+      metaDataPanel.add(preview2DPanel);
     }
 
     // information on compound
-    JPanel panelCompounds = new JPanel();
-    panelCompounds.setLayout(new BoxLayout(panelCompounds, BoxLayout.Y_AXIS));
-    panelCompounds.setBackground(Color.WHITE);
-    JLabel compoundInfo = new JLabel("Compound information");
-    compoundInfo.setToolTipText(
-        "This section shows all the compound information listed in the used database");
-    compoundInfo.setFont(headerFont);
-
-    constraintsMetaDataPanel.fill = GridBagConstraints.HORIZONTAL;
-    constraintsMetaDataPanel.anchor = GridBagConstraints.PAGE_START;
-    constraintsMetaDataPanel.insets = new Insets(5, 5, 5, 5);
-    // reset grid width
-    constraintsMetaDataPanel.gridwidth = 1;
-    constraintsMetaDataPanel.gridx = 0;
-    constraintsMetaDataPanel.gridy = 1;
-    metaDataPanel.add(compoundInfo, constraintsMetaDataPanel);
-
-    SpectralIdentificationSpectralDatabaseTextPane synonym =
-        new SpectralIdentificationSpectralDatabaseTextPane(
-            "Synonym: " + hit.getEntry().getField(DBEntryField.SYNONYM).orElse("N/A"));
-    if (hit.getEntry().getField(DBEntryField.SYNONYM).orElse("N/A") != "N/A")
-      panelCompounds.add(synonym);
-    SpectralIdentificationSpectralDatabaseTextPane formula =
-        new SpectralIdentificationSpectralDatabaseTextPane(
-            "Formula: " + hit.getEntry().getField(DBEntryField.FORMULA).orElse("N/A"));
-    if (hit.getEntry().getField(DBEntryField.FORMULA).orElse("N/A") != "N/A")
-      panelCompounds.add(formula);
-    SpectralIdentificationSpectralDatabaseTextPane molarWeight =
-        new SpectralIdentificationSpectralDatabaseTextPane(
-            "Molar Weight: " + hit.getEntry().getField(DBEntryField.MOLWEIGHT).orElse("N/A"));
-    if (hit.getEntry().getField(DBEntryField.MOLWEIGHT).orElse("N/A") != "N/A")
-      panelCompounds.add(molarWeight);
-    SpectralIdentificationSpectralDatabaseTextPane exactMass =
-        new SpectralIdentificationSpectralDatabaseTextPane(
-            "Exact mass: " + hit.getEntry().getField(DBEntryField.EXACT_MASS).orElse("N/A"));
-    if (hit.getEntry().getField(DBEntryField.EXACT_MASS).orElse("N/A") != "N/A")
-      panelCompounds.add(exactMass);
-    SpectralIdentificationSpectralDatabaseTextPane ionType =
-        new SpectralIdentificationSpectralDatabaseTextPane(
-            "Ion type: " + hit.getEntry().getField(DBEntryField.IONTYPE).orElse("N/A"));
-    if (hit.getEntry().getField(DBEntryField.IONTYPE).orElse("N/A") != "N/A")
-      panelCompounds.add(ionType);
-    SpectralIdentificationSpectralDatabaseTextPane rt =
-        new SpectralIdentificationSpectralDatabaseTextPane(
-            "Retention time: " + hit.getEntry().getField(DBEntryField.RT).orElse("N/A"));
-    if (hit.getEntry().getField(DBEntryField.RT).orElse("N/A") != "N/A")
-      panelCompounds.add(rt);
-    SpectralIdentificationSpectralDatabaseTextPane mz =
-        new SpectralIdentificationSpectralDatabaseTextPane(
-            "m/z: " + hit.getEntry().getField(DBEntryField.MZ).orElse("N/A"));
-    if (hit.getEntry().getField(DBEntryField.MZ).orElse("N/A") != "N/A")
-      panelCompounds.add(mz);
-    SpectralIdentificationSpectralDatabaseTextPane charge =
-        new SpectralIdentificationSpectralDatabaseTextPane(
-            "Charge: " + hit.getEntry().getField(DBEntryField.CHARGE).orElse("N/A"));
-    if (hit.getEntry().getField(DBEntryField.CHARGE).orElse("N/A") != "N/A")
-      panelCompounds.add(charge);
-    SpectralIdentificationSpectralDatabaseTextPane ionMode =
-        new SpectralIdentificationSpectralDatabaseTextPane(
-            "Ion mode: " + hit.getEntry().getField(DBEntryField.ION_MODE).orElse("N/A"));
-    if (hit.getEntry().getField(DBEntryField.ION_MODE).orElse("N/A") != "N/A")
-      panelCompounds.add(ionMode);
-    SpectralIdentificationSpectralDatabaseTextPane inchi =
-        new SpectralIdentificationSpectralDatabaseTextPane(
-            "INCHI: " + hit.getEntry().getField(DBEntryField.INCHI).orElse("N/A"));
-    if (hit.getEntry().getField(DBEntryField.INCHI).orElse("N/A") != "N/A")
-      panelCompounds.add(inchi);
-    SpectralIdentificationSpectralDatabaseTextPane inchiKey =
-        new SpectralIdentificationSpectralDatabaseTextPane(
-            "INCHI Key: " + hit.getEntry().getField(DBEntryField.INCHIKEY).orElse("N/A"));
-    if (hit.getEntry().getField(DBEntryField.INCHI).orElse("N/A") != "N/A")
-      panelCompounds.add(inchiKey);
-    SpectralIdentificationSpectralDatabaseTextPane smiles =
-        new SpectralIdentificationSpectralDatabaseTextPane(
-            "SMILES: " + hit.getEntry().getField(DBEntryField.SMILES).orElse("N/A"));
-    if (hit.getEntry().getField(DBEntryField.SMILES).orElse("N/A") != "N/A")
-      panelCompounds.add(smiles);
-    SpectralIdentificationSpectralDatabaseTextPane cas =
-        new SpectralIdentificationSpectralDatabaseTextPane(
-            "CAS: " + hit.getEntry().getField(DBEntryField.CAS).orElse("N/A"));
-    if (hit.getEntry().getField(DBEntryField.CAS).orElse("N/A") != "N/A")
-      panelCompounds.add(cas);
-    SpectralIdentificationSpectralDatabaseTextPane numberPeaks =
-        new SpectralIdentificationSpectralDatabaseTextPane(
-            "Number of peaks: " + hit.getEntry().getField(DBEntryField.NUM_PEAKS).orElse("N/A"));
-    if (hit.getEntry().getField(DBEntryField.NUM_PEAKS).orElse("N/A") != "N/A")
-      panelCompounds.add(numberPeaks);
+    JPanel panelCompounds =
+        extractMetaData("Compound information", hit.getEntry(), DBEntryField.COMPOUND_FIELDS);
 
     // instrument info
-    JPanel panelInstrument = new JPanel();
-    panelInstrument.setLayout(new BoxLayout(panelInstrument, BoxLayout.PAGE_AXIS));
-    panelInstrument.setBackground(Color.WHITE);
-    JLabel instrumentInfo = new JLabel("Instrument information");
-    instrumentInfo.setFont(headerFont);
-    constraintsMetaDataPanel.gridx = 1;
-    constraintsMetaDataPanel.gridy = 1;
-    metaDataPanel.add(instrumentInfo, constraintsMetaDataPanel);
-    SpectralIdentificationSpectralDatabaseTextPane instrumentType =
-        new SpectralIdentificationSpectralDatabaseTextPane("Instrument type: "
-            + hit.getEntry().getField(DBEntryField.INSTRUMENT_TYPE).orElse("N/A"));
-    if (hit.getEntry().getField(DBEntryField.INSTRUMENT_TYPE).orElse("N/A") != "N/A")
-      panelInstrument.add(instrumentType);
-    SpectralIdentificationSpectralDatabaseTextPane instrument =
-        new SpectralIdentificationSpectralDatabaseTextPane(
-            "Instrument: " + hit.getEntry().getField(DBEntryField.INSTRUMENT).orElse("N/A"));
-    if (hit.getEntry().getField(DBEntryField.INSTRUMENT).orElse("N/A") != "N/A")
-      panelInstrument.add(instrument);
-    SpectralIdentificationSpectralDatabaseTextPane ionSource =
-        new SpectralIdentificationSpectralDatabaseTextPane(
-            "Ion source: " + hit.getEntry().getField(DBEntryField.ION_SOURCE).orElse("N/A"));
-    if (hit.getEntry().getField(DBEntryField.ION_SOURCE).orElse("N/A") != "N/A")
-      panelInstrument.add(ionSource);
-    SpectralIdentificationSpectralDatabaseTextPane resolution =
-        new SpectralIdentificationSpectralDatabaseTextPane(
-            "Resolution: " + hit.getEntry().getField(DBEntryField.RESOLUTION).orElse("N/A"));
-    if (hit.getEntry().getField(DBEntryField.RESOLUTION).orElse("N/A") != "N/A")
-      panelInstrument.add(resolution);
-    SpectralIdentificationSpectralDatabaseTextPane msLevel =
-        new SpectralIdentificationSpectralDatabaseTextPane(
-            "MS level: " + hit.getEntry().getField(DBEntryField.MS_LEVEL).orElse("N/A"));
-    if (hit.getEntry().getField(DBEntryField.MS_LEVEL).orElse("N/A") != "N/A")
-      panelInstrument.add(msLevel);
-    SpectralIdentificationSpectralDatabaseTextPane collision =
-        new SpectralIdentificationSpectralDatabaseTextPane("Collision energy: "
-            + hit.getEntry().getField(DBEntryField.COLLISION_ENERGY).orElse("N/A"));
-    if (hit.getEntry().getField(DBEntryField.COLLISION_ENERGY).orElse("N/A") != "N/A")
-      panelInstrument.add(collision);
-    SpectralIdentificationSpectralDatabaseTextPane acquisition =
-        new SpectralIdentificationSpectralDatabaseTextPane(
-            "Acquisition: " + hit.getEntry().getField(DBEntryField.ACQUISITION).orElse("N/A"));
-    if (hit.getEntry().getField(DBEntryField.ACQUISITION).orElse("N/A") != "N/A")
-      panelInstrument.add(acquisition);
-    SpectralIdentificationSpectralDatabaseTextPane software =
-        new SpectralIdentificationSpectralDatabaseTextPane(
-            "Software: " + hit.getEntry().getField(DBEntryField.SOFTWARE).orElse("N/A"));
-    if (hit.getEntry().getField(DBEntryField.SOFTWARE).orElse("N/A") != "N/A")
-      panelInstrument.add(software);
+    JPanel panelInstrument =
+        extractMetaData("Instrument information", hit.getEntry(), DBEntryField.INSTRUMENT_FIELDS);
 
-    constraintsMetaDataPanel.weighty = 0.5;
-    constraintsMetaDataPanel.gridx = 0;
-    constraintsMetaDataPanel.gridy = 2;
-    metaDataPanel.add(panelCompounds, constraintsMetaDataPanel);
-
-    constraintsMetaDataPanel.gridx = 1;
-    constraintsMetaDataPanel.gridy = 2;
-    metaDataPanel.add(panelInstrument, constraintsMetaDataPanel);
+    JPanel g1 = new JPanel(new GridLayout(1, 2, 4, 0));
+    g1.setBackground(Color.WHITE);
+    g1.add(panelCompounds);
+    g1.add(panelInstrument);
+    metaDataPanel.add(g1);
 
     // database links
-    JPanel panelDB = new JPanel();
-    panelDB.setLayout(new BoxLayout(panelDB, BoxLayout.PAGE_AXIS));
-    panelDB.setBackground(Color.WHITE);
-    JLabel databaseLinks = new JLabel("Database links");
-    databaseLinks
-        .setToolTipText("This section shows links to other databases of the matched compound");
-    databaseLinks.setFont(headerFont);
-    constraintsMetaDataPanel.gridx = 0;
-    constraintsMetaDataPanel.gridy = 3;
-    metaDataPanel.add(databaseLinks, constraintsMetaDataPanel);
-
-    SpectralIdentificationSpectralDatabaseTextPane pubmed =
-        new SpectralIdentificationSpectralDatabaseTextPane(
-            "PUBMED: " + hit.getEntry().getField(DBEntryField.PUBMED).orElse("N/A"));
-    if (hit.getEntry().getField(DBEntryField.PUBMED).orElse("N/A") != "N/A")
-      panelDB.add(pubmed);
-    SpectralIdentificationSpectralDatabaseTextPane pubchem =
-        new SpectralIdentificationSpectralDatabaseTextPane(
-            "PUBCHEM: " + hit.getEntry().getField(DBEntryField.PUBCHEM).orElse("N/A"));
-    if (hit.getEntry().getField(DBEntryField.PUBCHEM).orElse("N/A") != "N/A")
-      panelDB.add(pubchem);
-    SpectralIdentificationSpectralDatabaseTextPane mona =
-        new SpectralIdentificationSpectralDatabaseTextPane(
-            "MONA ID: " + hit.getEntry().getField(DBEntryField.MONA_ID).orElse("N/A"));
-    if (hit.getEntry().getField(DBEntryField.MONA_ID).orElse("N/A") != "N/A")
-      panelDB.add(mona);
-    SpectralIdentificationSpectralDatabaseTextPane spider =
-        new SpectralIdentificationSpectralDatabaseTextPane(
-            "Chemspider: " + hit.getEntry().getField(DBEntryField.CHEMSPIDER).orElse("N/A"));
-    if (hit.getEntry().getField(DBEntryField.CHEMSPIDER).orElse("N/A") != "N/A")
-      panelDB.add(spider);
+    JPanel panelDB =
+        extractMetaData("Database links", hit.getEntry(), DBEntryField.DATABASE_FIELDS);
 
     // // Other info
-    JPanel panelOther = new JPanel();
-    panelOther.setLayout(new BoxLayout(panelOther, BoxLayout.PAGE_AXIS));
-    panelOther.setBackground(Color.WHITE);
-    JLabel otherInfo = new JLabel("Other information");
-    otherInfo.setToolTipText("This section shows all other information of the matched compound");
-    otherInfo.setFont(headerFont);
-    constraintsMetaDataPanel.gridx = 1;
-    constraintsMetaDataPanel.gridy = 3;
-    metaDataPanel.add(otherInfo, constraintsMetaDataPanel);
-    SpectralIdentificationSpectralDatabaseTextPane investigator =
-        new SpectralIdentificationSpectralDatabaseTextPane("Principal investigator: "
-            + hit.getEntry().getField(DBEntryField.PRINCIPAL_INVESTIGATOR).orElse("N/A"));
-    investigator.setToolTipText("Principal investigator: "
-        + hit.getEntry().getField(DBEntryField.PRINCIPAL_INVESTIGATOR).orElse("N/A"));
-    if (hit.getEntry().getField(DBEntryField.PRINCIPAL_INVESTIGATOR).orElse("N/A") != "N/A")
-      panelOther.add(investigator);
-    SpectralIdentificationSpectralDatabaseTextPane collector =
-        new SpectralIdentificationSpectralDatabaseTextPane("Data collector: "
-            + hit.getEntry().getField(DBEntryField.DATA_COLLECTOR).orElse("N/A"));
-    if (hit.getEntry().getField(DBEntryField.DATA_COLLECTOR).orElse("N/A") != "N/A")
-      panelOther.add(collector);
-    SpectralIdentificationSpectralDatabaseTextPane entry =
-        new SpectralIdentificationSpectralDatabaseTextPane(
-            "DB entry ID: " + hit.getEntry().getField(DBEntryField.ENTRY_ID).orElse("N/A"));
-    if (hit.getEntry().getField(DBEntryField.ENTRY_ID).orElse("N/A") != "N/A")
-      panelOther.add(entry);
-    SpectralIdentificationSpectralDatabaseTextPane comment =
-        new SpectralIdentificationSpectralDatabaseTextPane(
-            "Comment: " + hit.getEntry().getField(DBEntryField.COMMENT).orElse("N/A"));
-    if (hit.getEntry().getField(DBEntryField.COMMENT).orElse("N/A") != "N/A")
-      panelOther.add(comment);
+    JPanel panelOther =
+        extractMetaData("Other information", hit.getEntry(), DBEntryField.OTHER_FIELDS);
 
-    constraintsMetaDataPanel.gridx = 0;
-    constraintsMetaDataPanel.gridy = 4;
-    metaDataPanel.add(panelDB, constraintsMetaDataPanel);
-
-    constraintsMetaDataPanel.gridx = 1;
-    constraintsMetaDataPanel.gridy = 4;
-
-    metaDataPanel.add(panelOther, constraintsMetaDataPanel);
-
+    JPanel g2 = new JPanel(new GridLayout(1, 2, 4, 0));
+    g2.setBackground(Color.WHITE);
+    g2.add(panelDB);
+    g2.add(panelOther);
+    metaDataPanel.add(g2);
 
     // get mirror spectra window
     MirrorScanWindow mirrorWindow = new MirrorScanWindow();
@@ -469,9 +265,9 @@ public class SpectraIdentificationResultsWindow extends JFrame {
 
     spectrumPanel.add(mirrorWindow.getMirrorSpecrumPlot());
 
+    metaDataPanelScrollPane.setPreferredSize(new Dimension(META_WIDTH + 20, ENTRY_HEIGHT));
     panel.setPreferredSize(new Dimension(0, ENTRY_HEIGHT));
     boxTitle.setPreferredSize(new Dimension(META_WIDTH, 45));
-    metaDataPanelScrollPane.setPreferredSize(new Dimension(META_WIDTH + 20, ENTRY_HEIGHT));
 
     panel.add(boxTitle, BorderLayout.NORTH);
     panel.add(spectrumPanel, BorderLayout.CENTER);
@@ -479,10 +275,37 @@ public class SpectraIdentificationResultsWindow extends JFrame {
     panel.setBorder(BorderFactory.createLineBorder(Color.BLACK));
 
     metaDataPanelScrollPane.revalidate();
-    metaDataPanel.revalidate();
+    pn.revalidate();
     panel.revalidate();
     panel.repaint();
     return panel;
+  }
+
+  private JPanel extractMetaData(String title, SpectralDBEntry entry, DBEntryField[] other) {
+    JPanel panelOther = new JPanel();
+    panelOther.setLayout(new BoxLayout(panelOther, BoxLayout.Y_AXIS));
+    panelOther.setBackground(Color.WHITE);
+    panelOther.setAlignmentY(Component.TOP_ALIGNMENT);
+    panelOther.setAlignmentX(Component.TOP_ALIGNMENT);
+
+    for (DBEntryField db : other) {
+      Object o = entry.getField(db).orElse("N/A");
+      if (!o.equals("N/A")) {
+        SpectralIdentificationSpectralDatabaseTextPane pane =
+            new SpectralIdentificationSpectralDatabaseTextPane(db.toString() + ": " + o.toString());
+        panelOther.add(pane);
+      }
+    }
+
+    JLabel otherInfo = new JLabel(title);
+    otherInfo.setFont(headerFont);
+    JPanel pn = new JPanel(new BorderLayout());
+    pn.add(otherInfo, BorderLayout.NORTH);
+    pn.add(panelOther, BorderLayout.CENTER);
+    JPanel pn1 = new JPanel(new BorderLayout());
+    pn1.add(pn, BorderLayout.NORTH);
+    pn1.setBackground(Color.WHITE);
+    return pn1;
   }
 
   /**

--- a/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectraIdentificationResultsWindow.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectraIdentificationResultsWindow.java
@@ -31,7 +31,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.BorderFactory;
@@ -56,20 +55,29 @@ import org.openscience.cdk.smiles.SmilesParser;
 import net.sf.mzmine.desktop.impl.WindowsMenu;
 import net.sf.mzmine.modules.visualization.molstructure.Structure2DComponent;
 import net.sf.mzmine.modules.visualization.spectra.simplespectra.mirrorspectra.MirrorScanWindow;
+import net.sf.mzmine.util.ColorScaleUtil;
 import net.sf.mzmine.util.components.MultiLineLabel;
 import net.sf.mzmine.util.spectraldb.entry.DBEntryField;
 import net.sf.mzmine.util.spectraldb.entry.SpectralDBPeakIdentity;
 
+/**
+ * Window to show all spectral database matches from selected scan or peaklist match
+ * 
+ * @author Ansgar Korf (ansgar.korf@uni-muenster.de)
+ */
 public class SpectraIdentificationResultsWindow extends JFrame {
-  /**
-   * Window to show all spectral database matches from selected scan or peaklist match
-   * 
-   * @author Ansgar Korf (ansgar.korf@uni-muenster.de)
-   */
-
-  private Logger logger = Logger.getLogger(this.getClass().getName());
-
+  private final Logger logger = Logger.getLogger(this.getClass().getName());
   private static final long serialVersionUID = 1L;
+
+  // colors
+  public static final double MIN_COS_COLOR_VALUE = 0.5;
+  public static final double MAX_COS_COLOR_VALUE = 1.0;
+
+  // min color is a darker red
+  public static final Color MIN_COS_COLOR = new Color(0x388E3C);
+  // max color is a darker green
+  public static final Color MAX_COS_COLOR = new Color(0x388E3C);
+
   private JPanel pnGrid;
   private Font titleFont = new Font("Dialog", Font.BOLD, 18);
   private Font scoreFont = new Font("Dialog", Font.BOLD, 36);
@@ -142,22 +150,21 @@ public class SpectraIdentificationResultsWindow extends JFrame {
     // add title
     JPanel boxTitlePanel = new JPanel(new BorderLayout());
 
-    Random r1 = new Random();
-    Color randomCol = Color.getHSBColor(r1.nextFloat(), 1.0f, 0.6f);
-    boxTitlePanel.setBackground(randomCol);
+    double simScore = hit.getSimilarity().getScore();
+    Color gradientCol = ColorScaleUtil.getColor(MIN_COS_COLOR, MIN_COS_COLOR, MIN_COS_COLOR_VALUE,
+        MAX_COS_COLOR_VALUE, simScore);
+    boxTitlePanel.setBackground(gradientCol);
     Box boxTitle = Box.createHorizontalBox();
     boxTitle.add(Box.createHorizontalGlue());
 
     JPanel panelTitle = new JPanel(new BorderLayout());
-    panelTitle.setBackground(randomCol);
+    panelTitle.setBackground(gradientCol);
     String name = hit.getEntry().getField(DBEntryField.NAME).orElse("N/A").toString();
     JLabel title = new JLabel(name);
     title.setFont(headerFont);
-    title.setBackground(randomCol);
+    title.setBackground(gradientCol);
     title.setForeground(Color.WHITE);
     panelTitle.add(title);
-
-    double simScore = hit.getSimilarity().getScore();
 
     // score result
     JPanel panelScore = new JPanel();
@@ -172,7 +179,7 @@ public class SpectraIdentificationResultsWindow extends JFrame {
     score.setForeground(Color.WHITE);
     scoreLabel.setFont(titleFont);
     scoreLabel.setForeground(Color.WHITE);
-    panelScore.setBackground(randomCol);
+    panelScore.setBackground(gradientCol);
     panelScore.add(score);
     panelScore.add(scoreLabel);
     boxTitlePanel.add(panelTitle, BorderLayout.WEST);

--- a/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectralMatchPanel.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectralMatchPanel.java
@@ -45,6 +45,7 @@ import net.sf.mzmine.util.spectraldb.entry.SpectralDBPeakIdentity;
 
 public class SpectralMatchPanel extends JPanel {
   private final Logger logger = Logger.getLogger(this.getClass().getName());
+  public static final Font FONT = new Font("Verdana", Font.PLAIN, 24);
 
   private static final DecimalFormat COS_FORM = new DecimalFormat("0.000");
   private static final long serialVersionUID = 1L;
@@ -145,7 +146,7 @@ public class SpectralMatchPanel extends JPanel {
     // try to draw the component
     if (molecule != null) {
       try {
-        newComponent = new Structure2DComponent(molecule);
+        newComponent = new Structure2DComponent(molecule, FONT);
       } catch (Exception e) {
         String errorMessage = "Could not load 2D structure\n" + "Exception: ";
         logger.log(Level.WARNING, errorMessage, e);

--- a/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectralMatchPanel.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectralMatchPanel.java
@@ -1,0 +1,344 @@
+package net.sf.mzmine.modules.visualization.spectra.simplespectra.spectraidentification.spectraldatabase;
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.GridLayout;
+import java.text.DecimalFormat;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.ScrollPaneConstants;
+import org.jfree.chart.axis.NumberAxis;
+import org.jfree.chart.axis.ValueAxis;
+import org.jfree.chart.plot.CombinedDomainXYPlot;
+import org.jfree.chart.plot.XYPlot;
+import org.jfree.data.Range;
+import org.openscience.cdk.DefaultChemObjectBuilder;
+import org.openscience.cdk.exception.CDKException;
+import org.openscience.cdk.exception.InvalidSmilesException;
+import org.openscience.cdk.inchi.InChIGeneratorFactory;
+import org.openscience.cdk.inchi.InChIToStructure;
+import org.openscience.cdk.interfaces.IAtomContainer;
+import org.openscience.cdk.smiles.SmilesParser;
+import net.miginfocom.swing.MigLayout;
+import net.sf.mzmine.chartbasics.gui.swing.EChartPanel;
+import net.sf.mzmine.chartbasics.gui.wrapper.ChartViewWrapper;
+import net.sf.mzmine.chartbasics.listener.AxisRangeChangedListener;
+import net.sf.mzmine.framework.CustomTextPane;
+import net.sf.mzmine.framework.ScrollablePanel;
+import net.sf.mzmine.modules.visualization.molstructure.Structure2DComponent;
+import net.sf.mzmine.modules.visualization.spectra.simplespectra.mirrorspectra.MirrorScanWindow;
+import net.sf.mzmine.util.ColorScaleUtil;
+import net.sf.mzmine.util.components.MultiLineLabel;
+import net.sf.mzmine.util.spectraldb.entry.DBEntryField;
+import net.sf.mzmine.util.spectraldb.entry.SpectralDBEntry;
+import net.sf.mzmine.util.spectraldb.entry.SpectralDBPeakIdentity;
+
+public class SpectralMatchPanel extends JPanel {
+  private final Logger logger = Logger.getLogger(this.getClass().getName());
+
+  private static final DecimalFormat COS_FORM = new DecimalFormat("0.000");
+  private static final long serialVersionUID = 1L;
+  public static final int META_WIDTH = 500;
+  public static final int ENTRY_HEIGHT = 500;
+
+  // colors
+  public static final double MIN_COS_COLOR_VALUE = 0.5;
+  public static final double MAX_COS_COLOR_VALUE = 1.0;
+  // min color is a darker red
+  // max color is a darker green
+  public static final Color MAX_COS_COLOR = new Color(0x388E3C);
+  public static final Color MIN_COS_COLOR = new Color(0xE30B0B);
+
+  private Font headerFont = new Font("Dialog", Font.BOLD, 16);
+  private Font titleFont = new Font("Dialog", Font.BOLD, 18);
+  private Font scoreFont = new Font("Dialog", Font.BOLD, 30);
+
+  private EChartPanel mirrorChart;
+
+  private boolean setCoupleZoomY;
+
+  private XYPlot queryPlot;
+
+  private XYPlot libraryPlot;
+
+  public SpectralMatchPanel(SpectralDBPeakIdentity hit) {
+    JPanel panel = this;
+    panel.setLayout(new BorderLayout());
+
+    JPanel spectrumPanel = new JPanel(new BorderLayout());
+
+    // set meta data from identity
+    JPanel metaDataPanel = new JPanel();
+    metaDataPanel.setLayout(new BoxLayout(metaDataPanel, BoxLayout.Y_AXIS));
+
+    metaDataPanel.setBackground(Color.WHITE);
+
+    // add title
+    MigLayout l = new MigLayout("aligny center, wrap, insets 0 10 0 30", "[grow][]", "[grow]");
+    JPanel boxTitlePanel = new JPanel();
+    boxTitlePanel.setLayout(l);
+
+
+    double simScore = hit.getSimilarity().getScore();
+    Color gradientCol = ColorScaleUtil.getColor(MIN_COS_COLOR, MAX_COS_COLOR, MIN_COS_COLOR_VALUE,
+        MAX_COS_COLOR_VALUE, simScore);
+    boxTitlePanel.setBackground(gradientCol);
+    Box boxTitle = Box.createHorizontalBox();
+    // boxTitle.add(Box.createHorizontalGlue());
+
+    JPanel panelTitle = new JPanel(new GridLayout(1, 1));
+    panelTitle.setBackground(gradientCol);
+    String name = hit.getEntry().getField(DBEntryField.NAME).orElse("N/A").toString();
+    CustomTextPane title = new CustomTextPane(true);
+    title.setEditable(false);
+    title.setFont(headerFont);
+    title.setText(name);
+    title.setBackground(gradientCol);
+    title.setForeground(Color.WHITE);
+    panelTitle.add(title);
+
+    // score result
+    JPanel panelScore = new JPanel();
+    panelScore.setLayout(new BoxLayout(panelScore, BoxLayout.Y_AXIS));
+    JLabel score = new JLabel(COS_FORM.format(simScore));
+    score.setToolTipText("Cosine similarity of raw data scan (top, blue) and database scan: "
+        + COS_FORM.format(simScore));
+    score.setFont(scoreFont);
+    score.setForeground(Color.WHITE);
+    panelScore.setBackground(gradientCol);
+    panelScore.add(score);
+    boxTitlePanel.add(panelScore, "cell 1 0");
+    boxTitlePanel.add(panelTitle, "cell 0 0, growx, center");
+    boxTitle.add(boxTitlePanel);
+
+    // structure preview
+    IAtomContainer molecule;
+    JPanel preview2DPanel = new JPanel(new BorderLayout());
+    preview2DPanel.setPreferredSize(new Dimension(META_WIDTH, 150));
+    preview2DPanel.setMinimumSize(new Dimension(META_WIDTH, 150));
+    preview2DPanel.setMaximumSize(new Dimension(META_WIDTH, 150));
+    JComponent newComponent = null;
+
+    String inchiString = hit.getEntry().getField(DBEntryField.INCHI).orElse("N/A").toString();
+    String smilesString = hit.getEntry().getField(DBEntryField.SMILES).orElse("N/A").toString();
+
+    // check for INCHI
+    if (inchiString != "N/A") {
+      molecule = parseInChi(hit);
+    }
+    // check for smiles
+    else if (smilesString != "N/A") {
+      molecule = parseSmiles(hit);
+    } else
+      molecule = null;
+
+    // try to draw the component
+    if (molecule != null) {
+      try {
+        newComponent = new Structure2DComponent(molecule);
+      } catch (Exception e) {
+        String errorMessage = "Could not load 2D structure\n" + "Exception: ";
+        logger.log(Level.WARNING, errorMessage, e);
+        newComponent = new MultiLineLabel(errorMessage);
+      }
+      preview2DPanel.add(newComponent, BorderLayout.CENTER);
+      preview2DPanel.revalidate();
+
+      metaDataPanel.add(preview2DPanel);
+    }
+
+    // information on compound
+    JPanel panelCompounds =
+        extractMetaData("Compound information", hit.getEntry(), DBEntryField.COMPOUND_FIELDS);
+
+    // instrument info
+    JPanel panelInstrument =
+        extractMetaData("Instrument information", hit.getEntry(), DBEntryField.INSTRUMENT_FIELDS);
+
+    JPanel g1 = new JPanel(new GridLayout(1, 2, 4, 0));
+    g1.setBackground(Color.WHITE);
+    g1.add(panelCompounds);
+    g1.add(panelInstrument);
+    metaDataPanel.add(g1);
+
+    // database links
+    JPanel panelDB =
+        extractMetaData("Database links", hit.getEntry(), DBEntryField.DATABASE_FIELDS);
+
+    // // Other info
+    JPanel panelOther =
+        extractMetaData("Other information", hit.getEntry(), DBEntryField.OTHER_FIELDS);
+
+    JPanel g2 = new JPanel(new GridLayout(1, 2, 4, 0));
+    g2.setBackground(Color.WHITE);
+    g2.add(panelDB);
+    g2.add(panelOther);
+    metaDataPanel.add(g2);
+
+    // get mirror spectra window
+    MirrorScanWindow mirrorWindow = new MirrorScanWindow();
+    mirrorWindow.setScans(hit);
+
+    // fixed width panel
+    ScrollablePanel pn = new ScrollablePanel(new BorderLayout());
+    pn.setScrollableWidth(ScrollablePanel.ScrollableSizeHint.FIT);
+    pn.setScrollableHeight(ScrollablePanel.ScrollableSizeHint.STRETCH);
+    pn.add(metaDataPanel);
+
+
+    JScrollPane metaDataPanelScrollPane =
+        new JScrollPane(pn, ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED,
+            ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
+
+    mirrorChart = mirrorWindow.getMirrorSpecrumPlot();
+    spectrumPanel.add(mirrorChart);
+
+    coupleZoomYListener();
+
+    metaDataPanelScrollPane.setPreferredSize(new Dimension(META_WIDTH + 20, ENTRY_HEIGHT));
+    panel.setPreferredSize(new Dimension(0, ENTRY_HEIGHT));
+
+    panel.add(boxTitle, BorderLayout.NORTH);
+    panel.add(spectrumPanel, BorderLayout.CENTER);
+    panel.add(metaDataPanelScrollPane, BorderLayout.EAST);
+    panel.setBorder(BorderFactory.createLineBorder(Color.BLACK));
+
+    metaDataPanelScrollPane.revalidate();
+    pn.revalidate();
+    panel.revalidate();
+  }
+
+  private void coupleZoomYListener() {
+    CombinedDomainXYPlot domainPlot = (CombinedDomainXYPlot) mirrorChart.getChart().getXYPlot();
+    NumberAxis axis = (NumberAxis) domainPlot.getDomainAxis();
+    axis.setLabel("m/z");
+    queryPlot = (XYPlot) domainPlot.getSubplots().get(0);
+    libraryPlot = (XYPlot) domainPlot.getSubplots().get(1);
+    queryPlot.getRangeAxis().addChangeListener(new AxisRangeChangedListener(null) {
+      @Override
+      public void axisRangeChanged(ChartViewWrapper chart, ValueAxis axis, Range lastR,
+          Range newR) {
+        rangeHasChanged(newR);
+      }
+    });
+    libraryPlot.getRangeAxis().addChangeListener(new AxisRangeChangedListener(null) {
+      @Override
+      public void axisRangeChanged(ChartViewWrapper chart, ValueAxis axis, Range lastR,
+          Range newR) {
+        rangeHasChanged(newR);
+      }
+    });
+  }
+
+  /**
+   * Apply changes to all other charts
+   * 
+   * @param range
+   */
+  private void rangeHasChanged(Range range) {
+    if (setCoupleZoomY) {
+      ValueAxis axis = libraryPlot.getRangeAxis();
+      if (!axis.getRange().equals(range))
+        axis.setRange(range);
+      ValueAxis axisQuery = queryPlot.getRangeAxis();
+      if (!axisQuery.getRange().equals(range))
+        axisQuery.setRange(range);
+    }
+  }
+
+  private JPanel extractMetaData(String title, SpectralDBEntry entry, DBEntryField[] other) {
+    JPanel panelOther = new JPanel();
+    panelOther.setLayout(new BoxLayout(panelOther, BoxLayout.Y_AXIS));
+    panelOther.setBackground(Color.WHITE);
+    panelOther.setAlignmentY(Component.TOP_ALIGNMENT);
+    panelOther.setAlignmentX(Component.TOP_ALIGNMENT);
+
+    for (DBEntryField db : other) {
+      Object o = entry.getField(db).orElse("N/A");
+      if (!o.equals("N/A")) {
+        CustomTextPane textPane = new CustomTextPane(true);
+        textPane.setText(db.toString() + ": " + o.toString());
+        panelOther.add(textPane);
+      }
+    }
+
+    JLabel otherInfo = new JLabel(title);
+    otherInfo.setFont(headerFont);
+    JPanel pn = new JPanel(new BorderLayout());
+    pn.setBackground(Color.WHITE);
+    pn.add(otherInfo, BorderLayout.NORTH);
+    pn.add(panelOther, BorderLayout.CENTER);
+    JPanel pn1 = new JPanel(new BorderLayout());
+    pn1.add(pn, BorderLayout.NORTH);
+    pn1.setBackground(Color.WHITE);
+    return pn1;
+  }
+
+
+  private IAtomContainer parseInChi(SpectralDBPeakIdentity hit) {
+    String inchiString = hit.getEntry().getField(DBEntryField.INCHI).orElse("N/A").toString();
+    InChIGeneratorFactory factory;
+    IAtomContainer molecule;
+    if (inchiString != "N/A") {
+      try {
+        factory = InChIGeneratorFactory.getInstance();
+        // Get InChIToStructure
+        InChIToStructure inchiToStructure =
+            factory.getInChIToStructure(inchiString, DefaultChemObjectBuilder.getInstance());
+        molecule = inchiToStructure.getAtomContainer();
+        return molecule;
+      } catch (CDKException e) {
+        String errorMessage = "Could not load 2D structure\n" + "Exception: ";
+        logger.log(Level.WARNING, errorMessage, e);
+        return null;
+      }
+    } else
+      return null;
+  }
+
+  private IAtomContainer parseSmiles(SpectralDBPeakIdentity hit) {
+    SmilesParser smilesParser = new SmilesParser(DefaultChemObjectBuilder.getInstance());
+    String smilesString = hit.getEntry().getField(DBEntryField.SMILES).orElse("N/A").toString();
+    IAtomContainer molecule;
+    if (smilesString != "N/A") {
+      try {
+        molecule = smilesParser.parseSmiles(smilesString);
+        return molecule;
+      } catch (InvalidSmilesException e1) {
+        String errorMessage = "Could not load 2D structure\n" + "Exception: ";
+        logger.log(Level.WARNING, errorMessage, e1);
+        return null;
+      }
+    } else
+      return null;
+  }
+
+  /**
+   * The mirror chart panel
+   * 
+   * @return
+   */
+  public EChartPanel getMirrorChart() {
+    return mirrorChart;
+  }
+
+  /**
+   * Couple y zoom of both XYPlots
+   * 
+   * @param selected
+   */
+  public void setCoupleZoomY(boolean selected) {
+    setCoupleZoomY = selected;
+  }
+
+}

--- a/src/main/java/net/sf/mzmine/util/ColorScaleUtil.java
+++ b/src/main/java/net/sf/mzmine/util/ColorScaleUtil.java
@@ -1,0 +1,34 @@
+package net.sf.mzmine.util;
+
+import java.awt.Color;
+
+public class ColorScaleUtil {
+
+  /**
+   * Get color of gradient between min and max color
+   * 
+   * @param min
+   * @param max
+   * @param minValue
+   * @param maxValue
+   * @param value
+   * @return
+   */
+  public static Color getColor(Color min, Color max, double minValue, double maxValue,
+      double value) {
+    // hue saturation brightness
+    float[] minHSB = Color.RGBtoHSB(min.getRed(), min.getGreen(), min.getBlue(), null);
+    float[] maxHSB = Color.RGBtoHSB(max.getRed(), max.getGreen(), max.getBlue(), null);
+
+    double diff = maxValue - minValue;
+    double p = (Math.min(value, minValue) - minValue) / diff;
+    if (p > 1)
+      p = 1;
+
+    // gradient
+    float h = (float) ((maxHSB[0] - minHSB[0]) * p + minHSB[0]);
+    float s = (float) ((maxHSB[1] - minHSB[1]) * p + minHSB[1]);
+    float b = (float) ((maxHSB[2] - minHSB[2]) * p + minHSB[2]);
+    return Color.getHSBColor(h, s, b);
+  }
+}

--- a/src/main/java/net/sf/mzmine/util/ColorScaleUtil.java
+++ b/src/main/java/net/sf/mzmine/util/ColorScaleUtil.java
@@ -21,7 +21,7 @@ public class ColorScaleUtil {
     float[] maxHSB = Color.RGBtoHSB(max.getRed(), max.getGreen(), max.getBlue(), null);
 
     double diff = maxValue - minValue;
-    double p = (Math.min(value, minValue) - minValue) / diff;
+    double p = (Math.max(value, minValue) - minValue) / diff;
     if (p > 1)
       p = 1;
 

--- a/src/main/java/net/sf/mzmine/util/spectraldb/entry/DBEntryField.java
+++ b/src/main/java/net/sf/mzmine/util/spectraldb/entry/DBEntryField.java
@@ -18,12 +18,26 @@
 
 package net.sf.mzmine.util.spectraldb.entry;
 
+import org.apache.commons.lang3.StringUtils;
+
 public enum DBEntryField {
 
-  ENTRY_ID, NAME, SYNONYM, COMMENT, IONTYPE, RT(Double.class), MZ(Double.class), CHARGE(
+  ENTRY_ID, NAME, SYNONYM, COMMENT, ION_TYPE, RT(Double.class), MZ(Double.class), CHARGE(
       Integer.class), ION_MODE, COLLISION_ENERGY, FORMULA, MOLWEIGHT(Double.class), EXACT_MASS(
           Double.class), INCHI, INCHIKEY, SMILES, CAS, PUBMED, PUBCHEM, MONA_ID, CHEMSPIDER, INSTRUMENT_TYPE, INSTRUMENT, ION_SOURCE, NUM_PEAKS(
               Integer.class), ACQUISITION, PRINCIPAL_INVESTIGATOR, DATA_COLLECTOR, SOFTWARE, MS_LEVEL, RESOLUTION;
+
+  // group of DBEntryFields logically
+  public static final DBEntryField[] OTHER_FIELDS =
+      new DBEntryField[] {PRINCIPAL_INVESTIGATOR, DATA_COLLECTOR, ENTRY_ID, COMMENT};
+  public static final DBEntryField[] DATABASE_FIELDS =
+      new DBEntryField[] {PUBMED, PUBCHEM, MONA_ID, CHEMSPIDER, CAS};
+  public static final DBEntryField[] COMPOUND_FIELDS =
+      new DBEntryField[] {NAME, SYNONYM, FORMULA, MOLWEIGHT, EXACT_MASS, ION_TYPE, MZ, CHARGE, RT,
+          ION_MODE, INCHI, INCHIKEY, SMILES, NUM_PEAKS};
+  public static final DBEntryField[] INSTRUMENT_FIELDS = new DBEntryField[] {INSTRUMENT_TYPE,
+      INSTRUMENT, ION_SOURCE, RESOLUTION, MS_LEVEL, COLLISION_ENERGY, ACQUISITION, SOFTWARE};
+
 
   private final Class clazz;
 
@@ -37,6 +51,30 @@ public enum DBEntryField {
 
   public Class getObjectClass() {
     return clazz;
+  }
+
+  @Override
+  public String toString() {
+    switch (this) {
+      case RT:
+      case SMILES:
+      case CAS:
+        return super.toString().replace('_', ' ');
+      case ENTRY_ID:
+        return "Entry ID";
+      case INCHI:
+        return "InChI";
+      case INCHIKEY:
+        return "InChI key";
+      case MOLWEIGHT:
+        return "Mol. weight";
+      case MONA_ID:
+        return "MoNA ID";
+      case MZ:
+        return "Precursor m/z";
+      default:
+        return StringUtils.capitalize(super.toString().replace('_', ' ').toLowerCase());
+    }
   }
 
   /**
@@ -71,7 +109,7 @@ public enum DBEntryField {
         return "INSTRUMENT_NAME";
       case INSTRUMENT_TYPE:
         return "INSTRUMENT";
-      case IONTYPE:
+      case ION_TYPE:
         return "ADDUCT";
       case ION_MODE:
         return "IONMODE";
@@ -157,7 +195,7 @@ public enum DBEntryField {
         return "Instrument";
       case INSTRUMENT_TYPE:
         return "Instrument_type";
-      case IONTYPE:
+      case ION_TYPE:
         return "Precursor_type";
       case ION_MODE:
         return "Ion_mode"; // P / N
@@ -243,7 +281,7 @@ public enum DBEntryField {
         return "SOURCE_INSTRUMENT";
       case INSTRUMENT_TYPE:
         return "Instrument_type";
-      case IONTYPE:
+      case ION_TYPE:
         return "Precursor_type";
       case ION_MODE:
         return "IONMODE"; // Positive Negative
@@ -330,7 +368,7 @@ public enum DBEntryField {
         return "";
       case INSTRUMENT_TYPE:
         return "";
-      case IONTYPE:
+      case ION_TYPE:
         return "";
       case ION_MODE:
         return "";
@@ -398,4 +436,5 @@ public enum DBEntryField {
       return Integer.parseInt(content);
     return content;
   }
+
 }

--- a/src/main/java/net/sf/mzmine/util/spectraldb/entry/SpectralDBPeakIdentity.java
+++ b/src/main/java/net/sf/mzmine/util/spectraldb/entry/SpectralDBPeakIdentity.java
@@ -45,7 +45,7 @@ public class SpectralDBPeakIdentity extends SimplePeakIdentity {
             entry.getField(DBEntryField.NAME).orElse("NONAME"), // Name
             entry.getField(DBEntryField.MZ).orElse(""), // precursor m/z
             entry.getField(DBEntryField.FORMULA).orElse(""), // molecular formula
-            entry.getField(DBEntryField.IONTYPE).orElse(""), // Ion type
+            entry.getField(DBEntryField.ION_TYPE).orElse(""), // Ion type
             COS_FORM.format(similarity.getScore())), // cosine similarity
         entry.getField(DBEntryField.FORMULA).orElse("").toString(), method, "", "");
     this.entry = entry;

--- a/src/main/java/net/sf/mzmine/util/spectraldb/parser/GnpsMgfParser.java
+++ b/src/main/java/net/sf/mzmine/util/spectraldb/parser/GnpsMgfParser.java
@@ -130,7 +130,7 @@ public class GnpsMgfParser extends SpectralDBParser {
                                 // use as adduct
                                 String adduct = AdductParser.parse(adductCandidate);
                                 if (adduct != null && !adduct.isEmpty())
-                                  fields.put(DBEntryField.IONTYPE, adduct);
+                                  fields.put(DBEntryField.ION_TYPE, adduct);
                               }
                             }
 

--- a/src/main/java/net/sf/mzmine/util/spectraldb/parser/MonaJsonParser.java
+++ b/src/main/java/net/sf/mzmine/util/spectraldb/parser/MonaJsonParser.java
@@ -199,7 +199,7 @@ public class MonaJsonParser extends SpectralDBParser {
           if (value != null)
             value = value.toString();
           break;
-        case IONTYPE:
+        case ION_TYPE:
           value = readMetaData(main, "precursor type");
           break;
         case ION_MODE:

--- a/src/main/java/net/sf/mzmine/util/spectraldb/parser/MonaJsonParser.java
+++ b/src/main/java/net/sf/mzmine/util/spectraldb/parser/MonaJsonParser.java
@@ -23,7 +23,9 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.StringReader;
+import java.util.ArrayList;
 import java.util.EnumMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.logging.Level;
@@ -99,6 +101,9 @@ public class MonaJsonParser extends SpectralDBParser {
 
     int correct = 0;
     int error = 0;
+    List<InnerParser> parser = new ArrayList<>();
+    String[] buffer = new String[25];
+    int i = 0;
     // create db
     try (BufferedReader br = new BufferedReader(new FileReader(dataBaseFile))) {
       for (String l; (l = br.readLine()) != null;) {
@@ -107,6 +112,68 @@ public class MonaJsonParser extends SpectralDBParser {
           return false;
         }
 
+        buffer[i] = l;
+        i++;
+        if (i == buffer.length) {
+          // start new inner parser thread
+          InnerParser p = new InnerParser(buffer, mainTask);
+          Thread t = new Thread(p);
+          t.setDaemon(true);
+          t.setName("Inner parser of MonaJsonParser");
+          t.start();
+          buffer = new String[25];
+          i = 0;
+        }
+
+
+        // to many errors? wrong data format?
+        if (parser.size() > 0 && parser.get(0).getError() >= 4) {
+          logger.log(Level.WARNING, "This file was no MONA spectral json library");
+          parser.stream().forEach(InnerParser::stop);
+          return false;
+        }
+      }
+    }
+    // wait for all to finish
+    while (parser.stream().anyMatch(ip -> !ip.isDone))
+
+      //
+      finish();
+    return true;
+  }
+
+
+  /**
+   * Test of inner parser to separate reading and parsing
+   * 
+   * @author
+   * 
+   */
+  private class InnerParser implements Runnable {
+    private boolean isDone = false;
+    private boolean isStopped = false;
+    private String[] lines;
+    private int error = 0;
+    private int correct = 0;
+    private AbstractTask mainTask;
+
+    InnerParser(String[] lines, AbstractTask mainTask) {
+      this.lines = lines;
+      this.mainTask = mainTask;
+    }
+
+    @Override
+    public void run() {
+      error = 0;
+      correct = 0;
+      for (String l : lines) {
+        if (l == null || l.isEmpty())
+          continue;
+
+        if (isStopped || (mainTask != null && mainTask.isCanceled())) {
+          isDone = true;
+          return;
+        }
         JsonReader reader = null;
         try {
           reader = Json.createReader(new StringReader(l));
@@ -124,245 +191,254 @@ public class MonaJsonParser extends SpectralDBParser {
           if (reader != null)
             reader.close();
         }
-        // to many errors? wrong data format?
-        if (error > 5 && correct < 4) {
-          logger.log(Level.WARNING, "This file was no MONA spectral json library");
-          return false;
+      }
+      isDone = true;
+    }
+
+    public void stop() {
+      this.isStopped = true;
+    }
+
+    public int getCorrect() {
+      return correct;
+    }
+
+    public int getError() {
+      return error;
+    }
+
+    public boolean isDone() {
+      return isDone;
+    }
+
+
+    public SpectralDBEntry getDBEntry(JsonObject main) {
+      // extract dps
+      DataPoint[] dps = getDataPoints(main);
+      if (dps == null || dps.length == 0)
+        return null;
+      // metadata
+      Map<DBEntryField, Object> map = new EnumMap<>(DBEntryField.class);
+      extractAllFields(main, map);
+      return new SpectralDBEntry(map, dps);
+    }
+
+    private void extractAllFields(JsonObject main, Map<DBEntryField, Object> map) {
+      for (DBEntryField f : DBEntryField.values()) {
+        Object value = null;
+        JsonValue j = null;
+
+        switch (f) {
+          case INCHI:
+            value = readCompound(main, "inchi");
+            if (value == null) {
+              value = readCompoundMetaData(main, "InChI");
+            }
+            break;
+          case INCHIKEY:
+            value = readCompound(main, "inchiKey");
+            if (value == null) {
+              value = readCompoundMetaData(main, "InChIKey");
+            }
+            break;
+          case ACQUISITION:
+            break;
+          case MONA_ID:
+            value = readMetaData(main, "accession");
+            break;
+          case CAS:
+            // TODO check real id (cas CAS ?)
+            value = readCompoundMetaData(main, "cas");
+            break;
+          case CHARGE:
+            break;
+          case COLLISION_ENERGY:
+            value = readMetaData(main, "collision energy");
+            break;
+          case COMMENT:
+            break;
+          case DATA_COLLECTOR:
+            value = readMetaData(main, "author");
+            break;
+          case INSTRUMENT:
+            value = readMetaData(main, "instrument");
+            break;
+          case INSTRUMENT_TYPE:
+            value = readMetaData(main, "instrument type");
+            break;
+          case MS_LEVEL:
+            value = readMetaData(main, "ms level");
+            break;
+          case RESOLUTION:
+            value = readMetaData(main, "resolution");
+            if (value != null)
+              value = value.toString();
+            break;
+          case ION_TYPE:
+            value = readMetaData(main, "precursor type");
+            break;
+          case ION_MODE:
+            value = readMetaData(main, "ionization mode");
+            break;
+          case ION_SOURCE:
+            value = readMetaData(main, "ionization");
+            break;
+          case EXACT_MASS:
+            value = readMetaDataDouble(main, "exact mass");
+            break;
+          case MOLWEIGHT:
+            value = readMetaDataDouble(main, "exact mass");
+            break;
+          case MZ:
+            value = readMetaDataDouble(main, "precursor m/z");
+            break;
+          case NAME:
+            // can have multiple names
+            JsonArray names = main.getJsonArray(COMPOUND).getJsonObject(0).getJsonArray("names");
+            value = names.stream().map(v -> v.asJsonObject()).map(v -> v.getString("name", null))
+                .filter(Objects::nonNull).collect(Collectors.joining(", "));
+            break;
+          case NUM_PEAKS:
+            break;
+          case PRINCIPAL_INVESTIGATOR:
+            value = readMetaData(main, "author");
+            break;
+          case CHEMSPIDER:
+            j = readCompoundMetaDataJson(main, "chemspider");
+            if (j != null) {
+              if (j.getValueType().equals(ValueType.STRING))
+                value = ((JsonString) j).getString();
+              if (j.getValueType().equals(ValueType.NUMBER))
+                value = ((JsonNumber) j).intValue();
+            }
+            break;
+          case PUBCHEM:
+            j = readCompoundMetaDataJson(main, "pubchem cid");
+            if (j != null) {
+              if (j.getValueType().equals(ValueType.STRING))
+                value = ((JsonString) j).getString();
+              if (j.getValueType().equals(ValueType.NUMBER))
+                value = ((JsonNumber) j).intValue();
+            }
+            break;
+          case FORMULA:
+            value = readCompoundMetaData(main, "molecular formula");
+            break;
+          case PUBMED:
+            break;
+          case RT:
+            Object tmp = readMetaData(main, "retention time");
+            if (tmp != null) {
+              if (tmp instanceof Number)
+                value = ((Number) tmp).doubleValue();
+              else {
+                try {
+                  String v = (String) tmp;
+                  v = v.replaceAll(" ", "");
+                  // to minutes
+                  if (v.endsWith("sec")) {
+                    v = v.substring(0, v.length() - 3);
+                    value = Double.parseDouble(v) / 60d;
+                  } else {
+                    value = Double.parseDouble(v);
+                  }
+                } catch (Exception ex) {
+                }
+              }
+            }
+            break;
+          case SMILES:
+            value = readCompoundMetaData(main, "SMILES");
+            break;
+          case SOFTWARE:
+            break;
+          case SYNONYM:
+            break;
+          default:
+            break;
+        }
+
+        if (value != null && value.equals("N/A"))
+          value = null;
+        // add value
+        if (value != null) {
+          // add
+          map.put(f, value);
         }
       }
     }
 
-    //
-    finish();
-    return true;
-  }
+    /**
+     * read from META_DATA array
+     * 
+     * @param main
+     * @param id
+     * @return String or Number or null
+     */
+    private Object readMetaData(JsonObject main, String id) {
+      JsonValue j = main.getJsonArray(META_DATA).stream().map(v -> v.asJsonObject())
+          .filter(v -> v.getString("name").equals(id)).map(v -> v.get("value")).findFirst()
+          .orElse(null);
 
-  public SpectralDBEntry getDBEntry(JsonObject main) {
-    // extract dps
-    DataPoint[] dps = getDataPoints(main);
-    if (dps == null || dps.length == 0)
-      return null;
-    // metadata
-    Map<DBEntryField, Object> map = new EnumMap<>(DBEntryField.class);
-    extractAllFields(main, map);
-    return new SpectralDBEntry(map, dps);
-  }
-
-  private void extractAllFields(JsonObject main, Map<DBEntryField, Object> map) {
-    for (DBEntryField f : DBEntryField.values()) {
-      Object value = null;
-      JsonValue j = null;
-
-      switch (f) {
-        case INCHI:
-          value = readCompound(main, "inchi");
-          if (value == null) {
-            value = readCompoundMetaData(main, "InChI");
-          }
-          break;
-        case INCHIKEY:
-          value = readCompound(main, "inchiKey");
-          if (value == null) {
-            value = readCompoundMetaData(main, "InChIKey");
-          }
-          break;
-        case ACQUISITION:
-          break;
-        case MONA_ID:
-          value = readMetaData(main, "accession");
-          break;
-        case CAS:
-          // TODO check real id (cas CAS ?)
-          value = readCompoundMetaData(main, "cas");
-          break;
-        case CHARGE:
-          break;
-        case COLLISION_ENERGY:
-          value = readMetaData(main, "collision energy");
-          break;
-        case COMMENT:
-          break;
-        case DATA_COLLECTOR:
-          value = readMetaData(main, "author");
-          break;
-        case INSTRUMENT:
-          value = readMetaData(main, "instrument");
-          break;
-        case INSTRUMENT_TYPE:
-          value = readMetaData(main, "instrument type");
-          break;
-        case MS_LEVEL:
-          value = readMetaData(main, "ms level");
-          break;
-        case RESOLUTION:
-          value = readMetaData(main, "resolution");
-          if (value != null)
-            value = value.toString();
-          break;
-        case ION_TYPE:
-          value = readMetaData(main, "precursor type");
-          break;
-        case ION_MODE:
-          value = readMetaData(main, "ionization mode");
-          break;
-        case ION_SOURCE:
-          value = readMetaData(main, "ionization");
-          break;
-        case EXACT_MASS:
-          value = readMetaDataDouble(main, "exact mass");
-          break;
-        case MOLWEIGHT:
-          value = readMetaDataDouble(main, "exact mass");
-          break;
-        case MZ:
-          value = readMetaDataDouble(main, "precursor m/z");
-          break;
-        case NAME:
-          // can have multiple names
-          JsonArray names = main.getJsonArray(COMPOUND).getJsonObject(0).getJsonArray("names");
-          value = names.stream().map(v -> v.asJsonObject()).map(v -> v.getString("name", null))
-              .filter(Objects::nonNull).collect(Collectors.joining(", "));
-          break;
-        case NUM_PEAKS:
-          break;
-        case PRINCIPAL_INVESTIGATOR:
-          value = readMetaData(main, "author");
-          break;
-        case CHEMSPIDER:
-          j = readCompoundMetaDataJson(main, "chemspider");
-          if (j != null) {
-            if (j.getValueType().equals(ValueType.STRING))
-              value = ((JsonString) j).getString();
-            if (j.getValueType().equals(ValueType.NUMBER))
-              value = ((JsonNumber) j).intValue();
-          }
-          break;
-        case PUBCHEM:
-          j = readCompoundMetaDataJson(main, "pubchem cid");
-          if (j != null) {
-            if (j.getValueType().equals(ValueType.STRING))
-              value = ((JsonString) j).getString();
-            if (j.getValueType().equals(ValueType.NUMBER))
-              value = ((JsonNumber) j).intValue();
-          }
-          break;
-        case FORMULA:
-          value = readCompoundMetaData(main, "molecular formula");
-          break;
-        case PUBMED:
-          break;
-        case RT:
-          Object tmp = readMetaData(main, "retention time");
-          if (tmp != null) {
-            if (tmp instanceof Number)
-              value = ((Number) tmp).doubleValue();
-            else {
-              try {
-                String v = (String) tmp;
-                v = v.replaceAll(" ", "");
-                // to minutes
-                if (v.endsWith("sec")) {
-                  v = v.substring(0, v.length() - 3);
-                  value = Double.parseDouble(v) / 60d;
-                } else {
-                  value = Double.parseDouble(v);
-                }
-              } catch (Exception ex) {
-              }
-            }
-          }
-          break;
-        case SMILES:
-          value = readCompoundMetaData(main, "SMILES");
-          break;
-        case SOFTWARE:
-          break;
-        case SYNONYM:
-          break;
-        default:
-          break;
+      if (j != null) {
+        if (j.getValueType().equals(ValueType.STRING))
+          return ((JsonString) j).getString();
+        if (j.getValueType().equals(ValueType.NUMBER))
+          return ((JsonNumber) j).numberValue();
       }
-
-      if (value != null && value.equals("N/A"))
-        value = null;
-      // add value
-      if (value != null) {
-        // add
-        map.put(f, value);
-      }
-    }
-  }
-
-  /**
-   * read from META_DATA array
-   * 
-   * @param main
-   * @param id
-   * @return String or Number or null
-   */
-  private Object readMetaData(JsonObject main, String id) {
-    JsonValue j = main.getJsonArray(META_DATA).stream().map(v -> v.asJsonObject())
-        .filter(v -> v.getString("name").equals(id)).map(v -> v.get("value")).findFirst()
-        .orElse(null);
-
-    if (j != null) {
-      if (j.getValueType().equals(ValueType.STRING))
-        return ((JsonString) j).getString();
-      if (j.getValueType().equals(ValueType.NUMBER))
-        return ((JsonNumber) j).numberValue();
-    }
-    return null;
-  }
-
-  private Double readMetaDataDouble(JsonObject main, String id) {
-    return main.getJsonArray(META_DATA).stream().map(v -> v.asJsonObject())
-        .filter(v -> v.getString("name").equals(id))
-        .map(v -> v.getJsonNumber("value").doubleValue()).findFirst().orElse(null);
-  }
-
-  private JsonValue readCompoundMetaDataJson(JsonObject main, String id) {
-    return main.getJsonArray(COMPOUND).getJsonObject(0).getJsonArray(META_DATA).stream()
-        .map(v -> v.asJsonObject()).filter(v -> v.getString("name").equals(id))
-        .map(v -> v.get("value")).findFirst().orElse(null);
-  }
-
-  /**
-   * read from COMPOUND...META_DATA array
-   * 
-   * @param main
-   * @param id
-   * @return
-   */
-  private String readCompoundMetaData(JsonObject main, String id) {
-    return main.getJsonArray(COMPOUND).getJsonObject(0).getJsonArray(META_DATA).stream()
-        .map(v -> v.asJsonObject()).filter(v -> v.getString("name").equals(id))
-        .map(v -> v.getString("value")).findFirst().orElse(null);
-  }
-
-  /**
-   * Read from COMPOUND object
-   * 
-   * @param main
-   * @param id
-   * @return
-   */
-  private String readCompound(JsonObject main, String id) {
-    return main.getJsonArray(COMPOUND).getJsonObject(0).getString(id, null);
-  }
-
-
-  public DataPoint[] getDataPoints(JsonObject main) {
-    String spec = main.getString("spectrum");
-    if (spec == null)
       return null;
-    String[] data = spec.split(" ");
-    DataPoint[] dps = new DataPoint[data.length];
-    for (int i = 0; i < dps.length; i++) {
-      String[] dp = data[i].split(":");
-      double mz = Double.parseDouble(dp[0]);
-      double intensity = Double.parseDouble(dp[1]);
-      dps[i] = new SimpleDataPoint(mz, intensity);
     }
-    return dps;
+
+    private Double readMetaDataDouble(JsonObject main, String id) {
+      return main.getJsonArray(META_DATA).stream().map(v -> v.asJsonObject())
+          .filter(v -> v.getString("name").equals(id))
+          .map(v -> v.getJsonNumber("value").doubleValue()).findFirst().orElse(null);
+    }
+
+    private JsonValue readCompoundMetaDataJson(JsonObject main, String id) {
+      return main.getJsonArray(COMPOUND).getJsonObject(0).getJsonArray(META_DATA).stream()
+          .map(v -> v.asJsonObject()).filter(v -> v.getString("name").equals(id))
+          .map(v -> v.get("value")).findFirst().orElse(null);
+    }
+
+    /**
+     * read from COMPOUND...META_DATA array
+     * 
+     * @param main
+     * @param id
+     * @return
+     */
+    private String readCompoundMetaData(JsonObject main, String id) {
+      return main.getJsonArray(COMPOUND).getJsonObject(0).getJsonArray(META_DATA).stream()
+          .map(v -> v.asJsonObject()).filter(v -> v.getString("name").equals(id))
+          .map(v -> v.getString("value")).findFirst().orElse(null);
+    }
+
+    /**
+     * Read from COMPOUND object
+     * 
+     * @param main
+     * @param id
+     * @return
+     */
+    private String readCompound(JsonObject main, String id) {
+      return main.getJsonArray(COMPOUND).getJsonObject(0).getString(id, null);
+    }
+
+
+    public DataPoint[] getDataPoints(JsonObject main) {
+      String spec = main.getString("spectrum");
+      if (spec == null)
+        return null;
+      String[] data = spec.split(" ");
+      DataPoint[] dps = new DataPoint[data.length];
+      for (int i = 0; i < dps.length; i++) {
+        String[] dp = data[i].split(":");
+        double mz = Double.parseDouble(dp[0]);
+        double intensity = Double.parseDouble(dp[1]);
+        dps[i] = new SimpleDataPoint(mz, intensity);
+      }
+      return dps;
+    }
   }
 }


### PR DESCRIPTION
This is a first fix for the spectral match results visualisation:
- Color scale from red - to green (score = 0.5 to 1.0, respectively)
- Sizes of meta data panel and chart

A problem with the layout remains. Somehow, the meta data is visualised with larger height (also the structure). Suddenly after scrolling down, everthing changed to the actual layout. I did revalidate on every change but still...

![image](https://user-images.githubusercontent.com/10366914/58482741-40c46600-815f-11e9-8f27-cd990dd4f360.png)
![image](https://user-images.githubusercontent.com/10366914/58482768-4c179180-815f-11e9-90dc-ba26d312f58e.png)

