### PR TITLE
Data point processing fix - Null pointer exception on first start

### DIFF
--- a/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/datapointprocessing/DataPointProcessingController.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/datapointprocessing/DataPointProcessingController.java
@@ -18,26 +18,15 @@
 
 package net.sf.mzmine.modules.visualization.spectra.simplespectra.datapointprocessing;
 
-import java.awt.Color;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
-import org.apache.xalan.xsltc.compiler.util.ErrorMessages;
-import org.jfree.data.xy.XYDataset;
-import com.sun.xml.bind.v2.runtime.reflect.Accessor.SetterOnlyReflection;
+import cern.colt.Arrays;
 import net.sf.mzmine.datamodel.DataPoint;
-import net.sf.mzmine.datamodel.IsotopePattern;
-import net.sf.mzmine.datamodel.IsotopePattern.IsotopePatternStatus;
-import net.sf.mzmine.datamodel.impl.SimpleIsotopePattern;
 import net.sf.mzmine.main.MZmineCore;
 import net.sf.mzmine.modules.MZmineProcessingStep;
 import net.sf.mzmine.modules.visualization.spectra.simplespectra.SpectraPlot;
 import net.sf.mzmine.modules.visualization.spectra.simplespectra.datapointprocessing.datamodel.ProcessedDataPoint;
-import net.sf.mzmine.modules.visualization.spectra.simplespectra.datapointprocessing.datamodel.results.DPPIsotopePatternResult;
-import net.sf.mzmine.modules.visualization.spectra.simplespectra.datapointprocessing.datamodel.results.DPPResult.ResultType;
-import net.sf.mzmine.modules.visualization.spectra.simplespectra.datapointprocessing.datamodel.results.DPPResultsDataSet;
-import net.sf.mzmine.modules.visualization.spectra.simplespectra.datapointprocessing.datamodel.results.DPPResultsLabelGenerator;
-import net.sf.mzmine.modules.visualization.spectra.simplespectra.datasets.IsotopesDataSet;
 import net.sf.mzmine.parameters.ParameterSet;
 import net.sf.mzmine.taskcontrol.Task;
 import net.sf.mzmine.taskcontrol.TaskStatus;
@@ -192,6 +181,14 @@ public class DataPointProcessingController {
 
       DataPointProcessingModule inst = step.getModule();
       ParameterSet parameters = step.getParameterSet();
+      
+      List<String> err = new ArrayList<>();
+      if(!parameters.checkParameterValues(err)) {
+        setResults(ProcessedDataPoint.convert(dp));
+        setStatus(ControllerStatus.CANCELED);
+        logger.warning("Not all parameters set." + Arrays.toString(err.toArray(new String[0])));
+        return;
+      }
 
       Task t = ((DataPointProcessingModule) inst).createTask(dp, parameters, plot, this,
           new TaskStatusListener() {

--- a/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/datapointprocessing/DataPointProcessingController.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/datapointprocessing/DataPointProcessingController.java
@@ -19,9 +19,9 @@
 package net.sf.mzmine.modules.visualization.spectra.simplespectra.datapointprocessing;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Logger;
-import cern.colt.Arrays;
 import net.sf.mzmine.datamodel.DataPoint;
 import net.sf.mzmine.main.MZmineCore;
 import net.sf.mzmine.modules.MZmineProcessingStep;
@@ -181,7 +181,7 @@ public class DataPointProcessingController {
     if(!step.getParameterSet().checkParameterValues(err)) {
       setResults(ProcessedDataPoint.convert(dp));
       setStatus(ControllerStatus.CANCELED);
-      logger.warning("Not all parameters set." + Arrays.toString(err.toArray(new String[0])));
+      logger.warning(step.getModule().getName() + " Not all parameters set." + Arrays.toString(err.toArray(new String[0])));
       return;
     }
 

--- a/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/datapointprocessing/isotopes/deisotoper/DPPIsotopeGrouperParameters.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/datapointprocessing/isotopes/deisotoper/DPPIsotopeGrouperParameters.java
@@ -40,10 +40,10 @@ public class DPPIsotopeGrouperParameters extends SimpleParameterSet {
   public static final MZToleranceParameter mzTolerance = new MZToleranceParameter();
 
   public static final BooleanParameter monotonicShape = new BooleanParameter("Monotonic shape",
-      "If true, then monotonically decreasing height of isotope pattern is required");
+      "If true, then monotonically decreasing height of isotope pattern is required", false);
 
   public static final IntegerParameter maximumCharge = new IntegerParameter("Maximum charge",
-      "Maximum charge to consider for detecting the isotope patterns");
+      "Maximum charge to consider for detecting the isotope patterns", 1);
 
   public static final ComboParameter<String> representativeIsotope = new ComboParameter<String>(
       "Representative isotope",
@@ -51,10 +51,10 @@ public class DPPIsotopeGrouperParameters extends SimpleParameterSet {
           + "compounds with monotonically decreasing isotope pattern, the most intense isotope\n"
           + "should be representative. For high molecular weight peptides, the lowest m/z\n"
           + "peptides, the lowest m/z isotope may be the representative.",
-      representativeIsotopeValues);
+      representativeIsotopeValues, representativeIsotopeValues[0]);
 
   public static final BooleanParameter autoRemove = new BooleanParameter("Remove non-isotopes",
-      "If checked, all peaks without an isotope pattern will not be displayed and not passed to the next module.");
+      "If checked, all peaks without an isotope pattern will not be displayed and not passed to the next module.", false);
   
   public static final BooleanParameter displayResults = new BooleanParameter("Display results",
       "Check if you want to display the deisotoping results in the plot. Displaying too much datasets might decrease clarity.", false);

--- a/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/datapointprocessing/isotopes/deisotoper/DPPIsotopeGrouperParameters.java
+++ b/src/main/java/net/sf/mzmine/modules/visualization/spectra/simplespectra/datapointprocessing/isotopes/deisotoper/DPPIsotopeGrouperParameters.java
@@ -40,7 +40,7 @@ public class DPPIsotopeGrouperParameters extends SimpleParameterSet {
   public static final MZToleranceParameter mzTolerance = new MZToleranceParameter();
 
   public static final BooleanParameter monotonicShape = new BooleanParameter("Monotonic shape",
-      "If true, then monotonically decreasing height of isotope pattern is required", false);
+      "If true, then monotonically decreasing height of isotope pattern is required", Boolean.FALSE);
 
   public static final IntegerParameter maximumCharge = new IntegerParameter("Maximum charge",
       "Maximum charge to consider for detecting the isotope patterns", 1);


### PR DESCRIPTION
Hi tomas,
i noticed a null pointer exception on the first start of the data point processing task, when some if the parameters have not been set, which caused a null value in a boolean parameter somehow. The parameter sets are now checked before the creation of the task, which fixes the problem.

Best
Steffen