### PR TITLE
Added swing to PDF, EMF, EPS for SpectralMatchResultsWindow

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,13 @@
 			<artifactId>utils</artifactId>
 			<version>1.07.00</version>
 		</dependency>
+		<!-- https://mvnrepository.com/artifact/org.drjekyll/fontchooser -->
+<dependency>
+    <groupId>org.drjekyll</groupId>
+    <artifactId>fontchooser</artifactId>
+    <version>2.4</version>
+</dependency>
+		
 		<dependency>
 			<groupId>com.google.code.findbugs</groupId>
 			<artifactId>jsr305</artifactId>

--- a/src/main/java/net/sf/mzmine/main/MZmineModulesList.java
+++ b/src/main/java/net/sf/mzmine/main/MZmineModulesList.java
@@ -131,6 +131,7 @@ import net.sf.mzmine.modules.visualization.spectra.simplespectra.spectraidentifi
 import net.sf.mzmine.modules.visualization.spectra.simplespectra.spectraidentification.onlinedatabase.OnlineDBSpectraSearchModule;
 import net.sf.mzmine.modules.visualization.spectra.simplespectra.spectraidentification.spectraldatabase.SpectraIdentificationSpectralDatabaseModule;
 import net.sf.mzmine.modules.visualization.spectra.simplespectra.spectraidentification.sumformula.SumFormulaSpectraSearchModule;
+import net.sf.mzmine.modules.visualization.spectra.spectralmatchresults.SpectraIdentificationResultsModule;
 import net.sf.mzmine.modules.visualization.threed.ThreeDVisualizerModule;
 import net.sf.mzmine.modules.visualization.tic.TICVisualizerModule;
 import net.sf.mzmine.modules.visualization.twod.TwoDVisualizerModule;
@@ -221,7 +222,7 @@ public class MZmineModulesList {
       SpectraIdentificationSpectralDatabaseModule.class, LibrarySubmitModule.class,
       CustomDBSpectraSearchModule.class, LipidSpectraSearchModule.class,
       OnlineDBSpectraSearchModule.class, SumFormulaSpectraSearchModule.class,
-      ExportScansModule.class,
+      ExportScansModule.class, SpectraIdentificationResultsModule.class,
 
       // Data point processing, implement DataPointProcessingModule
       DataPointProcessingManager.class, DPPMassDetectionModule.class,

--- a/src/main/java/net/sf/mzmine/modules/visualization/spectra/spectralmatchresults/SpectraIdentificationResultsModule.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/spectra/spectralmatchresults/SpectraIdentificationResultsModule.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2006-2019 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package net.sf.mzmine.modules.visualization.spectra.spectralmatchresults;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import net.sf.mzmine.modules.MZmineModule;
+import net.sf.mzmine.parameters.ParameterSet;
+
+public class SpectraIdentificationResultsModule implements MZmineModule {
+
+  public static final String MODULE_NAME = "Local spectral database search results";
+
+
+  @Override
+  public @Nonnull String getName() {
+    return MODULE_NAME;
+  }
+
+  @Override
+  public @Nullable Class<? extends ParameterSet> getParameterSetClass() {
+    return SpectraIdentificationResultsParameters.class;
+  }
+}

--- a/src/main/java/net/sf/mzmine/modules/visualization/spectra/spectralmatchresults/SpectraIdentificationResultsParameters.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/spectra/spectralmatchresults/SpectraIdentificationResultsParameters.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2006-2018 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package net.sf.mzmine.modules.visualization.spectra.spectralmatchresults;
+
+import net.sf.mzmine.parameters.Parameter;
+import net.sf.mzmine.parameters.impl.SimpleParameterSet;
+import net.sf.mzmine.parameters.parametertypes.filenames.FileNameParameter;
+
+/**
+ * Saves the export paths of the SpectraIdentificationResultsWindow
+ * 
+ * @author Robin Schmid (robinschmid@uni-muenster.de)
+ *
+ */
+public class SpectraIdentificationResultsParameters extends SimpleParameterSet {
+
+  public static final FileNameParameter file =
+      new FileNameParameter("file", "file without extension");
+
+  public SpectraIdentificationResultsParameters() {
+    super(new Parameter[] {file});
+  }
+
+}

--- a/src/main/java/net/sf/mzmine/modules/visualization/spectra/spectralmatchresults/SpectraIdentificationResultsWindow.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/spectra/spectralmatchresults/SpectraIdentificationResultsWindow.java
@@ -33,10 +33,13 @@ import javax.swing.JCheckBoxMenuItem;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
+import javax.swing.WindowConstants;
+import org.drjekyll.fontchooser.FontDialog;
 import net.sf.mzmine.desktop.impl.WindowsMenu;
 import net.sf.mzmine.util.spectraldb.entry.SpectralDBPeakIdentity;
 
@@ -55,6 +58,8 @@ public class SpectraIdentificationResultsWindow extends JFrame {
   private Map<SpectralDBPeakIdentity, SpectralMatchPanel> matchPanels;
   // couple y zoom (if one is changed - change the other in a mirror plot)
   private boolean isCouplingZoomY;
+
+  private Font chartFont = new Font("Verdana", Font.PLAIN, 11);
 
   public SpectraIdentificationResultsWindow() {
     setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
@@ -82,6 +87,12 @@ public class SpectraIdentificationResultsWindow extends JFrame {
     cbCoupleZoomY.setSelected(true);
     cbCoupleZoomY.addItemListener(e -> setCoupleZoomY(cbCoupleZoomY.isSelected()));
     menuBar.add(cbCoupleZoomY);
+
+    // set font size of chart
+    JMenuItem btnSetFont = new JMenuItem("Set chart font");
+    btnSetFont.addActionListener(e -> setChartFont());
+    menuBar.add(btnSetFont);
+
     setJMenuBar(menuBar);
 
     scrollPane = new JScrollPane(pnGrid);
@@ -98,6 +109,15 @@ public class SpectraIdentificationResultsWindow extends JFrame {
     setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
     validate();
     repaint();
+  }
+
+  private void setChartFont() {
+    FontDialog dialog = new FontDialog(this, "Font Dialog Example", true);
+    dialog.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+    dialog.setVisible(true);
+    if (!dialog.isCancelSelected()) {
+      setChartFont(dialog.getSelectedFont());
+    }
   }
 
   public void setCoupleZoomY(boolean selected) {
@@ -196,4 +216,16 @@ public class SpectraIdentificationResultsWindow extends JFrame {
       this.pnGrid = pnGrid;
     });
   }
+
+  public Font getChartFont() {
+    return chartFont;
+  }
+
+  public void setChartFont(Font chartFont) {
+    this.chartFont = chartFont;
+    matchPanels.values().stream().forEach(pn -> {
+      pn.setChartFont(chartFont);
+    });
+  }
+
 }

--- a/src/main/java/net/sf/mzmine/util/swing/SwingExportUtil.java
+++ b/src/main/java/net/sf/mzmine/util/swing/SwingExportUtil.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2006-2018 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package net.sf.mzmine.util.swing;
+
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import javax.swing.JComponent;
+import org.freehep.graphics2d.VectorGraphics;
+import org.freehep.graphicsio.emf.EMFGraphics2D;
+import com.itextpdf.awt.DefaultFontMapper;
+import com.itextpdf.text.Document;
+import com.itextpdf.text.DocumentException;
+import com.itextpdf.text.Rectangle;
+import com.itextpdf.text.pdf.PdfContentByte;
+import com.itextpdf.text.pdf.PdfTemplate;
+import com.itextpdf.text.pdf.PdfWriter;
+import net.sf.epsgraphics.ColorMode;
+import net.sf.epsgraphics.EpsGraphics;
+import net.sf.mzmine.util.files.FileAndPathUtil;
+
+/**
+ * Export swing components to pdf, emf, eps
+ * 
+ * @author Robin Schmid (robinschmid@uni-muenster.de)
+ *
+ */
+public class SwingExportUtil {
+
+  /**
+   * 
+   * @param panel
+   * @param path
+   * @param fileName
+   * @param format without . (ALL, PDF, EMF, EPS). ALL = export all at once
+   */
+  public static void writeToGraphics(JComponent panel, File file, String format)
+      throws IOException, DocumentException {
+    writeToGraphics(panel, file.getParentFile(), file.getName(), format);
+  }
+
+  public static void writeToGraphics(JComponent panel, File path, String fileName, String format)
+      throws IOException, DocumentException {
+    switch (format.toLowerCase()) {
+      case "all":
+        writeToPDF(panel, path, fileName);
+        writeToEMF(panel, path, fileName);
+        writeToEPS(panel, path, fileName);
+        break;
+      case "pdf":
+        writeToPDF(panel, path, fileName);
+        break;
+      case "emf":
+        writeToEMF(panel, path, fileName);
+        writeToEPS(panel, path, fileName);
+        break;
+      case "eps":
+        writeToEPS(panel, path, fileName);
+        break;
+    }
+  }
+
+  /**
+   * Writes swing to pdf
+   * 
+   * @param panel
+   * @param fileName
+   * @throws DocumentException
+   * @throws Exception
+   */
+  public static void writeToPDF(JComponent panel, File fileName)
+      throws IOException, DocumentException {
+    // print the panel to pdf
+    int width = panel.getWidth();
+    int height = panel.getHeight();
+    Document document = new Document(new Rectangle(width, height));
+    try {
+      PdfWriter writer = PdfWriter.getInstance(document, new FileOutputStream(fileName));
+      document.open();
+      PdfContentByte contentByte = writer.getDirectContent();
+      PdfTemplate template = contentByte.createTemplate(width, height);
+      Graphics2D g2 = template.createGraphics(width, height, new DefaultFontMapper());
+      panel.print(g2);
+      g2.dispose();
+      contentByte.addTemplate(template, 0, 0);
+    } finally {
+      if (document.isOpen()) {
+        document.close();
+      }
+    }
+  }
+
+  /**
+   * Writes swing to EPS
+   * 
+   * @param panel
+   * @param fileName
+   * @throws Exception
+   */
+  public static void writeToEPS(JComponent panel, File fileName) throws IOException {
+    // print the panel to pdf
+    int width = panel.getWidth();
+    int height = panel.getWidth();
+    EpsGraphics g;
+    g = new EpsGraphics("EpsTools Drawable Export", new FileOutputStream(fileName), 0, 0, width,
+        height, ColorMode.COLOR_RGB);
+    panel.print(g);
+    g.close();
+  }
+
+  /**
+   * Writes swing to EMF
+   * 
+   * @param panel
+   * @param fileName
+   * @throws Exception
+   */
+  public static void writeToEMF(JComponent panel, File fileName) throws IOException {
+    // print the panel to pdf
+    int width = panel.getWidth();
+    int height = panel.getWidth();
+
+    VectorGraphics g = new EMFGraphics2D(fileName, new Dimension(width, height));
+    g.startExport();
+    panel.print(g);
+    g.endExport();
+  }
+
+  /**
+   * Writes swing to pdf
+   * 
+   * @param panel
+   * @param path
+   * @param fileName
+   * @throws Exception
+   */
+  public static void writeToPDF(JComponent panel, File path, String fileName)
+      throws IOException, DocumentException {
+    writeToPDF(panel, FileAndPathUtil.getRealFilePath(path, fileName, "pdf"));
+  }
+
+  /**
+   * Writes swing to EPS
+   * 
+   * @param panel
+   * @param path
+   * @param fileName
+   * @throws Exception
+   */
+  public static void writeToEPS(JComponent panel, File path, String fileName) throws IOException {
+    writeToEPS(panel, FileAndPathUtil.getRealFilePath(path, fileName, "eps"));
+  }
+
+  /**
+   * Writes swing to EMF
+   * 
+   * @param panel
+   * @param path
+   * @param fileName
+   * @throws Exception
+   */
+  public static void writeToEMF(JComponent panel, File path, String fileName) throws IOException {
+    writeToEMF(panel, FileAndPathUtil.getRealFilePath(path, fileName, "emf"));
+  }
+}


### PR DESCRIPTION
Hey Tomas,

this is a small addition to the spectral match results.
I have added the buttons ALL, PDF, EMF, EPS to export the results panel (mirror chart and meta data)  to one or all of these formats. 

Cheers
Robin