### PR TITLE
Color palettes and mode for color blindness

### DIFF
--- a/src/main/java/net/sf/mzmine/datamodel/MassSpectrum.java
+++ b/src/main/java/net/sf/mzmine/datamodel/MassSpectrum.java
@@ -18,10 +18,9 @@
 
 package net.sf.mzmine.datamodel;
 
-import com.google.common.collect.Range;
-
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import com.google.common.collect.Range;
 
 /**
  * This class represent one mass spectrum.
@@ -52,8 +51,9 @@ public interface MassSpectrum {
   public double getTIC();
 
   /**
-   *
-   * @return True if the scan data is centroided
+   * Centroid / profile / thresholded
+   * 
+   * @return
    */
   public MassSpectrumType getSpectrumType();
 

--- a/src/main/java/net/sf/mzmine/desktop/preferences/MZminePreferences.java
+++ b/src/main/java/net/sf/mzmine/desktop/preferences/MZminePreferences.java
@@ -26,12 +26,19 @@ import net.sf.mzmine.parameters.Parameter;
 import net.sf.mzmine.parameters.ParameterSet;
 import net.sf.mzmine.parameters.impl.SimpleParameterSet;
 import net.sf.mzmine.parameters.parametertypes.BooleanParameter;
+import net.sf.mzmine.parameters.parametertypes.ComboParameter;
 import net.sf.mzmine.parameters.parametertypes.WindowSettingsParameter;
 import net.sf.mzmine.parameters.parametertypes.filenames.FileNameParameter;
 import net.sf.mzmine.parameters.parametertypes.submodules.OptionalModuleParameter;
+import net.sf.mzmine.util.ColorPalettes;
 import net.sf.mzmine.util.ExitCode;
 
 public class MZminePreferences extends SimpleParameterSet {
+
+  public static final ComboParameter<ColorPalettes.Vision> colorPalettes = new ComboParameter<>(
+      "Color palettes (color blindness mode)",
+      "Some modules use the color blindness aware palettes for a higher contrast. Think about using this mode even with \"normal vision\" to reach everyone.",
+      ColorPalettes.Vision.values(), ColorPalettes.Vision.DEUTERANOPIA);
 
   public static final NumberFormatParameter mzFormat = new NumberFormatParameter("m/z value format",
       "Format of m/z values", false, new DecimalFormat("0.0000"));
@@ -62,8 +69,8 @@ public class MZminePreferences extends SimpleParameterSet {
   public static final WindowSettingsParameter windowSetttings = new WindowSettingsParameter();
 
   public MZminePreferences() {
-    super(new Parameter[] {mzFormat, rtFormat, intensityFormat, numOfThreads, proxySettings,
-        rExecPath, sendStatistics, windowSetttings, sendErrorEMail});
+    super(new Parameter[] {colorPalettes, mzFormat, rtFormat, intensityFormat, numOfThreads,
+        proxySettings, rExecPath, sendStatistics, windowSetttings, sendErrorEMail});
   }
 
   @Override

--- a/src/main/java/net/sf/mzmine/main/MZmineConfiguration.java
+++ b/src/main/java/net/sf/mzmine/main/MZmineConfiguration.java
@@ -27,6 +27,7 @@ import net.sf.mzmine.desktop.preferences.MZminePreferences;
 import net.sf.mzmine.modules.MZmineModule;
 import net.sf.mzmine.parameters.ParameterSet;
 import net.sf.mzmine.parameters.parametertypes.filenames.FileNameListSilentParameter;
+import net.sf.mzmine.util.ColorPalettes.Vision;
 
 /**
  * MZmine configuration interface
@@ -70,5 +71,12 @@ public interface MZmineConfiguration {
   public String getRexecPath();
 
   public Boolean getSendStatistics();
+
+  /**
+   * For color blindness or "normal vision"
+   * 
+   * @return
+   */
+  public Vision getColorVision();
 
 }

--- a/src/main/java/net/sf/mzmine/main/impl/MZmineConfigurationImpl.java
+++ b/src/main/java/net/sf/mzmine/main/impl/MZmineConfigurationImpl.java
@@ -47,6 +47,7 @@ import net.sf.mzmine.main.MZmineCore;
 import net.sf.mzmine.modules.MZmineModule;
 import net.sf.mzmine.parameters.ParameterSet;
 import net.sf.mzmine.parameters.parametertypes.filenames.FileNameListSilentParameter;
+import net.sf.mzmine.util.ColorPalettes;
 
 /**
  * MZmine configuration class
@@ -91,6 +92,12 @@ public class MZmineConfigurationImpl implements MZmineConfiguration {
     }
     moduleParameters.put(moduleClass, parameters);
 
+  }
+
+  // color palettes
+  @Override
+  public ColorPalettes.Vision getColorVision() {
+    return preferences.getParameter(MZminePreferences.colorPalettes).getValue();
   }
 
   // Number formatting functions

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/spectraldbsubmit/view/ScanSelectPanel.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/spectraldbsubmit/view/ScanSelectPanel.java
@@ -23,6 +23,8 @@ import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.Image;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 import java.awt.event.ItemEvent;
 import java.text.MessageFormat;
 import java.util.List;
@@ -50,19 +52,21 @@ import net.sf.mzmine.chartbasics.gui.swing.EChartPanel;
 import net.sf.mzmine.datamodel.DataPoint;
 import net.sf.mzmine.datamodel.MassList;
 import net.sf.mzmine.datamodel.PeakListRow;
-import net.sf.mzmine.datamodel.RawDataFile;
 import net.sf.mzmine.datamodel.Scan;
 import net.sf.mzmine.framework.documentfilter.DocumentSizeFilter;
 import net.sf.mzmine.main.MZmineCore;
 import net.sf.mzmine.modules.peaklistmethods.io.spectraldbsubmit.AdductParser;
 import net.sf.mzmine.modules.visualization.spectra.simplespectra.SpectraPlot;
-import net.sf.mzmine.modules.visualization.spectra.simplespectra.SpectraVisualizerWindow;
+import net.sf.mzmine.modules.visualization.spectra.simplespectra.datasets.DataPointsDataSet;
 import net.sf.mzmine.util.exceptions.MissingMassListException;
 import net.sf.mzmine.util.scans.ScanUtils;
 import net.sf.mzmine.util.scans.sorting.ScanSortMode;
 
-public class ScanSelectPanel extends JPanel {
+public class ScanSelectPanel extends JPanel implements ActionListener {
 
+
+  public static final Color colorRemovedData = new Color(0xF57C00); // orange
+  public static final Color colorUsedData = new Color(0x388E3C); // green
   private static final int SIZE = 40;
   // icons
   static final Icon iconTIC = createIcon("icons/btnTIC.png");
@@ -94,12 +98,8 @@ public class ScanSelectPanel extends JPanel {
 
   private JPanel pnChart;
 
-  private boolean showLegend = true;
-
   private JToggleButton btnSignals;
-
   private JToggleButton btnMaxTic;
-
   private SpectraPlot spectrumPlot;
 
   private Consumer<EChartPanel> listener;
@@ -114,6 +114,8 @@ public class ScanSelectPanel extends JPanel {
   private JLabel lblChargeMz;
   private JButton btnFromScan;
 
+  private boolean showRemovedData = true;
+  private boolean showLegend = true;
   // MS1 or MS2
   private boolean isFragmentScan = true;
 
@@ -473,24 +475,35 @@ public class ScanSelectPanel extends JPanel {
    */
   public void createChart() {
     setValidSelection(false);
-    EChartPanel oldChart = spectrumPlot;
-    // empty
     pnChart.removeAll();
-    spectrumPlot = null;
 
     if (scans != null && !scans.isEmpty()) {
-      Scan scan = scans.get(selectedScanI);
-      RawDataFile raw = scan.getDataFile();
       // get MS/MS spectra window only for the spectra chart
-      SpectraVisualizerWindow spectraWindow = new SpectraVisualizerWindow(raw);
-      spectraWindow.loadRawData(scan);
+      // create dataset
 
-      spectrumPlot = spectraWindow.getSpectrumPlot();
+      if (spectrumPlot == null) {
+        spectrumPlot = new SpectraPlot(this, false);
+        if (listener != null)
+          // chart has changed
+          listener.accept(spectrumPlot);
+      }
+      spectrumPlot.removeAllDataSets();
+
+      DataPointsDataSet data = new DataPointsDataSet("Data", getFilteredDataPoints());
+      // green
+      spectrumPlot.addDataSet(data, colorUsedData, false);
+      if (showRemovedData) {
+        // orange
+        DataPointsDataSet dataRemoved =
+            new DataPointsDataSet("Removed", getFilteredDataPointsRemoved());
+        spectrumPlot.addDataSet(dataRemoved, colorRemovedData, false);
+      }
       spectrumPlot.getChart().getLegend().setVisible(showLegend);
       spectrumPlot.setMaximumSize(new Dimension(chartSize.width, 10000));
       spectrumPlot.setPreferredSize(chartSize);
       pnChart.add(spectrumPlot, BorderLayout.CENTER);
 
+      Scan scan = scans.get(selectedScanI);
       analyzeScan(scan);
       applySelectionState();
       setValidSelection(true);
@@ -503,12 +516,6 @@ public class ScanSelectPanel extends JPanel {
       error.setForeground(new Color(220, 20, 60));
       pnChart.add(error, BorderLayout.CENTER);
       //
-    }
-
-    // listener on change
-    if (listener != null && oldChart != spectrumPlot
-        && (oldChart != null && !oldChart.equals(spectrumPlot))) {
-      listener.accept(spectrumPlot);
     }
 
     revalidate();
@@ -540,6 +547,11 @@ public class ScanSelectPanel extends JPanel {
     }
   }
 
+  /**
+   * Remaining data points after filtering
+   * 
+   * @return
+   */
   @Nullable
   public DataPoint[] getFilteredDataPoints() {
     if (scans != null && !scans.isEmpty()) {
@@ -547,6 +559,22 @@ public class ScanSelectPanel extends JPanel {
       MassList massList = ScanUtils.getMassListOrFirst(scan, massListName);
       if (massList != null)
         return ScanUtils.getFiltered(massList.getDataPoints(), noiseLevel);
+    }
+    return null;
+  }
+
+  /**
+   * Removed data points
+   * 
+   * @return
+   */
+  @Nullable
+  public DataPoint[] getFilteredDataPointsRemoved() {
+    if (scans != null && !scans.isEmpty()) {
+      Scan scan = scans.get(selectedScanI);
+      MassList massList = ScanUtils.getMassListOrFirst(scan, massListName);
+      if (massList != null)
+        return ScanUtils.getBelowThreshold(massList.getDataPoints(), noiseLevel);
     }
     return null;
   }
@@ -604,6 +632,10 @@ public class ScanSelectPanel extends JPanel {
     chartSize = dim;
   }
 
+  public void setShowRemovedData(boolean showRemovedData) {
+    this.showRemovedData = showRemovedData;
+  }
+
   /**
    * Valid spectrum and is selected? Still check for correct adduct
    * 
@@ -623,6 +655,12 @@ public class ScanSelectPanel extends JPanel {
 
   public boolean hasAdduct() {
     return !getAdduct().isEmpty();
+  }
+
+  @Override
+  public void actionPerformed(ActionEvent e) {
+    // TODO Auto-generated method stub
+
   }
 
 }

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/spectraldbsubmit/view/ScanSelectPanel.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/spectraldbsubmit/view/ScanSelectPanel.java
@@ -58,6 +58,8 @@ import net.sf.mzmine.main.MZmineCore;
 import net.sf.mzmine.modules.peaklistmethods.io.spectraldbsubmit.AdductParser;
 import net.sf.mzmine.modules.visualization.spectra.simplespectra.SpectraPlot;
 import net.sf.mzmine.modules.visualization.spectra.simplespectra.datasets.DataPointsDataSet;
+import net.sf.mzmine.util.ColorPalettes;
+import net.sf.mzmine.util.ColorPalettes.Vision;
 import net.sf.mzmine.util.exceptions.MissingMassListException;
 import net.sf.mzmine.util.scans.ScanUtils;
 import net.sf.mzmine.util.scans.sorting.ScanSortMode;
@@ -65,8 +67,9 @@ import net.sf.mzmine.util.scans.sorting.ScanSortMode;
 public class ScanSelectPanel extends JPanel implements ActionListener {
 
 
-  public static final Color colorRemovedData = new Color(0xF57C00); // orange
-  public static final Color colorUsedData = new Color(0x388E3C); // green
+  public final Color colorRemovedData;
+  public final Color colorUsedData;
+
   private static final int SIZE = 40;
   // icons
   static final Icon iconTIC = createIcon("icons/btnTIC.png");
@@ -150,6 +153,11 @@ public class ScanSelectPanel extends JPanel implements ActionListener {
 
   public ScanSelectPanel(ScanSortMode sort, double noiseLevel, int minNumberOfSignals,
       String massListName) {
+    // get colors for vision
+    Vision vision = MZmineCore.getConfiguration().getColorVision();
+    colorUsedData = ColorPalettes.getPositiveColor(vision);
+    colorRemovedData = ColorPalettes.getNegativeColor(vision);
+
     setBorder(new LineBorder(UIManager.getColor("textHighlight")));
     this.massListName = massListName;
     this.sort = sort;

--- a/src/main/java/net/sf/mzmine/modules/visualization/peaklisttable/PeakListTablePopupMenu.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/peaklisttable/PeakListTablePopupMenu.java
@@ -66,7 +66,7 @@ import net.sf.mzmine.modules.visualization.spectra.multimsms.MultiMSMSWindow;
 import net.sf.mzmine.modules.visualization.spectra.simplespectra.MultiSpectraVisualizerWindow;
 import net.sf.mzmine.modules.visualization.spectra.simplespectra.SpectraVisualizerModule;
 import net.sf.mzmine.modules.visualization.spectra.simplespectra.mirrorspectra.MirrorScanWindow;
-import net.sf.mzmine.modules.visualization.spectra.simplespectra.spectraidentification.spectraldatabase.SpectraIdentificationResultsWindow;
+import net.sf.mzmine.modules.visualization.spectra.spectralmatchresults.SpectraIdentificationResultsWindow;
 import net.sf.mzmine.modules.visualization.threed.ThreeDVisualizerModule;
 import net.sf.mzmine.modules.visualization.tic.TICPlotType;
 import net.sf.mzmine.modules.visualization.tic.TICVisualizerModule;

--- a/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/mirrorspectra/MirrorScanWindow.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/mirrorspectra/MirrorScanWindow.java
@@ -34,9 +34,12 @@ import org.jfree.chart.ui.RectangleEdge;
 import net.sf.mzmine.chartbasics.gui.swing.EChartPanel;
 import net.sf.mzmine.datamodel.DataPoint;
 import net.sf.mzmine.datamodel.Scan;
+import net.sf.mzmine.main.MZmineCore;
 import net.sf.mzmine.modules.visualization.spectra.multimsms.SpectrumChartFactory;
 import net.sf.mzmine.modules.visualization.spectra.multimsms.pseudospectra.PseudoSpectraRenderer;
 import net.sf.mzmine.modules.visualization.spectra.multimsms.pseudospectra.PseudoSpectrumDataSet;
+import net.sf.mzmine.util.ColorPalettes;
+import net.sf.mzmine.util.ColorPalettes.Vision;
 import net.sf.mzmine.util.spectraldb.entry.DBEntryField;
 import net.sf.mzmine.util.spectraldb.entry.DataPointsTag;
 import net.sf.mzmine.util.spectraldb.entry.SpectralDBPeakIdentity;
@@ -53,12 +56,6 @@ public class MirrorScanWindow extends JFrame {
 
   public static final DataPointsTag[] tags =
       new DataPointsTag[] {DataPointsTag.ORIGINAL, DataPointsTag.FILTERED, DataPointsTag.ALIGNED};
-  // colors for the different DataPointsTags:
-  public static final Color[] colors = new Color[] {Color.black, // black = filtered
-      new Color(0xF57C00), // orange = unaligned
-      new Color(0x388E3C) // green = aligned
-  };
-
 
   private JPanel contentPane;
   private EChartPanel mirrorSpecrumPlot;
@@ -135,6 +132,14 @@ public class MirrorScanWindow extends JFrame {
           "This data set has no original data points in the query spectrum (development error)");
     if (mostIntenseDB == 0d || mostIntenseQuery == 0d)
       return;
+
+    // get colors for vision
+    Vision vision = MZmineCore.getConfiguration().getColorVision();
+    // colors for the different DataPointsTags:
+    final Color[] colors = new Color[] {Color.black, // black = filtered
+        ColorPalettes.getNegativeColor(vision), // unaligned
+        ColorPalettes.getPositiveColor(vision) // aligned
+    };
 
     // scan a
     double precursorMZA = scan.getPrecursorMZ();

--- a/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectraIdentificationSpectralDatabaseTask.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectraIdentificationSpectralDatabaseTask.java
@@ -29,6 +29,7 @@ import net.sf.mzmine.desktop.Desktop;
 import net.sf.mzmine.desktop.impl.HeadLessDesktop;
 import net.sf.mzmine.main.MZmineCore;
 import net.sf.mzmine.modules.visualization.spectra.simplespectra.SpectraPlot;
+import net.sf.mzmine.modules.visualization.spectra.spectralmatchresults.SpectraIdentificationResultsWindow;
 import net.sf.mzmine.parameters.ParameterSet;
 import net.sf.mzmine.taskcontrol.AbstractTask;
 import net.sf.mzmine.taskcontrol.TaskStatus;

--- a/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectralMatchTask.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectralMatchTask.java
@@ -38,6 +38,7 @@ import net.sf.mzmine.modules.visualization.spectra.simplespectra.SpectraPlot;
 import net.sf.mzmine.modules.visualization.spectra.simplespectra.datapointprocessing.isotopes.MassListDeisotoper;
 import net.sf.mzmine.modules.visualization.spectra.simplespectra.datapointprocessing.isotopes.MassListDeisotoperParameters;
 import net.sf.mzmine.modules.visualization.spectra.simplespectra.datasets.DataPointsDataSet;
+import net.sf.mzmine.modules.visualization.spectra.spectralmatchresults.SpectraIdentificationResultsWindow;
 import net.sf.mzmine.parameters.ParameterSet;
 import net.sf.mzmine.parameters.parametertypes.tolerances.MZTolerance;
 import net.sf.mzmine.taskcontrol.AbstractTask;

--- a/src/main/java/net/sf/mzmine/modules/visualization/spectra/spectralmatchresults/SpectraIdentificationResultsWindow.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/spectra/spectralmatchresults/SpectraIdentificationResultsWindow.java
@@ -16,7 +16,7 @@
  * USA
  */
 
-package net.sf.mzmine.modules.visualization.spectra.simplespectra.spectraidentification.spectraldatabase;
+package net.sf.mzmine.modules.visualization.spectra.spectralmatchresults;
 
 import java.awt.BorderLayout;
 import java.awt.Color;

--- a/src/main/java/net/sf/mzmine/modules/visualization/spectra/spectralmatchresults/SpectralIdentificationSpectralDatabaseTextPane.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/spectra/spectralmatchresults/SpectralIdentificationSpectralDatabaseTextPane.java
@@ -15,7 +15,7 @@
  * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
  * USA
  */
-package net.sf.mzmine.modules.visualization.spectra.simplespectra.spectraidentification.spectraldatabase;
+package net.sf.mzmine.modules.visualization.spectra.spectralmatchresults;
 
 import javax.swing.JTextPane;
 

--- a/src/main/java/net/sf/mzmine/modules/visualization/spectra/spectralmatchresults/SpectralMatchPanel.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/spectra/spectralmatchresults/SpectralMatchPanel.java
@@ -16,7 +16,7 @@
  * USA
  */
 
-package net.sf.mzmine.modules.visualization.spectra.simplespectra.spectraidentification.spectraldatabase;
+package net.sf.mzmine.modules.visualization.spectra.spectralmatchresults;
 
 import java.awt.BorderLayout;
 import java.awt.Color;

--- a/src/main/java/net/sf/mzmine/util/ColorPalettes.java
+++ b/src/main/java/net/sf/mzmine/util/ColorPalettes.java
@@ -27,10 +27,30 @@ import java.awt.Color;
  *
  */
 public class ColorPalettes {
+  /**
+   * Color blindness or normal vision
+   * 
+   */
+  public enum Vision {
+    NORMAL_VISION, //
+    DEUTERANOPIA, // green blindness, 6% male population
+    PROTANOPIA, // red blindness, 1% male population
+    TRITANOPIA; // blue blindness, very rare
+
+    @Override
+    public String toString() {
+      return super.toString().replaceAll("_", " ");
+    }
+  }
+
+
 
   // colors to mark positive or negative results (color blindness aware)
-  public static final Color POSITIVE_MARKER = new Color(0.f, 0.447f, 0.698f, 1f); // blue
-  public static final Color NEGATIVE_MARKER = new Color(0.835f, 0.369f, 0.f, 1f); // darker orange
+  private static final Color POSITIVE_MARKER_COLORBLIND = new Color(0.f, 0.447f, 0.698f, 1f); // blue
+  private static final Color NEGATIVE_MARKER_COLORBLIND = new Color(0.835f, 0.369f, 0.f, 1f); // orange
+
+  private static final Color POSITIVE_MARKER = new Color(0.220f, 0.557f, 0.235f, 1f); // green
+  private static final Color NEGATIVE_MARKER = new Color(0.808f, 0.090f, 0.161f, 1f); // red
 
 
   /**
@@ -39,7 +59,7 @@ public class ColorPalettes {
    * <br>
    * http://mkweb.bcgsc.ca/colorblind/img/colorblindness.palettes.trivial.png
    */
-  public Color[] COLORS_7_AND_BLACK = new Color[] { //
+  private static Color[] COLORS_7_AND_BLACK = new Color[] { //
       Color.BLACK, // black
       new Color(0.902f, 0.624f, 0f, 1f), // orange
       new Color(0.337f, 0.706f, 0.914f, 1f), // sky blue
@@ -54,7 +74,7 @@ public class ColorPalettes {
    * Orange, sky blue, bluish green, yellow, blue, vermillion (darker orange), reddish purple <br>
    * http://mkweb.bcgsc.ca/colorblind/img/colorblindness.palettes.trivial.png
    */
-  public Color[] COLORS_7 = new Color[] { //
+  private static Color[] COLORS_7 = new Color[] { //
       new Color(0.902f, 0.624f, 0f, 1f), // orange
       new Color(0.337f, 0.706f, 0.914f, 1f), // sky blue
       new Color(0.f, 0.620f, 0.451f, 1f), // bluish green
@@ -63,4 +83,56 @@ public class ColorPalettes {
       new Color(0.835f, 0.369f, 0.f, 1f), // vermillion (darker orange)
       new Color(0.800f, 0.475f, 0.655f, 1f)}; // reddish purple
 
+
+  /**
+   * Seven colors (+black)
+   * 
+   * @param mode color blindness?
+   * @param includeBlack include black as the first color
+   * @return
+   */
+  public static Color[] getSevenColorPalette(Vision vision, boolean includeBlack) {
+    // so far always the same color palette
+    return includeBlack ? COLORS_7_AND_BLACK : COLORS_7;
+  }
+
+  /**
+   * Return positive feedback color
+   * 
+   * @param mode
+   * @return
+   */
+  public static Color getPositiveColor(Vision vision) {
+    switch (vision) {
+      // color blind
+      case DEUTERANOPIA:
+      case PROTANOPIA:
+      case TRITANOPIA:
+        return POSITIVE_MARKER_COLORBLIND;
+      // normal vision
+      case NORMAL_VISION:
+      default:
+        return POSITIVE_MARKER;
+    }
+  }
+
+  /**
+   * Return positive feedback color
+   * 
+   * @param mode
+   * @return
+   */
+  public static Color getNegativeColor(Vision vision) {
+    switch (vision) {
+      // color blind
+      case DEUTERANOPIA:
+      case PROTANOPIA:
+      case TRITANOPIA:
+        return NEGATIVE_MARKER_COLORBLIND;
+      // normal vision
+      case NORMAL_VISION:
+      default:
+        return NEGATIVE_MARKER;
+    }
+  }
 }

--- a/src/main/java/net/sf/mzmine/util/ColorPalettes.java
+++ b/src/main/java/net/sf/mzmine/util/ColorPalettes.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2006-2018 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package net.sf.mzmine.util;
+
+import java.awt.Color;
+
+/**
+ * ColorPalletes (some based on http://mkweb.bcgsc.ca/colorblind) for color blindness
+ * 
+ * @author Robin Schmid
+ *
+ */
+public class ColorPalettes {
+
+  // colors to mark positive or negative results (color blindness aware)
+  public static final Color POSITIVE_MARKER = new Color(0.f, 0.447f, 0.698f, 1f); // blue
+  public static final Color NEGATIVE_MARKER = new Color(0.835f, 0.369f, 0.f, 1f); // darker orange
+
+
+  /**
+   * Color palette with black+7colors for color blindness: <br>
+   * Black, orange, sky blue, bluish green, yellow, blue, vermillion (darker orange), reddish purple
+   * <br>
+   * http://mkweb.bcgsc.ca/colorblind/img/colorblindness.palettes.trivial.png
+   */
+  public Color[] COLORS_7_AND_BLACK = new Color[] { //
+      Color.BLACK, // black
+      new Color(0.902f, 0.624f, 0f, 1f), // orange
+      new Color(0.337f, 0.706f, 0.914f, 1f), // sky blue
+      new Color(0.f, 0.620f, 0.451f, 1f), // bluish green
+      new Color(0.941f, 0.894f, 0.259f, 1f), // yellow
+      new Color(0.f, 0.447f, 0.698f, 1f), // blue
+      new Color(0.835f, 0.369f, 0.f, 1f), // vermillion (darker orange)
+      new Color(0.800f, 0.475f, 0.655f, 1f)}; // reddish purple
+
+  /**
+   * Color palette with black+7colors for color blindness: <br>
+   * Orange, sky blue, bluish green, yellow, blue, vermillion (darker orange), reddish purple <br>
+   * http://mkweb.bcgsc.ca/colorblind/img/colorblindness.palettes.trivial.png
+   */
+  public Color[] COLORS_7 = new Color[] { //
+      new Color(0.902f, 0.624f, 0f, 1f), // orange
+      new Color(0.337f, 0.706f, 0.914f, 1f), // sky blue
+      new Color(0.f, 0.620f, 0.451f, 1f), // bluish green
+      new Color(0.941f, 0.894f, 0.259f, 1f), // yellow
+      new Color(0.f, 0.447f, 0.698f, 1f), // blue
+      new Color(0.835f, 0.369f, 0.f, 1f), // vermillion (darker orange)
+      new Color(0.800f, 0.475f, 0.655f, 1f)}; // reddish purple
+
+}

--- a/src/main/java/net/sf/mzmine/util/scans/ScanUtils.java
+++ b/src/main/java/net/sf/mzmine/util/scans/ScanUtils.java
@@ -884,6 +884,17 @@ public class ScanUtils {
   }
 
   /**
+   * below threshold: keep data points < noiseLevel
+   * 
+   * @param data
+   * @param noiseLevel
+   * @return
+   */
+  public static DataPoint[] getBelowThreshold(DataPoint[] data, double noiseLevel) {
+    return Stream.of(data).filter(dp -> dp.getIntensity() < noiseLevel).toArray(DataPoint[]::new);
+  }
+
+  /**
    * Number of signals >=noiseLevel
    * 
    * @param data


### PR DESCRIPTION
Hey all,

I have added a class ColorPalettes to store different colors for normal/color blind vision. The preferred vision can be changed in the MZmine preferences. 

All modules and charts can then get the colors from the ColorPalettes. 
- getPositiveColor(Vision vision) (green or blue)
- getNegativeColor(Vision vision) (red or orange)
- getSevenColorPalette(Vision vision, boolean includeBlack)
    - taken from http://mkweb.bcgsc.ca/colorblind/img/colorblindness.palettes.trivial.png

So far I have changed the colors of the charts in spectral match results and spectral database submission. From my side, I would suggest to set the default color vision to color blind (DEUTERANOPIA). These color palettes are great for nearly everyone.

```
public enum Vision {
    NORMAL_VISION, //
    DEUTERANOPIA, // green blindness, 6% male population
    PROTANOPIA, // red blindness, 1% male population
    TRITANOPIA; // blue blindness, very rare
}
```
![image](https://user-images.githubusercontent.com/10366914/58963188-05541800-87ad-11e9-9aca-aaaac93fa1fb.png)

