### PR TITLE
Option to remove empty rows after PeakFilter

### DIFF
--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/filtering/peakfilter/PeakFilterParameters.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/filtering/peakfilter/PeakFilterParameters.java
@@ -73,9 +73,6 @@ public class PeakFilterParameters extends SimpleParameterSet {
           "Permissible range of the asymmetry factor for a peak",
           MZmineCore.getConfiguration().getRTFormat(), Range.closed(0.5, 2.0)));
 
-  public static final BooleanParameter REMOVE_EMPTY_ROWS = new BooleanParameter("Remove empty rows",
-      "Remove empty rows with 0 features after the filtering process");
-
   public static final BooleanParameter AUTO_REMOVE = new BooleanParameter(
       "Remove source feature list after filtering",
       "If checked, the original feature list will be removed leaving only the filtered version");
@@ -85,9 +82,9 @@ public class PeakFilterParameters extends SimpleParameterSet {
           "If checked, the feature that don't contain MS2 scan will be removed.");
 
   public PeakFilterParameters() {
-    super(new Parameter[] {PEAK_LISTS, SUFFIX, PEAK_DURATION, PEAK_AREA, PEAK_HEIGHT,
-        PEAK_DATAPOINTS, PEAK_FWHM, PEAK_TAILINGFACTOR, PEAK_ASYMMETRYFACTOR, REMOVE_EMPTY_ROWS,
-        MS2_Filter, AUTO_REMOVE});
+    super(
+        new Parameter[] {PEAK_LISTS, SUFFIX, PEAK_DURATION, PEAK_AREA, PEAK_HEIGHT, PEAK_DATAPOINTS,
+            PEAK_FWHM, PEAK_TAILINGFACTOR, PEAK_ASYMMETRYFACTOR, MS2_Filter, AUTO_REMOVE});
   }
 
   @Override

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/filtering/peakfilter/PeakFilterParameters.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/filtering/peakfilter/PeakFilterParameters.java
@@ -19,7 +19,7 @@
 package net.sf.mzmine.modules.peaklistmethods.filtering.peakfilter;
 
 import java.awt.Window;
-
+import com.google.common.collect.Range;
 import net.sf.mzmine.main.MZmineCore;
 import net.sf.mzmine.parameters.Parameter;
 import net.sf.mzmine.parameters.UserParameter;
@@ -28,12 +28,10 @@ import net.sf.mzmine.parameters.impl.SimpleParameterSet;
 import net.sf.mzmine.parameters.parametertypes.BooleanParameter;
 import net.sf.mzmine.parameters.parametertypes.OptionalParameter;
 import net.sf.mzmine.parameters.parametertypes.StringParameter;
-import net.sf.mzmine.parameters.parametertypes.ranges.IntRangeParameter;
 import net.sf.mzmine.parameters.parametertypes.ranges.DoubleRangeParameter;
+import net.sf.mzmine.parameters.parametertypes.ranges.IntRangeParameter;
 import net.sf.mzmine.parameters.parametertypes.selectors.PeakListsParameter;
 import net.sf.mzmine.util.ExitCode;
-
-import com.google.common.collect.Range;
 
 public class PeakFilterParameters extends SimpleParameterSet {
 
@@ -75,18 +73,21 @@ public class PeakFilterParameters extends SimpleParameterSet {
           "Permissible range of the asymmetry factor for a peak",
           MZmineCore.getConfiguration().getRTFormat(), Range.closed(0.5, 2.0)));
 
-  public static final BooleanParameter AUTO_REMOVE =
-      new BooleanParameter("Remove source feature list after filtering",
-          "If checked, the original feature list will be removed leaving only the filtered version");
+  public static final BooleanParameter REMOVE_EMPTY_ROWS = new BooleanParameter("Remove empty rows",
+      "Remove empty rows with 0 features after the filtering process");
+
+  public static final BooleanParameter AUTO_REMOVE = new BooleanParameter(
+      "Remove source feature list after filtering",
+      "If checked, the original feature list will be removed leaving only the filtered version");
 
   public static final BooleanParameter MS2_Filter =
       new BooleanParameter("Keep only features with MS/MS scan",
           "If checked, the feature that don't contain MS2 scan will be removed.");
 
   public PeakFilterParameters() {
-    super(
-        new Parameter[] {PEAK_LISTS, SUFFIX, PEAK_DURATION, PEAK_AREA, PEAK_HEIGHT, PEAK_DATAPOINTS,
-            PEAK_FWHM, PEAK_TAILINGFACTOR, PEAK_ASYMMETRYFACTOR, MS2_Filter, AUTO_REMOVE});
+    super(new Parameter[] {PEAK_LISTS, SUFFIX, PEAK_DURATION, PEAK_AREA, PEAK_HEIGHT,
+        PEAK_DATAPOINTS, PEAK_FWHM, PEAK_TAILINGFACTOR, PEAK_ASYMMETRYFACTOR, REMOVE_EMPTY_ROWS,
+        MS2_Filter, AUTO_REMOVE});
   }
 
   @Override

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/filtering/peakfilter/PeakFilterTask.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/filtering/peakfilter/PeakFilterTask.java
@@ -145,8 +145,6 @@ public class PeakFilterTask extends AbstractTask {
     final boolean filterByAsymmetryFactor =
         parameters.getParameter(PeakFilterParameters.PEAK_ASYMMETRYFACTOR).getValue();
     final boolean filterByMS2 = parameters.getParameter(PeakFilterParameters.MS2_Filter).getValue();
-    final boolean removeEmptyRows =
-        parameters.getParameter(PeakFilterParameters.REMOVE_EMPTY_ROWS).getValue();
 
     // Loop through all rows in feature list
     final PeakListRow[] rows = peakList.getRows();
@@ -262,7 +260,7 @@ public class PeakFilterTask extends AbstractTask {
       }
       // empty row?
       boolean isEmpty = Booleans.asList(keepPeak).stream().allMatch(keep -> !keep);
-      if (!(removeEmptyRows && isEmpty))
+      if (!isEmpty)
         newPeakList.addRow(copyPeakRow(row, keepPeak));
 
     }

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/filtering/peakfilter/PeakFilterTask.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/filtering/peakfilter/PeakFilterTask.java
@@ -20,7 +20,8 @@ package net.sf.mzmine.modules.peaklistmethods.filtering.peakfilter;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
+import com.google.common.collect.Range;
+import com.google.common.primitives.Booleans;
 import net.sf.mzmine.datamodel.Feature;
 import net.sf.mzmine.datamodel.MZmineProject;
 import net.sf.mzmine.datamodel.PeakList;
@@ -34,8 +35,6 @@ import net.sf.mzmine.parameters.ParameterSet;
 import net.sf.mzmine.taskcontrol.AbstractTask;
 import net.sf.mzmine.taskcontrol.TaskStatus;
 import net.sf.mzmine.util.PeakUtils;
-
-import com.google.common.collect.Range;
 
 /**
  * Filters out peaks from feature list.
@@ -146,6 +145,8 @@ public class PeakFilterTask extends AbstractTask {
     final boolean filterByAsymmetryFactor =
         parameters.getParameter(PeakFilterParameters.PEAK_ASYMMETRYFACTOR).getValue();
     final boolean filterByMS2 = parameters.getParameter(PeakFilterParameters.MS2_Filter).getValue();
+    final boolean removeEmptyRows =
+        parameters.getParameter(PeakFilterParameters.REMOVE_EMPTY_ROWS).getValue();
 
     // Loop through all rows in feature list
     final PeakListRow[] rows = peakList.getRows();
@@ -259,7 +260,10 @@ public class PeakFilterTask extends AbstractTask {
             keepPeak[i] = false;
         }
       }
-      newPeakList.addRow(copyPeakRow(row, keepPeak));
+      // empty row?
+      boolean isEmpty = Booleans.asList(keepPeak).stream().allMatch(keep -> !keep);
+      if (!(removeEmptyRows && isEmpty))
+        newPeakList.addRow(copyPeakRow(row, keepPeak));
 
     }
 

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/filtering/peakfilter/help/help.html
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/filtering/peakfilter/help/help.html
@@ -42,9 +42,6 @@
     <dt>Asymmetry factor</dt>
     <dd>Peaks with an asymmetry factor outside the entered range will be removed.</dd>
     
-    <dt>Remove empty rows</dt>
-    <dd>After filtering features, remove empty rows with 0 features.</dd>
-    
     <dt>MS/MS scan filter</dt>
     <dd>Peaks without any MS/MS scans will be removed.</dd>
 

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/filtering/peakfilter/help/help.html
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/filtering/peakfilter/help/help.html
@@ -42,6 +42,9 @@
     <dt>Asymmetry factor</dt>
     <dd>Peaks with an asymmetry factor outside the entered range will be removed.</dd>
     
+    <dt>Remove empty rows</dt>
+    <dd>After filtering features, remove empty rows with 0 features.</dd>
+    
     <dt>MS/MS scan filter</dt>
     <dd>Peaks without any MS/MS scans will be removed.</dd>
 


### PR DESCRIPTION
Hey Tomas,

this is a small addition to the PeakFilter module. If the resulting feature list row is empty - it can now be removed automatically. Previously, we had to run PeakFilter + FeatureListRowFIlter (min features=1) to do this.

Cheers
Robin