### PR TITLE
Added missing separator

### DIFF
--- a/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/SpectraToolBar.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/SpectraToolBar.java
@@ -91,6 +91,8 @@ public class SpectraToolBar extends JToolBar {
     GUIUtils.addButton(this, null, exportIcon, masterFrame, "EXPORT_SPECTRA",
         "Export spectra to spectra file");
 
+    addSeparator();
+
     GUIUtils.addButton(this, null, exportIcon, masterFrame, "CREATE_LIBRARY_ENTRY",
         "Create spectral library entry");
 


### PR DESCRIPTION
Hey Tomas,
just a really small fix that adds the missing space between to icons in the spectra plot tool bar.
![image](https://user-images.githubusercontent.com/27132602/61277803-3283e500-a7b3-11e9-8a26-bce1ad6479c6.png)
