### PR TITLE
Join aligner spectra similarity

### DIFF
--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/alignment/join/JoinAlignerParameters.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/alignment/join/JoinAlignerParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2018 The MZmine 2 Development Team
+ * Copyright 2006-2019 The MZmine 2 Development Team
  * 
  * This file is part of MZmine 2.
  * 

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/alignment/join/JoinAlignerParameters.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/alignment/join/JoinAlignerParameters.java
@@ -57,9 +57,14 @@ public class JoinAlignerParameters extends SimpleParameterSet {
           "If both peaks represent an isotope pattern, add isotope pattern score to match score",
           new IsotopePatternScoreParameters());
 
+  public static final OptionalModuleParameter compareSpectraSimilarity =
+      new OptionalModuleParameter("Compare spectra similarity",
+          "Compare MS1 or MS2 spectra similarity",
+          new JoinAlignerSpectraSimilarityScoreParameters());
+
   public JoinAlignerParameters() {
     super(new Parameter[] {peakLists, peakListName, MZTolerance, MZWeight, RTTolerance, RTWeight,
-        SameChargeRequired, SameIDRequired, compareIsotopePattern});
+        SameChargeRequired, SameIDRequired, compareIsotopePattern, compareSpectraSimilarity});
   }
 
 }

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/alignment/join/JoinAlignerSpectraSimilarityScoreParameters.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/alignment/join/JoinAlignerSpectraSimilarityScoreParameters.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2006-2019 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package net.sf.mzmine.modules.peaklistmethods.alignment.join;
+
+import net.sf.mzmine.parameters.Parameter;
+import net.sf.mzmine.parameters.impl.SimpleParameterSet;
+import net.sf.mzmine.parameters.parametertypes.IntegerParameter;
+import net.sf.mzmine.parameters.parametertypes.MassListParameter;
+import net.sf.mzmine.parameters.parametertypes.ModuleComboParameter;
+import net.sf.mzmine.parameters.parametertypes.tolerances.MZToleranceParameter;
+import net.sf.mzmine.util.scans.similarity.SpectralSimilarityFunction;
+
+/**
+ * Parameters to compare spectra in join aligner
+ * 
+ * @author Ansgar Korf (ansgar.korf@uni-muenster.de)
+ */
+public class JoinAlignerSpectraSimilarityScoreParameters extends SimpleParameterSet {
+
+  public static final MassListParameter massList = new MassListParameter();
+
+  public static final MZToleranceParameter mzTolerance = new MZToleranceParameter(
+      "Spectral m/z tolerance",
+      "Spectral m/z tolerance is used to match all signals between spectra of two compared raw files",
+      0.001, 10);
+
+  public static final IntegerParameter msLevel = new IntegerParameter("MS level",
+      "Choose the MS level of the scans that should be compared. Enter \"1\" for MS1 scans or \"2\" for MS/MS scans on MS level 2",
+      2, 1, 1000);
+
+  public static final ModuleComboParameter<SpectralSimilarityFunction> similarityFunction =
+      new ModuleComboParameter<>("Compare spectra similarity",
+          "Algorithm to calculate similarity and filter matches",
+          SpectralSimilarityFunction.FUNCTIONS);
+
+  public JoinAlignerSpectraSimilarityScoreParameters() {
+    super(new Parameter[] {massList, mzTolerance, msLevel, similarityFunction});
+  }
+
+}

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/alignment/join/JoinAlignerTask.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/alignment/join/JoinAlignerTask.java
@@ -249,7 +249,12 @@ class JoinAlignerTask extends AbstractTask {
 
             // compare mass list data points of selected scans
             if (rowDPs != null && candidateDPs != null) {
+
+              // calculate similarity using SimilarityFunction
               sim = createSimilarity(rowDPs, candidateDPs);
+
+              // check if similarity is null. Similarity is not null if similarity score is >= the
+              // user set threshold
               if (sim == null) {
                 continue;
               }
@@ -330,8 +335,6 @@ class JoinAlignerTask extends AbstractTask {
   /**
    * Uses the similarity function and filter to create similarity.
    * 
-   * @param a
-   * @param b
    * @return positive match with similarity or null if criteria was not met
    */
   private SpectralSimilarity createSimilarity(DataPoint[] library, DataPoint[] query) {

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/alignment/join/JoinAlignerTask.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/alignment/join/JoinAlignerTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2018 The MZmine 2 Development Team
+ * Copyright 2006-2019 The MZmine 2 Development Team
  * 
  * This file is part of MZmine 2.
  * 
@@ -70,7 +70,6 @@ class JoinAlignerTask extends AbstractTask {
   private MZmineProcessingStep<SpectralSimilarityFunction> simFunction;
   private int msLevel;
   private String massList;
-  private MZTolerance mzToleranceSpectraMatching;
 
   JoinAlignerTask(MZmineProject project, ParameterSet parameters) {
 
@@ -112,16 +111,13 @@ class JoinAlignerTask extends AbstractTask {
       massList = parameters.getParameter(JoinAlignerParameters.compareSpectraSimilarity)
           .getEmbeddedParameters()
           .getParameter(JoinAlignerSpectraSimilarityScoreParameters.massList).getValue();
-
-      mzToleranceSpectraMatching = parameters
-          .getParameter(JoinAlignerParameters.compareSpectraSimilarity).getEmbeddedParameters()
-          .getParameter(JoinAlignerSpectraSimilarityScoreParameters.mzTolerance).getValue();
     }
   }
 
   /**
    * @see net.sf.mzmine.taskcontrol.Task#getTaskDescription()
    */
+  @Override
   public String getTaskDescription() {
     return "Join aligner, " + peakListName + " (" + peakLists.length + " feature lists)";
   }
@@ -129,6 +125,7 @@ class JoinAlignerTask extends AbstractTask {
   /**
    * @see net.sf.mzmine.taskcontrol.Task#getFinishedPercentage()
    */
+  @Override
   public double getFinishedPercentage() {
     if (totalRows == 0)
       return 0f;
@@ -138,6 +135,7 @@ class JoinAlignerTask extends AbstractTask {
   /**
    * @see Runnable#run()
    */
+  @Override
   public void run() {
 
     if ((mzWeight == 0) && (rtWeight == 0)) {
@@ -252,10 +250,9 @@ class JoinAlignerTask extends AbstractTask {
             // compare mass list data points of selected scans
             if (rowDPs != null && candidateDPs != null) {
               sim = createSimilarity(rowDPs, candidateDPs);
-              if (sim != null) {
-                row.setComment(Double.toString(sim.getScore()));
-              } else
+              if (sim == null) {
                 continue;
+              }
             }
           }
 

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/alignment/join/help/help.html
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/alignment/join/help/help.html
@@ -78,8 +78,10 @@
             <dd>If both peaks represent an isotope pattern, add isotope pattern score to match score.</dd>
             <dt>Isotope pattern score threshold level</dt>
             <dd>If the score between isotope pattern is lower, discard this match.</dd>
+			<dt>Compare spectra similarity</dt>
+            <dd>Compare MS1 or MS2 scans similarity. Select the mass list, m/z tolerance and spectra similarity score.
+            For the score, set a minimum cos similarity. Only features meeting this criteria will be aligned.</dd>
             </dd>
-
         </dl>
        
         <p>


### PR DESCRIPTION
Dear Tomas,
I have added spectra similarity as an optional parameter to the join aligner following @robinschmid suggestion to potentially solve the problems described in issue #627.  
The user can now compare the similarity of the representative MS1 scans or the similarity of best MS2 scans. I have tested it with LC-MS/MS data and GC-EI-TOF MS data. General alignment results seem pretty good.
best Ansgar 