### PR TITLE
Options to add retention time and ANOVA p-value to MSP files

### DIFF
--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/mspexport/MSPExportParameters.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/mspexport/MSPExportParameters.java
@@ -20,6 +20,8 @@ import net.sf.mzmine.parameters.Parameter;
 import net.sf.mzmine.parameters.impl.SimpleParameterSet;
 import net.sf.mzmine.parameters.parametertypes.BooleanParameter;
 import net.sf.mzmine.parameters.parametertypes.ComboParameter;
+import net.sf.mzmine.parameters.parametertypes.OptionalParameter;
+import net.sf.mzmine.parameters.parametertypes.StringParameter;
 import net.sf.mzmine.parameters.parametertypes.filenames.FileNameParameter;
 import net.sf.mzmine.parameters.parametertypes.selectors.PeakListsParameter;
 
@@ -42,11 +44,21 @@ public class MSPExportParameters extends SimpleParameterSet {
           + "If the file already exists, it will be overwritten.",
       "msp");
 
-  public static final BooleanParameter ADD_RET_TIME = new BooleanParameter("Add retention time",
-          "If checked, each MSP record will contain line 'RT: retention time'", true);
+  public static final OptionalParameter<StringParameter> ADD_RET_TIME = new OptionalParameter<>(
+          new StringParameter("Add retention time",
+                  "If selected, each MSP record will contain the feature's retention time",
+                  "RT"), true);
 
-  public static final BooleanParameter ADD_ANOVA_P_VALUE = new BooleanParameter("Add ANOVA p-value (if present)",
-          "If checked, each MSP record will contain line 'ANOVA_P_VALUE: p-value' (if calculated)", true);
+//  public static final BooleanParameter ADD_RET_TIME = new BooleanParameter("Add retention time",
+//          "If checked, each MSP record will contain line 'RT: retention time'", true);
+
+  public static final OptionalParameter<StringParameter> ADD_ANOVA_P_VALUE = new OptionalParameter<>(
+          new StringParameter("Add ANOVA p-value (if calculated)",
+                  "If selected, each MSP record will contain the One-way ANOVA p-value (if calculated)",
+                  "ANOVA_P_VALUE"), true);
+
+//  public static final BooleanParameter ADD_ANOVA_P_VALUE = new BooleanParameter("Add ANOVA p-value (if present)",
+//          "If checked, each MSP record will contain line 'ANOVA_P_VALUE: p-value' (if calculated)", true);
 
   public static final BooleanParameter FRACTIONAL_MZ = new BooleanParameter("Fractional m/z values",
       "If checked, write fractional m/z values", false);

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/mspexport/MSPExportParameters.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/mspexport/MSPExportParameters.java
@@ -42,6 +42,12 @@ public class MSPExportParameters extends SimpleParameterSet {
           + "If the file already exists, it will be overwritten.",
       "msp");
 
+  public static final BooleanParameter ADD_RET_TIME = new BooleanParameter("Add retention time",
+          "If checked, each MSP record will contain line 'RT: retention time'", true);
+
+  public static final BooleanParameter ADD_ANOVA_P_VALUE = new BooleanParameter("Add ANOVA p-value (if present)",
+          "If checked, each MSP record will contain line 'ANOVA_P_VALUE: p-value' (if calculated)", true);
+
   public static final BooleanParameter FRACTIONAL_MZ = new BooleanParameter("Fractional m/z values",
       "If checked, write fractional m/z values", false);
 
@@ -50,6 +56,6 @@ public class MSPExportParameters extends SimpleParameterSet {
       new String[] {ROUND_MODE_MAX, ROUND_MODE_SUM}, ROUND_MODE_MAX);
 
   public MSPExportParameters() {
-    super(new Parameter[] {PEAK_LISTS, FILENAME, FRACTIONAL_MZ, ROUND_MODE});
+    super(new Parameter[] {PEAK_LISTS, FILENAME, ADD_RET_TIME, ADD_ANOVA_P_VALUE, FRACTIONAL_MZ, ROUND_MODE});
   }
 }

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/mspexport/MSPExportTask.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/mspexport/MSPExportTask.java
@@ -41,6 +41,8 @@ public class MSPExportTask extends AbstractTask {
   private final PeakList[] peakLists;
   private final File fileName;
   private final String plNamePattern = "{}";
+  private final boolean addRetTime;
+  private final boolean addAnovaPValue;
   private final boolean fractionalMZ;
   private final String roundMode;
 
@@ -49,6 +51,10 @@ public class MSPExportTask extends AbstractTask {
         parameters.getParameter(MSPExportParameters.PEAK_LISTS).getValue().getMatchingPeakLists();
 
     this.fileName = parameters.getParameter(MSPExportParameters.FILENAME).getValue();
+
+    this.addRetTime = parameters.getParameter(MSPExportParameters.ADD_RET_TIME).getValue();
+
+    this.addAnovaPValue = parameters.getParameter(MSPExportParameters.ADD_ANOVA_P_VALUE).getValue();
 
     this.fractionalMZ = parameters.getParameter(MSPExportParameters.FRACTIONAL_MZ).getValue();
 
@@ -158,7 +164,7 @@ public class MSPExportTask extends AbstractTask {
       }
 
       PeakInformation peakInformation = row.getPeakInformation();
-      if (peakInformation != null) {
+      if (addAnovaPValue && peakInformation != null) {
         for (Map.Entry<String, String> e : peakInformation.getAllProperties().entrySet())
           if (e.getValue() != null && e.getValue().trim().length() > 0)
             writer.write(e.getKey() + ": " + e.getValue() + newLine);
@@ -168,7 +174,8 @@ public class MSPExportTask extends AbstractTask {
       if (rowID != null)
         writer.write("DB#: " + rowID + newLine);
 
-      writer.write("RT: " + row.getAverageRT() + newLine);
+      if (addRetTime)
+        writer.write("RT: " + row.getAverageRT() + newLine);
 
       DataPoint[] dataPoints = ip.getDataPoints();
 

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/mspexport/MSPExportTask.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/mspexport/MSPExportTask.java
@@ -24,11 +24,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.regex.Pattern;
-import net.sf.mzmine.datamodel.DataPoint;
-import net.sf.mzmine.datamodel.IsotopePattern;
-import net.sf.mzmine.datamodel.PeakIdentity;
-import net.sf.mzmine.datamodel.PeakList;
-import net.sf.mzmine.datamodel.PeakListRow;
+
+import net.sf.mzmine.datamodel.*;
 import net.sf.mzmine.datamodel.impl.SimpleDataPoint;
 import net.sf.mzmine.parameters.ParameterSet;
 import net.sf.mzmine.taskcontrol.AbstractTask;
@@ -158,6 +155,13 @@ public class MSPExportTask extends AbstractTask {
         String id = identity.getPropertyValue(PeakIdentity.PROPERTY_ID);
         if (id != null)
           writer.write("Comments: " + id + newLine);
+      }
+
+      PeakInformation peakInformation = row.getPeakInformation();
+      if (peakInformation != null) {
+        for (Map.Entry<String, String> e : peakInformation.getAllProperties().entrySet())
+          if (e.getValue() != null && e.getValue().trim().length() > 0)
+            writer.write(e.getKey() + ": " + e.getValue() + newLine);
       }
 
       String rowID = Integer.toString(row.getID());

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/mspexport/help/help.html
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/io/mspexport/help/help.html
@@ -22,6 +22,12 @@
     <dt>DB#</dt>
     <dd>Row number in the peak list</dd>
 
+    <dt>RT (optional)</dt>
+    <dd>Retention time of a feature</dd>
+
+    <dt>ANOVA_P_VALUE (optional)</dt>
+    <dd>P-value calculated by the module Data analysis -> One-way ANOVA Test</dd>
+
     <dt>Num Peaks</dt>
     <dd>Number of peaks in the spectrum</dd>
 </dl>
@@ -29,6 +35,12 @@
 <h4>Method Parameters</h4>
 
 <dl>
+    <dt>Add retention time</dt>
+    <dd>If selected, each MSP record will contain a line 'RT: retention time'</dd>
+
+    <dt>Add ANOVA p-value (if present)</dt>
+    <dd>If selected, each MSP record will contain a line 'ANOVA_P_VALUE: p-value' if such p-value is present</dd>
+
     <dt>Fractional m/z values</dt>
     <dd>If not selected, all fractional m/z values are rounded to the closest integer and the corresponding peaks are merged</dd>
 


### PR DESCRIPTION
Hi Tomas,

This is a small change to MSP Export module. It adds two parameters that users can select to add Retention Time and ANOVA p-value to MSP files.

Previously, each MSP file would contain retention time. I would like to add an option to output ANOVA p-value as well.