### PR TITLE
Bump fontchooser to 2.5.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -146,7 +146,7 @@ dependencies {
     implementation "io.gsonfire:gson-fire:1.8.0"
     implementation "org.threeten:threetenbp:1.3.8"
     implementation "org.controlsfx:controlsfx:$controlsfxVersion"
-    implementation "org.drjekyll:fontchooser:2.4"
+    implementation "org.drjekyll:fontchooser:2.5.2"
     implementation "org.json:json:20190722"
 }
 


### PR DESCRIPTION
Hi @tomas-pluskal!

The new fontchooser version has several improvements. The "API" is still the same. I propose an update.

Best regards
Daniel