### PR TITLE
Add an error message when both MS1 and MS2 signals are used to build …

### DIFF
--- a/src/main/java/net/sf/mzmine/modules/masslistmethods/ADAPchromatogrambuilder/ADAPChromatogramBuilderTask.java
+++ b/src/main/java/net/sf/mzmine/modules/masslistmethods/ADAPchromatogrambuilder/ADAPChromatogramBuilderTask.java
@@ -178,6 +178,25 @@ public class ADAPChromatogramBuilderTask extends AbstractTask {
       prevRT = s.getRetentionTime();
     }
 
+    // Check if the scans are MS1-only or MS2-only.
+
+    int minMsLevel = Arrays.stream(scans)
+            .mapToInt(Scan::getMSLevel)
+            .min()
+            .orElseThrow(() -> new IllegalStateException("Cannot find the minimum MS level"));
+
+    int maxMsLevel = Arrays.stream(scans)
+            .mapToInt(Scan::getMSLevel)
+            .max()
+            .orElseThrow(() -> new IllegalStateException("Cannot find the maximum MS level"));
+
+    if (minMsLevel != maxMsLevel) {
+      setStatus(TaskStatus.ERROR);
+      setErrorMessage("Only scans of one MS level should be used for building chromatograms. " +
+              "Please, set the scan filter parameter to a specific MS level");
+      return;
+    }
+
 
     // Create new peak list
     newPeakList = new SimplePeakList(dataFile + " " + suffix, dataFile);

--- a/src/main/java/net/sf/mzmine/modules/masslistmethods/ADAPchromatogrambuilder/ADAPChromatogramBuilderTask.java
+++ b/src/main/java/net/sf/mzmine/modules/masslistmethods/ADAPchromatogrambuilder/ADAPChromatogramBuilderTask.java
@@ -34,6 +34,7 @@ import net.sf.mzmine.datamodel.RawDataFile;
 import net.sf.mzmine.datamodel.Scan;
 import net.sf.mzmine.datamodel.impl.SimplePeakList;
 import net.sf.mzmine.datamodel.impl.SimplePeakListRow;
+import net.sf.mzmine.main.MZmineCore;
 import net.sf.mzmine.modules.peaklistmethods.qualityparameters.QualityParameters;
 import net.sf.mzmine.parameters.ParameterSet;
 import net.sf.mzmine.parameters.parametertypes.selectors.ScanSelection;
@@ -179,7 +180,6 @@ public class ADAPChromatogramBuilderTask extends AbstractTask {
     }
 
     // Check if the scans are MS1-only or MS2-only.
-
     int minMsLevel = Arrays.stream(scans)
             .mapToInt(Scan::getMSLevel)
             .min()
@@ -191,10 +191,10 @@ public class ADAPChromatogramBuilderTask extends AbstractTask {
             .orElseThrow(() -> new IllegalStateException("Cannot find the maximum MS level"));
 
     if (minMsLevel != maxMsLevel) {
-      setStatus(TaskStatus.ERROR);
-      setErrorMessage("Only scans of one MS level should be used for building chromatograms. " +
-              "Please, set the scan filter parameter to a specific MS level");
-      return;
+      MZmineCore.getDesktop().displayMessage(null,
+              "MZmine thinks that you are running ADAP Chromatogram builder on both MS1- and MS2-scans. " +
+                      "This will likely produce wrong results. " +
+                      "Please, set the scan filter parameter to a specific MS level");
     }
 
 


### PR DESCRIPTION
As discussed in #319,

I add an error message when both MS1 and MS2 signals are used to build chromatograms.