### PR TITLE
Move alignment score from Comments to PeakInformation

### DIFF
--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/alignment/adap3/ADAP3AlignerTask.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/alignment/adap3/ADAP3AlignerTask.java
@@ -219,7 +219,12 @@ public class ADAP3AlignerTask extends AbstractTask {
                 newRow.addPeak(file, feature);
             }
 
-            newRow.setComment("Alignment Score = " + referenceComponent.getScore());
+            // Save alignment score
+            SimplePeakInformation peakInformation = (SimplePeakInformation) newRow.getPeakInformation();
+            if (peakInformation == null)
+                peakInformation = new SimplePeakInformation();
+            peakInformation.addProperty("Alignment score", Double.toString(referenceComponent.getScore()));
+            newRow.setPeakInformation(peakInformation);
 
             alignedPeakList.addRow(newRow);
         }


### PR DESCRIPTION
Previously, ADAP Aligner module would use `PeakListRow.setComment()` to save the alignment score. This makes the aligned peaklist to look somewhat cluttered. See the figure.

<img width="1112" alt="alignment_score" src="https://user-images.githubusercontent.com/13631120/62571431-517c1100-b85f-11e9-8a7a-9b08fb078746.png">

With this update, I save the alignment score into `PeakInformation` instead.

Tomas, I could create a separate variable of `PeakListRow` to store the alignment score if you prefer the latter.

