### PR TITLE
Fixed crash after sum formula prediction, inability to reopen parameter setup windows in DPP

### DIFF
--- a/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/datapointprocessing/datamodel/customguicomponents/ProcessingComponent.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/datapointprocessing/datamodel/customguicomponents/ProcessingComponent.java
@@ -228,9 +228,9 @@ public class ProcessingComponent extends JPanel implements ActionListener {
     if (stepParameters.getParameters().length > 0 && !selected.isDialogShowing()) {
       selected.setDialogShowing(true);
       ExitCode exitCode = stepParameters.showSetupDialog(null, true);
+      selected.setDialogShowing(false);
       if (exitCode == ExitCode.OK) {
         // store the parameters in the tree item
-        selected.setDialogShowing(false);
         selected.setParameters(stepParameters);
         // sendValueWrapper(); // update the list
       }

--- a/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/datapointprocessing/datamodel/results/DPPResultsDataSet.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/datapointprocessing/datamodel/results/DPPResultsDataSet.java
@@ -18,19 +18,24 @@
 
 package net.sf.mzmine.modules.visualization.spectra.simplespectra.datapointprocessing.datamodel.results;
 
+import net.sf.mzmine.datamodel.DataPoint;
 import net.sf.mzmine.modules.visualization.spectra.simplespectra.datapointprocessing.datamodel.ProcessedDataPoint;
 import net.sf.mzmine.modules.visualization.spectra.simplespectra.datasets.DataPointsDataSet;
 
 public class DPPResultsDataSet extends DataPointsDataSet {
 
   private static final long serialVersionUID = 1L;
-  
+
   public DPPResultsDataSet(String label, ProcessedDataPoint[] mzPeaks) {
     super(label, mzPeaks);
   }
 
-  public ProcessedDataPoint[] getDataPoints() {
-    return (ProcessedDataPoint[]) mzPeaks;
+  /**
+   * This type has to be DataPoint, else you will get class cast exceptions. Casting it later on is
+   * still possible.
+   */
+  public DataPoint[] getDataPoints() {
+    return mzPeaks;
   }
-  
+
 }

--- a/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/datapointprocessing/datamodel/results/DPPResultsLabelGenerator.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/datapointprocessing/datamodel/results/DPPResultsLabelGenerator.java
@@ -20,6 +20,7 @@ package net.sf.mzmine.modules.visualization.spectra.simplespectra.datapointproce
 
 import java.text.NumberFormat;
 import org.jfree.data.xy.XYDataset;
+import net.sf.mzmine.datamodel.DataPoint;
 import net.sf.mzmine.main.MZmineCore;
 import net.sf.mzmine.modules.visualization.spectra.simplespectra.SpectraPlot;
 import net.sf.mzmine.modules.visualization.spectra.simplespectra.datapointprocessing.datamodel.ProcessedDataPoint;
@@ -81,7 +82,11 @@ public class DPPResultsLabelGenerator extends SpectraItemLabelGenerator {
     if (dataset instanceof ScanDataSet) {
       label = ((ScanDataSet) dataset).getAnnotation(item);
     } else if (dataset instanceof DPPResultsDataSet) {
-      label = createLabel(((DPPResultsDataSet) dataset).getDataPoints()[item]);
+      DataPoint[] dps = ((DPPResultsDataSet) dataset).getDataPoints();
+      if(dps[item] instanceof ProcessedDataPoint) {
+        ProcessedDataPoint p = (ProcessedDataPoint) dps[item];
+        label = createLabel(p);
+      }
     }
 
     if (label == null || label.equals("")) {

--- a/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/datapointprocessing/identification/sumformulaprediction/DPPSumFormulaPredictionTask.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/datapointprocessing/identification/sumformulaprediction/DPPSumFormulaPredictionTask.java
@@ -45,7 +45,6 @@ import net.sf.mzmine.modules.visualization.spectra.simplespectra.datapointproces
 import net.sf.mzmine.modules.visualization.spectra.simplespectra.datapointprocessing.datamodel.results.DPPResult.ResultType;
 import net.sf.mzmine.modules.visualization.spectra.simplespectra.datapointprocessing.datamodel.results.DPPResultsDataSet;
 import net.sf.mzmine.modules.visualization.spectra.simplespectra.datapointprocessing.datamodel.results.DPPResultsLabelGenerator;
-import net.sf.mzmine.modules.visualization.spectra.simplespectra.datapointprocessing.isotopes.deisotoper.DPPIsotopeGrouperParameters;
 import net.sf.mzmine.modules.visualization.spectra.simplespectra.datapointprocessing.learnermodule.DPPLearnerModuleParameters;
 import net.sf.mzmine.modules.visualization.spectra.simplespectra.datapointprocessing.datamodel.results.DPPSumFormulaResult;
 import net.sf.mzmine.parameters.ParameterSet;
@@ -158,6 +157,8 @@ public class DPPSumFormulaPredictionTask extends DataPointProcessingTask {
     }
 
     setStatus(TaskStatus.PROCESSING);
+    
+    List<ProcessedDataPoint> resultList = new ArrayList<>();
 
     IChemObjectBuilder builder = SilentChemObjectBuilder.getInstance();
 
@@ -180,10 +181,12 @@ public class DPPSumFormulaPredictionTask extends DataPointProcessingTask {
       DPPSumFormulaResult[] results = genereateResults(formulas, numResults);
 
       ((ProcessedDataPoint) dataPoints[i]).addAllResults(results);
+      resultList.add((ProcessedDataPoint) dataPoints[i]);
       currentIndex++;
     }
 
-    setResults((ProcessedDataPoint[]) dataPoints);
+//    setResults((ProcessedDataPoint[]) dataPoints);
+    setResults(resultList.toArray(new ProcessedDataPoint[0]));
     setStatus(TaskStatus.FINISHED);
   }
 


### PR DESCRIPTION
Hi Tomas,

this PR fixes a null pointer exception that occured, when using the sum formula prediction in data point processing. This problem occurred when the DataPointsDataSet checks for zero/double data points and recreates them from a list as DataPoint[0]. I don't know exactly why this happened, but it should be fixed now.
Furthermore, the results data set of the sum formula prediction will only contain data points that did get an actual sum formula assigned to them.
Also, i fixed a small bug that occured when a parameter setup window in the data point processing component was closed without pressing O.K. and resulted in it not being able to be reopened again until you closed the whole component.

Best regards
Steffen