### PR TITLE
Change ScanSelection for single scan filter like smoothing

### DIFF
--- a/src/main/java/net/sf/mzmine/modules/rawdatamethods/filtering/scanfilters/ScanFiltersParameters.java
+++ b/src/main/java/net/sf/mzmine/modules/rawdatamethods/filtering/scanfilters/ScanFiltersParameters.java
@@ -28,6 +28,8 @@ import net.sf.mzmine.parameters.parametertypes.BooleanParameter;
 import net.sf.mzmine.parameters.parametertypes.ModuleComboParameter;
 import net.sf.mzmine.parameters.parametertypes.StringParameter;
 import net.sf.mzmine.parameters.parametertypes.selectors.RawDataFilesParameter;
+import net.sf.mzmine.parameters.parametertypes.selectors.ScanSelection;
+import net.sf.mzmine.parameters.parametertypes.selectors.ScanSelectionParameter;
 
 public class ScanFiltersParameters extends SimpleParameterSet {
 
@@ -35,6 +37,9 @@ public class ScanFiltersParameters extends SimpleParameterSet {
       {new SGFilter(), new MeanFilter(), new ResampleFilter(), new RndResampleFilter()};
 
   public static final RawDataFilesParameter dataFiles = new RawDataFilesParameter();
+
+  public static final ScanSelectionParameter scanSelect =
+      new ScanSelectionParameter(new ScanSelection(1));
 
   public static final StringParameter suffix =
       new StringParameter("Suffix", "This string is added to filename as suffix", "filtered");
@@ -47,7 +52,7 @@ public class ScanFiltersParameters extends SimpleParameterSet {
           "If checked, original file will be removed and only filtered version remains");
 
   public ScanFiltersParameters() {
-    super(new Parameter[] {dataFiles, suffix, filter, autoRemove});
+    super(new Parameter[] {dataFiles, scanSelect, suffix, filter, autoRemove});
   }
 
 }

--- a/src/main/java/net/sf/mzmine/modules/rawdatamethods/filtering/scanfilters/mean/MeanFilter.java
+++ b/src/main/java/net/sf/mzmine/modules/rawdatamethods/filtering/scanfilters/mean/MeanFilter.java
@@ -19,9 +19,7 @@
 package net.sf.mzmine.modules.rawdatamethods.filtering.scanfilters.mean;
 
 import java.util.Vector;
-
 import javax.annotation.Nonnull;
-
 import net.sf.mzmine.datamodel.DataPoint;
 import net.sf.mzmine.datamodel.MassSpectrumType;
 import net.sf.mzmine.datamodel.Scan;
@@ -38,9 +36,9 @@ public class MeanFilter implements ScanFilter {
     double windowLength =
         parameters.getParameter(MeanFilterParameters.oneSidedWindowLength).getValue();
 
-    if (sc.getMSLevel() != 1) {
-      return sc;
-    }
+
+    // changed to also allow MS2 if selected in ScanSelection
+
     Vector<Double> massWindow = new Vector<Double>();
     Vector<Double> intensityWindow = new Vector<Double>();
 
@@ -84,10 +82,10 @@ public class MeanFilter implements ScanFilter {
 
       elSum = 0;
       for (int j = 0; j < intensityWindow.size(); j++) {
-        elSum += ((Double) (intensityWindow.get(j))).doubleValue();
+        elSum += (intensityWindow.get(j)).doubleValue();
       }
 
-      newDataPoints[i] = new SimpleDataPoint(currentMass, elSum / (double) intensityWindow.size());
+      newDataPoints[i] = new SimpleDataPoint(currentMass, elSum / intensityWindow.size());
 
     }
 

--- a/src/main/java/net/sf/mzmine/modules/rawdatamethods/filtering/scanfilters/savitzkygolay/SGFilter.java
+++ b/src/main/java/net/sf/mzmine/modules/rawdatamethods/filtering/scanfilters/savitzkygolay/SGFilter.java
@@ -19,9 +19,7 @@
 package net.sf.mzmine.modules.rawdatamethods.filtering.scanfilters.savitzkygolay;
 
 import java.util.Hashtable;
-
 import javax.annotation.Nonnull;
-
 import net.sf.mzmine.datamodel.DataPoint;
 import net.sf.mzmine.datamodel.Scan;
 import net.sf.mzmine.datamodel.impl.SimpleDataPoint;
@@ -72,6 +70,7 @@ public class SGFilter implements ScanFilter {
 
   }
 
+  @Override
   public Scan filterScan(Scan scan, ParameterSet parameters) {
 
     int numOfDataPoints = parameters.getParameter(SGFilterParameters.datapoints).getValue();
@@ -82,10 +81,7 @@ public class SGFilter implements ScanFilter {
     int[] aVals = Avalues.get(numOfDataPoints);
     int h = Hvalues.get(numOfDataPoints).intValue();
 
-    // only process MS level 1 scans
-    if (scan.getMSLevel() != 1) {
-      return scan;
-    }
+    // changed to also allow MS2 if selected in ScanSelection
 
     int marginSize = (numOfDataPoints + 1) / 2 - 1;
     double sumOfInts;
@@ -132,6 +128,7 @@ public class SGFilter implements ScanFilter {
 
   }
 
+  @Override
   public @Nonnull String getName() {
     return "Savitzky-Golay filter";
   }

--- a/src/main/java/net/sf/mzmine/parameters/parametertypes/selectors/ScanSelection.java
+++ b/src/main/java/net/sf/mzmine/parameters/parametertypes/selectors/ScanSelection.java
@@ -126,7 +126,16 @@ public class ScanSelection {
 
   public boolean matches(Scan scan) {
     // scan offset was changed
-    int offset = scanNumberRange == null ? 1 : scanNumberRange.lowerEndpoint();
+    int offset;
+    if (scanNumberRange != null)
+      offset = scanNumberRange.lowerEndpoint();
+    else {
+      // first scan number
+      if (scan.getDataFile() != null && scan.getDataFile().getScanNumbers().length > 0)
+        offset = scan.getDataFile().getScanNumbers()[0];
+      else
+        offset = 1;
+    }
     return matches(scan, offset);
   }
 

--- a/src/main/java/net/sf/mzmine/parameters/parametertypes/selectors/ScanSelection.java
+++ b/src/main/java/net/sf/mzmine/parameters/parametertypes/selectors/ScanSelection.java
@@ -20,15 +20,10 @@ package net.sf.mzmine.parameters.parametertypes.selectors;
 
 import java.util.ArrayList;
 import java.util.List;
-
 import javax.annotation.concurrent.Immutable;
-
 import com.google.common.base.Strings;
 import com.google.common.collect.Range;
 import com.google.common.primitives.Ints;
-
-import org.apache.xpath.functions.FuncFalse;
-
 import net.sf.mzmine.datamodel.MassSpectrumType;
 import net.sf.mzmine.datamodel.PolarityType;
 import net.sf.mzmine.datamodel.RawDataFile;
@@ -101,57 +96,16 @@ public class ScanSelection {
   public Scan[] getMatchingScans(RawDataFile dataFile) {
 
     final List<Scan> matchingScans = new ArrayList<>();
-    boolean offsetSet = false;
-    int offset = 1;
 
     int scanNumbers[] = dataFile.getScanNumbers();
     for (int scanNumber : scanNumbers) {
 
       Scan scan = dataFile.getScan(scanNumber);
-
-      if ((msLevel != null) && (!msLevel.equals(scan.getMSLevel())))
-        continue;
-
-      if ((polarity != null) && (!polarity.equals(scan.getPolarity())))
-        continue;
-
-      if ((spectrumType != null) && (!spectrumType.equals(scan.getSpectrumType())))
-        continue;
-
-      if ((scanNumberRange != null) && (!scanNumberRange.contains(scanNumber))) {
-        continue;
-      } else {
-        if (!offsetSet) {
-          offsetSet = true;
-          offset = scanNumber;
-        }
-      }
-
-      if ((baseFilteringInteger != null) && ((scanNumber - offset) % baseFilteringInteger != 0))
-        continue;
-
-      if ((scanRTRange != null) && (!scanRTRange.contains(scan.getRetentionTime())))
-        continue;
-
-      if (!Strings.isNullOrEmpty(scanDefinition)) {
-
-        final String actualScanDefition = scan.getScanDefinition();
-
-        if (Strings.isNullOrEmpty(actualScanDefition))
-          continue;
-
-        final String regex = TextUtils.createRegexFromWildcards(scanDefinition);
-
-        if (!actualScanDefition.matches(regex))
-          continue;
-
-      }
-
-      matchingScans.add(scan);
+      if (matches(scan))
+        matchingScans.add(scan);
     }
 
     return matchingScans.toArray(new Scan[matchingScans.size()]);
-
   }
 
   public int[] getMatchingScanNumbers(RawDataFile dataFile) {
@@ -159,54 +113,61 @@ public class ScanSelection {
     final List<Integer> matchingScans = new ArrayList<>();
 
     int scanNumbers[] = dataFile.getScanNumbers();
-    boolean offsetSet = false;
-    int offset = 1;
+
     for (int scanNumber : scanNumbers) {
-
       Scan scan = dataFile.getScan(scanNumber);
-
-      if ((msLevel != null) && (!msLevel.equals(scan.getMSLevel())))
-        continue;
-
-      if ((polarity != null) && (!polarity.equals(scan.getPolarity())))
-        continue;
-
-      if ((spectrumType != null) && (!spectrumType.equals(scan.getSpectrumType())))
-        continue;
-
-      if ((scanNumberRange != null) && (!scanNumberRange.contains(scanNumber))) {
-        continue;
-      } else {
-        if (!offsetSet) {
-          offsetSet = true;
-          offset = scanNumber;
-        }
-      }
-      if ((baseFilteringInteger != null)
-          && ((scan.getScanNumber() - offset) % baseFilteringInteger != 0))
-        continue;
-
-      if ((scanRTRange != null) && (!scanRTRange.contains(scan.getRetentionTime())))
-        continue;
-
-      if (!Strings.isNullOrEmpty(scanDefinition)) {
-
-        final String actualScanDefinition = scan.getScanDefinition();
-
-        if (Strings.isNullOrEmpty(actualScanDefinition))
-          continue;
-
-        final String regex = TextUtils.createRegexFromWildcards(scanDefinition);
-
-        if (!actualScanDefinition.matches(regex))
-          continue;
-
-      }
-
-      matchingScans.add(scanNumber);
+      if (matches(scan))
+        matchingScans.add(scanNumber);
     }
 
     return Ints.toArray(matchingScans);
+  }
 
+
+  public boolean matches(Scan scan) {
+    // scan offset was changed
+    int offset = scanNumberRange == null ? 1 : scanNumberRange.lowerEndpoint();
+    return matches(scan, offset);
+  }
+
+  /**
+   * 
+   * @param scan
+   * @param scanNumberOffset is used for baseFilteringInteger (filter every n-th scan)
+   * @return
+   */
+  public boolean matches(Scan scan, int scanNumberOffset) {
+    if ((msLevel != null) && (!msLevel.equals(scan.getMSLevel())))
+      return false;
+
+    if ((polarity != null) && (!polarity.equals(scan.getPolarity())))
+      return false;
+
+    if ((spectrumType != null) && (!spectrumType.equals(scan.getSpectrumType())))
+      return false;
+
+    if ((scanNumberRange != null) && (!scanNumberRange.contains(scan.getScanNumber())))
+      return false;
+
+    if ((baseFilteringInteger != null)
+        && ((scan.getScanNumber() - scanNumberOffset) % baseFilteringInteger != 0))
+      return false;
+
+    if ((scanRTRange != null) && (!scanRTRange.contains(scan.getRetentionTime())))
+      return false;
+
+    if (!Strings.isNullOrEmpty(scanDefinition)) {
+
+      final String actualScanDefinition = scan.getScanDefinition();
+
+      if (Strings.isNullOrEmpty(actualScanDefinition))
+        return false;
+
+      final String regex = TextUtils.createRegexFromWildcards(scanDefinition);
+
+      if (!actualScanDefinition.matches(regex))
+        return false;
+    }
+    return true;
   }
 }


### PR DESCRIPTION
I was trying to apply smoothing (single scan filter) to MS/MS scans - the result was that the filter just ignored the MS/MS scan and left me with an empty raw data file. 

Therefore, this PR adds the scan selection to the single scan filter. Not everyone acquires MS/MS scans in centroid mode - so scan smoothing should be applicable to all types of scans.

cheers
Robin