### PR TITLE
Bugfixes DataPointProcessing

### DIFF
--- a/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/SpectraPlot.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/SpectraPlot.java
@@ -531,13 +531,15 @@ public class SpectraPlot extends EChartPanel {
     this.processingAllowed = processingAllowed;
   }
 
-  public void removeDataPointProcessingResultDataSets() {
+  public synchronized void removeDataPointProcessingResultDataSets() {
     for (int i = 0; i < plot.getDatasetCount(); i++) {
       XYDataset dataSet = plot.getDataset(i);
       if (dataSet instanceof DPPResultsDataSet) {
         plot.setDataset(i, null);
       }
     }
+    // when adding DPPResultDataSet the label generator is overwritten, revert here
+    SpectraItemLabelGenerator labelGenerator = new SpectraItemLabelGenerator(this);
+    plot.getRenderer().setDefaultItemLabelGenerator(labelGenerator);
   }
-
 }

--- a/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/SpectraVisualizerWindow.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/SpectraVisualizerWindow.java
@@ -623,6 +623,8 @@ public class SpectraVisualizerWindow extends JFrame implements ActionListener {
 
             dppmWindowOpen = false;
             if (exitCode == ExitCode.OK && DataPointProcessingManager.getInst().isEnabled()) {
+              // if processing was run before, this removes the previous results.
+              getSpectrumPlot().removeDataPointProcessingResultDataSets();
               getSpectrumPlot().checkAndRunController();
             }
           }
@@ -641,8 +643,8 @@ public class SpectraVisualizerWindow extends JFrame implements ActionListener {
 
           // if the tick is removed, set the data back to default
           if (!inst.isEnabled()) {
-            // getSpectrumPlot().removeDataPointProcessingResultDataSets();
-            loadRawData(currentScan);
+            getSpectrumPlot().removeDataPointProcessingResultDataSets();
+            // loadRawData(currentScan);
           }
         }
       });

--- a/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/datapointprocessing/datamodel/ProcessedDataPoint.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/datapointprocessing/datamodel/ProcessedDataPoint.java
@@ -46,26 +46,23 @@ public class ProcessedDataPoint extends SimpleDataPoint {
    * @param dp DataPoints to convert.
    * @return Array of ProcessedDataPoints from DataPoints.
    */
-  public static ProcessedDataPoint[] convert(DataPoint[] dp) {
-    if (dp == null)
-      return new ProcessedDataPoint[0];
-
+  public static ProcessedDataPoint[] convert(@Nonnull DataPoint[] dp) {
     ProcessedDataPoint[] pdp = new ProcessedDataPoint[dp.length];
     for (int i = 0; i < pdp.length; i++)
       pdp[i] = new ProcessedDataPoint(dp[i]);
     return pdp;
   }
 
-  public ProcessedDataPoint(DataPoint dp) {
+  public ProcessedDataPoint(@Nonnull DataPoint dp) {
     super(dp);
   }
 
-  public ProcessedDataPoint(DataPoint dp, DPPResult<?> result) {
+  public ProcessedDataPoint(@Nonnull DataPoint dp, @Nonnull DPPResult<?> result) {
     this(dp);
     addResult(result);
   }
 
-  public ProcessedDataPoint(DataPoint dp, Collection<DPPResult<?>> results) {
+  public ProcessedDataPoint(@Nonnull DataPoint dp, @Nonnull Collection<DPPResult<?>> results) {
     this(dp);
     addAllResults(results);
   }

--- a/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/datapointprocessing/datamodel/ProcessedDataPoint.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/datapointprocessing/datamodel/ProcessedDataPoint.java
@@ -22,6 +22,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Vector;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import net.sf.mzmine.datamodel.DataPoint;
 import net.sf.mzmine.datamodel.impl.SimpleDataPoint;
 import net.sf.mzmine.modules.visualization.spectra.simplespectra.datapointprocessing.datamodel.results.DPPResult;
@@ -73,10 +75,7 @@ public class ProcessedDataPoint extends SimpleDataPoint {
    * 
    * @param result
    */
-  public void addResult(DPPResult<?> result) {
-    if (result == null)
-      return;
-
+  public void addResult(@Nonnull DPPResult<?> result) {
     if (results == null)
       results = new Vector<DPPResult<?>>();
 
@@ -88,10 +87,7 @@ public class ProcessedDataPoint extends SimpleDataPoint {
    * 
    * @param results
    */
-  public void addAllResults(Collection<DPPResult<?>> results) {
-    if (results == null)
-      return;
-
+  public void addAllResults(@Nonnull Collection<DPPResult<?>> results) {
     if (this.results == null)
       this.results = new Vector<DPPResult<?>>();
 
@@ -100,10 +96,7 @@ public class ProcessedDataPoint extends SimpleDataPoint {
     }
   }
 
-  public void addAllResults(DPPResult<?>[] result) {
-    if (result == null)
-      return;
-
+  public void addAllResults(@Nonnull DPPResult<?>[] result) {
     if (results == null)
       results = new Vector<DPPResult<?>>();
 
@@ -118,7 +111,7 @@ public class ProcessedDataPoint extends SimpleDataPoint {
    * @return DPPResult with the given key, may be null if no result with that key exits or no result
    *         exists at all.
    */
-  public DPPResult<?> getResult(int i) {
+  public @Nullable DPPResult<?> getResult(int i) {
     if (results == null)
       return null;
     return results.get(i);
@@ -133,7 +126,7 @@ public class ProcessedDataPoint extends SimpleDataPoint {
   public boolean resultTypeExists(DPPResult.ResultType type) {
     if (results == null)
       return false;
-    
+
     for (DPPResult<?> r : results)
       if (r.getResultType() == type)
         return true;
@@ -142,6 +135,7 @@ public class ProcessedDataPoint extends SimpleDataPoint {
 
   /**
    * The number of results with the given type.
+   * 
    * @param type
    * @return
    */
@@ -161,11 +155,11 @@ public class ProcessedDataPoint extends SimpleDataPoint {
    *
    * @return Returns List of all results of the given type. Null if no result exists.
    */
-  public List<DPPResult<?>> getAllResultsByType(DPPResult.ResultType type) {
-    if (results == null)
-      return null;
-
+  public @Nonnull List<DPPResult<?>> getAllResultsByType(DPPResult.ResultType type) {
     List<DPPResult<?>> list = new ArrayList<>();
+    
+    if (results == null)
+      return list;
 
     for (DPPResult<?> r : results) {
       if (r.getResultType() == type) {
@@ -173,33 +167,33 @@ public class ProcessedDataPoint extends SimpleDataPoint {
       }
     }
 
-    if (list.isEmpty())
-      return null;
-
     return list;
   }
-  
+
   /**
    * Returns the first result of the given type.
+   * 
    * @param type
    * @return Instance of DPPResult<?> or null if no result of that type exists.
    */
-  public DPPResult<?> getFirstResultByType(DPPResult.ResultType type){
+  public @Nullable DPPResult<?> getFirstResultByType(DPPResult.ResultType type) {
     if (results == null)
       return null;
-    
-    for(DPPResult<?> r : results)
-      if(r.getResultType() == type)
+
+    for (DPPResult<?> r : results)
+      if (r.getResultType() == type)
         return r;
     return null;
   }
 
   public void removeResult(int i) {
-    results.remove(i);
+    if (results != null)
+      results.remove(i);
   }
-  
+
   public void removeResult(DPPResult<?> result) {
-    results.remove(result);
+    if (results != null)
+      results.remove(result);
   }
   /*
    * public boolean equals(ProcessedDataPoint p) { //TODO }

--- a/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/datapointprocessing/datamodel/customguicomponents/ProcessingComponent.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/datapointprocessing/datamodel/customguicomponents/ProcessingComponent.java
@@ -471,9 +471,6 @@ public class ProcessingComponent extends JPanel implements ActionListener {
   private @Nonnull DPPMSLevelTreeNode getTargetNode() {
     DefaultMutableTreeNode n = getSelectedItem(tvProcessing);
 
-    if (n instanceof DPPModuleTreeNode || n == tiProcessingRoot)
-      return tiLastTarget;
-
     if (n instanceof DPPMSLevelTreeNode)
       tiLastTarget = (DPPMSLevelTreeNode) n;
     if (tiLastTarget == null)


### PR DESCRIPTION
Hi Tomas, i fixed a few small bugs I noticed.

1. After setting new parameters, the processing was executed, but the previous results were not removed.
2. A null pointer exception occurred, when the last selected node and currently selected node were both null and a data point did not have a result at all and a remove method was called. 
3. Furthermore, i added Nonnull and Nullable annotations to ProcessedDataPoint.

Best regards
Steffen

