### PR TITLE
Fix for issue #883

### DIFF
--- a/src/main/java/net/sf/mzmine/modules/projectmethods/projectload/version_2_0/PeakListOpenHandler_2_0.java
+++ b/src/main/java/net/sf/mzmine/modules/projectmethods/projectload/version_2_0/PeakListOpenHandler_2_0.java
@@ -63,7 +63,7 @@ public class PeakListOpenHandler_2_0 extends DefaultHandler implements PeakListO
   private double mass, rt, area;
   private int[] scanNumbers;
   private int[] allMS2FragmentScanNumbers;
-  private Vector<Integer> currentAllMS2FragmentScans;
+  private Vector<Integer> currentAllMS2FragmentScans = new Vector<Integer>();
   private double height;
   private double[] masses, intensities;
   private String peakStatus, peakListName, name, identityPropertyName, rawDataFileID;


### PR DESCRIPTION
Just seemed to be a null variable that wasn't initialized. Checking for null variable with an if conditional didn't seem to work, hence the initialization.  If there is an easy explanation why the null check didn't work would be curious to know :) Details below:

More detailed error:
```java.lang.NullPointerException
	at net.sf.mzmine.modules.projectmethods.projectload.version_2_0.PeakListOpenHandler_2_0.endElement(PeakListOpenHandler_2_0.java:278)
	at java.xml/com.sun.org.apache.xerces.internal.parsers.AbstractSAXParser.endElement(AbstractSAXParser.java:610)
	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl.scanEndElement(XMLDocumentFragmentScannerImpl.java:1718)
	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl$FragmentContentDriver.next(XMLDocumentFragmentScannerImpl.java:2883)
	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLDocumentScannerImpl.next(XMLDocumentScannerImpl.java:605)
	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl.scanDocument(XMLDocumentFragmentScannerImpl.java:534)
	at java.xml/com.sun.org.apache.xerces.internal.parsers.XML11Configuration.parse(XML11Configuration.java:888)
	at java.xml/com.sun.org.apache.xerces.internal.parsers.XML11Configuration.parse(XML11Configuration.java:824)
	at java.xml/com.sun.org.apache.xerces.internal.parsers.XMLParser.parse(XMLParser.java:141)
	at java.xml/com.sun.org.apache.xerces.internal.parsers.AbstractSAXParser.parse(AbstractSAXParser.java:1216)
	at java.xml/com.sun.org.apache.xerces.internal.jaxp.SAXParserImpl$JAXPSAXParser.parse(SAXParserImpl.java:635)
	at java.xml/com.sun.org.apache.xerces.internal.jaxp.SAXParserImpl.parse(SAXParserImpl.java:324)
	at java.xml/javax.xml.parsers.SAXParser.parse(SAXParser.java:197)
	at net.sf.mzmine.modules.projectmethods.projectload.version_2_0.PeakListOpenHandler_2_0.readPeakList(PeakListOpenHandler_2_0.java:115)
	at net.sf.mzmine.modules.peaklistmethods.io.xmlimport.XMLImportTask.run(XMLImportTask.java:133)
	at net.sf.mzmine.taskcontrol.impl.WorkerThread.run(WorkerThread.java:58)
Dec 11, 2020 12:10:23 AM net.sf.mzmine.taskcontrol.impl.WorkerThread run
```

The part of `PeakListOpenHandler_2_0.java` which was calling the null pointer error (referencing initialized `currentAllMS2FragmentScans`):
```
      // convert vector of allMS2FragmentScans to array
      allMS2FragmentScanNumbers = new int[currentAllMS2FragmentScans.size()];
      for (int i = 0; i < allMS2FragmentScanNumbers.length; i++) {
        allMS2FragmentScanNumbers[i] = currentAllMS2FragmentScans.get(i);
      }

      // clear all MS2 fragment scan numbers list for next peak
      currentAllMS2FragmentScans.clear();
```