### PR TITLE
Fix for legend not matching graph colour after applying theme during export

### DIFF
--- a/src/main/java/net/sf/mzmine/chartbasics/chartthemes/ChartThemeParameters.java
+++ b/src/main/java/net/sf/mzmine/chartbasics/chartthemes/ChartThemeParameters.java
@@ -143,7 +143,7 @@ public class ChartThemeParameters extends SimpleParameterSet {
     Color cygrid = this.getParameter(ChartThemeParameters.yGridPaint).getEmbeddedParameter().getValue();
 
     theme.setShowTitle(showTitle);
-    theme.getShowSubtitles(showLegends);
+    theme.setShowSubtitles(showLegends);
 
     FontSpecs master = this.getParameter(ChartThemeParameters.masterFont).getValue();
     FontSpecs large = this.getParameter(ChartThemeParameters.titleFont).getValue();

--- a/src/main/java/net/sf/mzmine/chartbasics/chartthemes/EStandardChartTheme.java
+++ b/src/main/java/net/sf/mzmine/chartbasics/chartthemes/EStandardChartTheme.java
@@ -24,9 +24,12 @@ import java.awt.Paint;
 import org.jfree.chart.JFreeChart;
 import org.jfree.chart.StandardChartTheme;
 import org.jfree.chart.axis.NumberAxis;
+import org.jfree.chart.plot.XYPlot;
 import org.jfree.chart.renderer.category.StandardBarPainter;
 import org.jfree.chart.renderer.xy.StandardXYBarPainter;
+import org.jfree.chart.title.LegendTitle;
 import org.jfree.chart.title.PaintScaleLegend;
+import org.jfree.chart.ui.RectangleEdge;
 import net.sf.mzmine.chartbasics.chartthemes.ChartThemeFactory.THEME;
 
 
@@ -106,7 +109,6 @@ public class EStandardChartTheme extends StandardChartTheme {
 
   @Override
   public void apply(JFreeChart chart) {
-    // TODO Auto-generated method stub
     super.apply(chart);
     //
     chart.getXYPlot().setDomainGridlinesVisible(showXGrid);
@@ -145,6 +147,9 @@ public class EStandardChartTheme extends StandardChartTheme {
     chart.setAntiAlias(isAntiAliased());
     chart.getTitle().setVisible(isShowTitle());
     chart.getPlot().setBackgroundAlpha(isNoBackground() ? 0 : 1);
+
+    // make the legend's colours change, too, if the theme changed them.
+    fixLegend(chart);
   }
 
   public boolean isNoBackground() {
@@ -159,6 +164,25 @@ public class EStandardChartTheme extends StandardChartTheme {
         new Color(cchart.getRed(), cchart.getGreen(), cchart.getBlue(), state ? 0 : 255));
     this.setLegendBackgroundPaint(
         new Color(cchart.getRed(), cchart.getGreen(), cchart.getBlue(), state ? 0 : 255));
+  }
+
+  /**
+   * Fixes the legend item's colour after the colours of the datasets/series in the plot were
+   * changed.
+   * 
+   * @param chart The chart.
+   */
+  public static void fixLegend(JFreeChart chart) {
+    XYPlot plot = chart.getXYPlot();
+    LegendTitle oldLegend = chart.getLegend();
+    RectangleEdge pos = oldLegend.getPosition();
+    chart.removeLegend();
+    
+    LegendTitle newLegend = new LegendTitle(plot);
+    newLegend.setPosition(pos);
+    newLegend.setItemFont(oldLegend.getItemFont());
+    chart.addLegend(newLegend);
+    newLegend.setVisible(oldLegend.isVisible());
   }
 
   // GETTERS AND SETTERS
@@ -242,7 +266,7 @@ public class EStandardChartTheme extends StandardChartTheme {
     this.masterFontColor = masterFontColor;
   }
 
-  public void getShowSubtitles(boolean subtitleVisible) {
+  public void setShowSubtitles(boolean subtitleVisible) {
     this.subtitleVisible = subtitleVisible;
   }
 

--- a/src/main/java/net/sf/mzmine/chartbasics/graphicsexport/GraphicsExportDialog.java
+++ b/src/main/java/net/sf/mzmine/chartbasics/graphicsexport/GraphicsExportDialog.java
@@ -23,11 +23,9 @@ import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.GridBagConstraints;
-import java.awt.Paint;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.File;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
@@ -46,14 +44,8 @@ import javax.swing.border.EmptyBorder;
 import org.jfree.chart.ChartFactory;
 import org.jfree.chart.ChartPanel;
 import org.jfree.chart.JFreeChart;
-import org.jfree.chart.LegendItem;
-import org.jfree.chart.LegendItemCollection;
 import org.jfree.chart.plot.DefaultDrawingSupplier;
 import org.jfree.chart.plot.DrawingSupplier;
-import org.jfree.chart.plot.XYPlot;
-import org.jfree.chart.renderer.xy.AbstractXYItemRenderer;
-import org.jfree.chart.renderer.xy.XYItemRenderer;
-import org.jfree.data.xy.XYDataset;
 import org.jfree.data.xy.XYSeries;
 import org.jfree.data.xy.XYSeriesCollection;
 import net.miginfocom.swing.MigLayout;
@@ -355,50 +347,18 @@ public class GraphicsExportDialog extends JFrame {
     // apply settings
     chartParam.applyToChartTheme(theme);
     chartParam.applyToChart(chartPanel.getChart());
+
     setStandardColors();
     theme.apply(chartPanel.getChart());
+
     // renewPreview();
     chartPanel.getChart().getXYPlot().setRangeCrosshairVisible(false);
     chartPanel.getChart().getXYPlot().setDomainCrosshairVisible(false);
-
-    LegendItemCollection legends = chartPanel.getChart().getXYPlot().getLegendItems();
-    for (int i = 0; i < legends.getItemCount(); i++) {
-      System.out.println(i + " " + legends.get(i).getLabel() + " clr: "
-          + legends.get(i).getFillPaint().toString());
-    }
-
-    // chartPanel.getChart().getXYPlot()
-    // chartPanel.getChart().getXYPlot().getRenderer().getLegendItem(datasetIndex, series);
-
-    XYPlot plot = chartPanel.getChart().getXYPlot();
-    for (int i = 0; i < plot.getDatasetCount(); i++) {
-      XYDataset ds = plot.getDataset(i);
-      if (ds == null)
-        continue;
-
-      XYItemRenderer r = plot.getRendererForDataset(ds);
-      Paint p = r.getSeriesPaint(0);
-      
-//      System.out.println(r.getDefaultFillPaint().toString());
-//      System.out.println(r.getDefaultItemLabelPaint().toString());
-//      System.out.println(r.getDefaultOutlinePaint().toString());
-//      System.out.println(r.getSeriesPaint(0).toString());
-
-      LegendItemCollection lc = r.getLegendItems();
-      for (int j = 0; j < lc.getItemCount(); j++) {
-        if (lc.get(j) == null)
-          continue;
-        System.out.println("DS: " + i + "p: " + p.toString() + " legend: " + lc.get(j).getLabel()
-            + " clr: " + lc.get(j).getFillPaint());
-        lc.get(j).setFillPaint(p);
-        lc.get(j).setLinePaint(p);
-        lc.get(j).setLabelPaint(p);
-        lc.get(j).setOutlinePaint(p);
-        
-      }
-    }
   }
 
+  /**
+   * Sets the colours of the selected colour palette to the chart theme.
+   */
   protected void setStandardColors() {
     DrawingSupplier ds = new DefaultDrawingSupplier(colors, colors, colors,
         DefaultDrawingSupplier.DEFAULT_STROKE_SEQUENCE,


### PR DESCRIPTION
Hi Tomas, 
this fixes the issue as described above and discussed in Slack.
Also, the export uses the colour preset as set in the preferences. I thought that might be useful.

Best regards
Steffen